### PR TITLE
feat(react): export SelectorCache class

### DIFF
--- a/packages/react/src/classes/index.ts
+++ b/packages/react/src/classes/index.ts
@@ -1,8 +1,9 @@
-export * from './templates/IonTemplate' // this .. has to be imported before AtomTemplate or the build breaks :exploding_head:
-export * from './templates/AtomTemplate'
-export * from './templates/AtomTemplateBase'
 export * from './instances/AtomInstance'
 export * from './instances/AtomInstanceBase'
+export * from './templates/IonTemplate' // this has to be imported before AtomTemplate or the build breaks
+export * from './templates/AtomTemplate'
+export * from './templates/AtomTemplateBase'
 export * from './AtomApi'
 export * from './Ecosystem'
 export * from './ZeduxPlugin'
+export { SelectorCache } from './Selectors'


### PR DESCRIPTION
## Description

The SelectorCache class is documented, but not exported yet. This is necessary for type casting sometimes e.g. in ecosystem plugin modBus subscriptions when getting actions with payloads that can be either an atom instance or an atom selector. Export it.