### PR TITLE
fix(react): remove dehydrated state generic from ssr atom config options for now

### DIFF
--- a/packages/react/src/types/index.ts
+++ b/packages/react/src/types/index.ts
@@ -14,9 +14,9 @@ import {
 export * from './atoms'
 
 export interface AtomConfig<State = any> {
-  dehydrate?: <D>(state: State) => D
+  dehydrate?: (state: State) => any
   flags?: string[]
-  hydrate?: <D>(dehydratedState: D) => State
+  hydrate?: (dehydratedState: unknown) => State
   manualHydration?: boolean
   ttl?: number
 }


### PR DESCRIPTION
## Description

The `dehydrate` and `hydrate` atom config functions need to use a generic at the `atom()` factory level to really work. Maybe we'll get to this eventually, but for now just remove the not-good-enough `D` generics and use `any` and `unknown` types.