### PR TITLE
fix: improve `state.on` and `Observable` types

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -176,8 +176,8 @@ export type NextSubscriber<State = any> = (
   action: ActionChain
 ) => any
 
-export interface Observable<State = any> {
-  subscribe(subscriber: Subscriber<Store<State>>): Subscription
+export interface Observable<T = any> {
+  subscribe(subscriber: (value: T) => any): Subscription
 }
 
 export type Reactable<Payload = any, Type extends string = any> =

--- a/packages/react/src/injectors/injectMachineStore.ts
+++ b/packages/react/src/injectors/injectMachineStore.ts
@@ -40,7 +40,7 @@ export interface MachineState<
   Context extends Record<string, any> | undefined = any,
   Name extends string = string,
   Events extends string[] = [],
-  ChildStates extends string[] = []
+  ChildStates extends string[] = [Name]
 > {
   on: <E extends string, S extends string>(
     eventName: E,


### PR DESCRIPTION
## Description

The core package's `Observable` type was incompatible with RxJS observables. Fix that. Also add the current state's name to the inferred state names available on an individual MachineState.

## Affects

core, react