### PR TITLE
feat(react): make selectors trigger statusChanged mod events on init and destroy

### DIFF
--- a/docs/docs/api/classes/ZeduxPlugin.mdx
+++ b/docs/docs/api/classes/ZeduxPlugin.mdx
@@ -265,12 +265,38 @@ Every ZeduxPlugin has just two properties:
       property transitions to a new state (e.g. from Initializing to Active or
       from Active to Stale).
     </p>
+    <p>
+      This mod also triggers messages when selectors are finished initializing
+      and when selectors are destroyed. Selectors don't track their lifecycle
+      like atom instances do, but the <code>newStatus</code> and{' '}
+      <code>oldStatus</code> fields for these events will be LifeCycle strings
+      exactly like the strings used for atom instances.
+    </p>
     <p>Payload shape:</p>
     <Ts>{`{
-  instance: AnyAtomInstance
+  node: AnyAtomInstance | SelectorCache
   newStatus: LifecycleStatus
   oldStatus: LifecycleStatus
 }`}</Ts>
+    <p>
+      <code>node</code> will be either an atom instance or an atom selector. You
+      can use{' '}
+      <Link to="../utils/is">
+        <code>is()</code>
+      </Link>{' '}
+      to determine which.
+    </p>
+    <p>
+      <code>oldStatus</code> will be one of "Active", "Initializing", or "Stale"
+    </p>
+    <p>
+      <code>newStatus</code> will be one of "Initializing", "Stale", or
+      "Destroyed"
+    </p>
+    <p>
+      Note that atom selectors can never be "Stale". Their lifecycle essentially
+      goes <code>Initializing -> Active -> Destroyed</code>.
+    </p>
   </Item>
 </Legend>
 

--- a/packages/react/src/classes/instances/AtomInstance.ts
+++ b/packages/react/src/classes/instances/AtomInstance.ts
@@ -517,8 +517,8 @@ export class AtomInstance<G extends AtomGenerics> extends AtomInstanceBase<
     if (this.ecosystem._mods.statusChanged) {
       this.ecosystem.modBus.dispatch(
         pluginActions.statusChanged({
-          instance: this,
           newStatus,
+          node: this,
           oldStatus,
         })
       )

--- a/packages/react/src/utils/plugin-actions.ts
+++ b/packages/react/src/utils/plugin-actions.ts
@@ -59,7 +59,7 @@ export const pluginActions = {
   >('stateChanged'),
   statusChanged: actionFactory<
     {
-      instance: AnyAtomInstance
+      node: AnyAtomInstance | SelectorCache
       newStatus: LifecycleStatus
       oldStatus: LifecycleStatus
     },


### PR DESCRIPTION
## Description

Plugins need access to selector create/destroy events so they can track the graph correctly. Rework the `statusChanged` mod to work with both atom instances and selectors. Update ZeduxPlugin docs to reflect this change.