### PR TITLE
release: v0.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.5.8 (Apr 13, 2023)
+
+### Fixes:
+
+- `react`: make useAtomSelector rerender components when the selector value becomes undefined (#8)
+
 ## v0.5.7 (Apr 12, 2023)
 
 ### New Features:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zedux",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "A Molecular State Engine for React",
   "type": "module",
   "author": "Joshua Claunch (bowheart <bowheart31@gmail.com>)",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/core",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "A high-level, declarative, composable form of Redux",
   "main": "./dist/zedux.umd.js",
   "module": "./dist/esm/index.js",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/immer",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Official Immer integration for Zedux's store and atomic APIs",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "devDependencies": {
-    "@zedux/react": "^0.5.7",
+    "@zedux/react": "^0.5.8",
     "immer": "^9.0.21"
   },
   "exports": {
@@ -40,7 +40,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/react": "^0.5.7",
+    "@zedux/react": "^0.5.8",
     "immer": ">=9.0.19"
   },
   "repository": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/react",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/core": "^0.5.7"
+    "@zedux/core": "^0.5.8"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",


### PR DESCRIPTION
## Description

Increment monorepo package versions and update the CHANGELOG for version 0.5.8.

This PR was generated by the release script at https://github.com/Omnistac/zedux/tree/master/scripts/release.js

The packages will be published to npm and a GitHub release will be created after this PR merges.