### PR TITLE
fix(react): make all stores of all atoms in the evaluation stack use the ecosystem's scheduler

### DIFF
--- a/packages/react/src/classes/EvaluationStack.ts
+++ b/packages/react/src/classes/EvaluationStack.ts
@@ -123,7 +123,10 @@ export class EvaluationStack {
 
   public finish() {
     const item = stack.pop()
-    Store._scheduler = undefined
+
+    // if we just popped the last thing off the stack, restore the default
+    // scheduler
+    if (!stack.length) Store._scheduler = undefined
 
     if (!item || !this.ecosystem._mods.evaluationFinished) return
 

--- a/packages/react/test/integrations/atom-stores.test.tsx
+++ b/packages/react/test/integrations/atom-stores.test.tsx
@@ -95,4 +95,22 @@ describe('stores in atoms', () => {
     expect(instance1.getState()).toBe(3)
     expect(instance2.getState()).toBe(1)
   })
+
+  test('all atoms in the evaluation stack get the right store scheduler', () => {
+    const atom1 = atom('1', () => injectStore('a'))
+    const atom2 = atom('2', () => {
+      const child = injectStore('b')
+      const one = injectAtomInstance(atom1)
+
+      const store = injectStore(() => createStore({ child, one: one.store }))
+
+      return store
+    })
+
+    const instance2 = ecosystem.getInstance(atom2)
+    const instance1 = ecosystem.getInstance(atom1)
+
+    expect(instance1.store['_scheduler']).toBe(ecosystem._scheduler)
+    expect(instance2.store['_scheduler']).toBe(ecosystem._scheduler)
+  })
 })


### PR DESCRIPTION
## Description

The recent fix to make sure the default scheduler is restored whether or not the `evaluationFinished` mod is enabled (26d980b1eca3478bfdf7a1db1508261aa365c0b2) exposed a bug where the default scheduler would be restored as soon as any item in the evaluation stack is popped off.

Only restore the default scheduler when the _last_ item in the stack is popped off.

Also add a regression test that 💯% reproduces this and confirms the fix.