### PR TITLE
feat(react): make timestamp generation easily overridable; fix statusChanged event order

### DIFF
--- a/docs/docs/api/classes/Ecosystem.mdx
+++ b/docs/docs/api/classes/Ecosystem.mdx
@@ -591,6 +591,11 @@ instance.setState('new state')`}</Ts>
       (if any), and calls <code>onReady</code> again to reinitialize the
       ecosystem.
     </p>
+    <p>
+      Note that this doesn't remove overrides or plugins but <i>does</i> remove
+      hydrations. This is because you can remove overrides/plugins yourself if
+      needed, but there isn't currently a way to remove hydrations.
+    </p>
     <p>Signature:</p>
     <Ts>{`reset = (newContext?) => void`}</Ts>
     <p>

--- a/packages/react/src/classes/IdGenerator.ts
+++ b/packages/react/src/classes/IdGenerator.ts
@@ -54,6 +54,16 @@ export class IdGenerator {
     return this.generateId('es')
   }
 
+  /**
+   * Generate a pretty-much-guaranteed unique id using the passed prefix.
+   *
+   * This method and `IdGenerator#now()` are the only methods in Zedux that
+   * produce random values.
+   *
+   * Override these when testing to create reproducible graphs/dehydrations that
+   * can be used easily in snapshot testing. See our setup in the Zedux repo at
+   * `<repo root>/packages/react/test/utils/ecosystem.ts` for an example.
+   */
   public generateId = (prefix: string) =>
     `${prefix}-${++this.idCounter}${Math.random().toString(16).slice(2, 14)}`
 
@@ -124,6 +134,22 @@ export class IdGenerator {
           return result
         }, {} as Record<string, any>)
     })
+  }
+
+  /**
+   * Generate a timestamp. Pass true to make it a high res timestamp if possible
+   *
+   * This method and `IdGenerator#generateId()` are the only methods in Zedux
+   * that produce random values.
+   *
+   * Override these when testing to create reproducible graphs/dehydrations that
+   * can be used easily in snapshot testing. See our setup in the Zedux repo at
+   * `<repo root>/packages/react/test/utils/ecosystem.ts` for an example.
+   */
+  public now(highRes?: boolean) {
+    return highRes && typeof performance !== 'undefined'
+      ? performance.now()
+      : Date.now()
   }
 
   private cacheClass(instance: { new (): any }) {


### PR DESCRIPTION
## Description

We generate timestamps/high-res timestamps in several places. These values end up in graph views and ecosystem dehydrations which is annoying for snapshot testing especially. Make all these calls go through a single method - `IdGenerator#now`. Now you only have to override the IdGenerator class's `generateId` and `now` methods to create fully-reproducible ids.

We may expand this someday to use functions or an IdGenerator-extending class that you pass to `createEcosystem`. Bu monkey-patching in test envs is good enough for now.