### PR TITLE
refactor(react): remove some unnecessary logic and cleanup code

### DIFF
--- a/docs/docs/api/classes/Ecosystem.mdx
+++ b/docs/docs/api/classes/Ecosystem.mdx
@@ -572,12 +572,18 @@ instance.setState('new state')`}</Ts>
       the passed list will be force-destroyed, allowing their dependents to
       recreate them using the original, non-overridden atom template.
     </p>
+    <p>
+      You can pass either the original template or the override. Zedux only
+      looks at their <code>key</code> properties. You can also pass strings
+      matching atom template keys.
+    </p>
     <p>Signature:</p>
     <Ts>{`removeOverrides = (overrides) => void`}</Ts>
     <Legend>
       <Item name="overrides">
-        Required. An array of <Link to="AtomTemplate">atom templates</Link>. If
-        any haven't been set as overrides previously, they'll be ignored.
+        Required. An array of <Link to="AtomTemplate">atom templates</Link>{' '}
+        and/or template key strings. If any haven't been set as overrides
+        previously, they'll be ignored.
       </Item>
     </Legend>
   </Item>

--- a/docs/docs/api/classes/ZeduxPlugin.mdx
+++ b/docs/docs/api/classes/ZeduxPlugin.mdx
@@ -144,6 +144,15 @@ Every ZeduxPlugin has just two properties:
       the ecosystem's graph. This edge represents a dependency between two nodes
       in the graph.
     </p>
+    <p>
+      This mod can also be used to determine when an edge has "moved" after a
+      dependency was force-destroyed. Since no <code>edgeRemoved</code> events
+      are sent for edges between a force-destroyed node and its dependents, a
+      plugin's internal graph representation would still have those edges intact
+      when the new <code>edgeCreated</code> events come in after the dependency
+      is recreated. These <code>edgeCreated</code> events will thus appear to be
+      duplicates. When this happens, you can infer that the edge was "moved".
+    </p>
     <p>Payload shape:</p>
     <Ts>{`{
   dependency: AnyAtomInstance | SelectorCache
@@ -266,9 +275,9 @@ Every ZeduxPlugin has just two properties:
       from Active to Stale).
     </p>
     <p>
-      This mod also triggers messages when selectors are finished initializing
-      and when selectors are destroyed. Selectors don't track their lifecycle
-      like atom instances do, but the <code>newStatus</code> and{' '}
+      This mod also triggers messages when selector caches are finished
+      initializing and when selector caches are destroyed. Selectors don't track
+      their lifecycle like atom instances do, but the <code>newStatus</code> and{' '}
       <code>oldStatus</code> fields for these events will be LifeCycle strings
       exactly like the strings used for atom instances.
     </p>

--- a/packages/react/src/classes/Ecosystem.ts
+++ b/packages/react/src/classes/Ecosystem.ts
@@ -319,7 +319,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
   public findAll(template?: AnyAtomTemplate | string) {
     const isAtom = (template as AnyAtomTemplate)?.key
     const filterKey = isAtom
-      ? (template as AnyAtomTemplate)?.key
+      ? (template as AnyAtomTemplate).key
       : (template as string)
     const hash: Record<string, AnyAtomInstance> = {}
 
@@ -469,7 +469,8 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
         instance.template.hydrate ? instance.template.hydrate(val) : val
       )
 
-      delete this.hydration?.[key]
+      // we know hydration is defined at this point
+      delete (this.hydration as Record<string, any>)[key]
     })
   }
 
@@ -513,11 +514,11 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
    */
   public removeOverrides(overrides: (AnyAtomTemplate | string)[]) {
     this.overrides = mapOverrides(
-      Object.values(this.overrides).filter(atom =>
+      Object.values(this.overrides).filter(template =>
         overrides.every(override => {
           const key = typeof override === 'string' ? override : override.key
 
-          return key !== atom.key
+          return key !== template.key
         })
       )
     )
@@ -600,8 +601,6 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
         instance.destroy(true)
       })
     })
-
-    if (!oldOverrides) return
 
     Object.values(oldOverrides).forEach(atom => {
       const instances = this.findAll(atom)

--- a/packages/react/src/hooks/useAtomSelector.ts
+++ b/packages/react/src/hooks/useAtomSelector.ts
@@ -122,7 +122,7 @@ export const useAtomSelector = <T, Args extends any[]>(
   const isDifferent =
     argsChanged || isRefDifferent(ecosystem, selectorOrConfig, cacheRef)
 
-  if (isDifferent || !cacheRef.current) {
+  if (isDifferent) {
     // yes, this mutation is fine
     cacheRef.current = ecosystem.selectors.getCache(
       selectorOrConfig,

--- a/packages/react/src/injectors/injectStore.ts
+++ b/packages/react/src/injectors/injectStore.ts
@@ -63,8 +63,7 @@ export const doSubscribe = <State>(
  * Use the latter for maximum flexibility.
  *
  * Subscribes to the store by default, causing the atom to be reevaluated on
- * every state change. This can be changed by passing `false` as the
- * subscribe config option.
+ * every state change. This can be changed by passing `subscribe: false`.
  *
  * In most cases you won't need to prevent subscribing. But it can be a useful
  * performance optimization.
@@ -151,7 +150,8 @@ export const injectStore: {
 
     // we were subscribed, now we're not
     if (!subscribe) {
-      prevDescriptor.cleanup?.()
+      // cleanup must be defined here. This cast is fine:
+      ;(prevDescriptor.cleanup as () => void)()
       prevDescriptor.cleanup = undefined
       return prevDescriptor
     }

--- a/packages/react/src/types/index.ts
+++ b/packages/react/src/types/index.ts
@@ -188,7 +188,7 @@ export interface EcosystemConfig<
 export interface EcosystemGraphNode {
   dependencies: Record<string, true>
   dependents: Record<string, DependentEdge>
-  isAtomSelector?: boolean
+  isSelector?: boolean
   weight: number
 }
 

--- a/packages/react/test/integrations/__snapshots__/selection.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/selection.test.tsx.snap
@@ -1,0 +1,229 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`selection same-name selectors share the namespace when destroyed and recreated at different times 1`] = `
+{
+  "1": {
+    "dependencies": {
+      "@@selector-common-name": true,
+    },
+    "dependents": {
+      "no-0": {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 3,
+        "operation": "addDependent",
+      },
+    },
+    "isSelector": undefined,
+    "weight": 3,
+  },
+  "@@selector-common-name": {
+    "dependencies": {
+      "root": true,
+    },
+    "dependents": {
+      "1": {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 0,
+        "operation": "select",
+      },
+    },
+    "isSelector": true,
+    "weight": 2,
+  },
+  "root": {
+    "dependencies": {},
+    "dependents": {
+      "@@selector-common-name": {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 0,
+        "operation": "get",
+      },
+    },
+    "isSelector": undefined,
+    "weight": 1,
+  },
+}
+`;
+
+exports[`selection same-name selectors share the namespace when destroyed and recreated at different times 2`] = `
+{
+  "2": {
+    "dependencies": {
+      "@@selector-common-name": true,
+    },
+    "dependents": {
+      "no-1": {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 3,
+        "operation": "addDependent",
+      },
+    },
+    "isSelector": undefined,
+    "weight": 3,
+  },
+  "@@selector-common-name": {
+    "dependencies": {
+      "root": true,
+    },
+    "dependents": {
+      "2": {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 0,
+        "operation": "select",
+      },
+    },
+    "isSelector": true,
+    "weight": 2,
+  },
+  "root": {
+    "dependencies": {},
+    "dependents": {
+      "@@selector-common-name": {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 0,
+        "operation": "get",
+      },
+    },
+    "isSelector": undefined,
+    "weight": 1,
+  },
+}
+`;
+
+exports[`selection same-name selectors share the namespace when destroyed and recreated at different times 3`] = `
+{
+  "1": {
+    "dependencies": {
+      "@@selector-common-name-2": true,
+    },
+    "dependents": {
+      "no-3": {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 3,
+        "operation": "addDependent",
+      },
+    },
+    "isSelector": undefined,
+    "weight": 3,
+  },
+  "2": {
+    "dependencies": {
+      "@@selector-common-name": true,
+    },
+    "dependents": {
+      "no-1": {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 3,
+        "operation": "addDependent",
+      },
+    },
+    "isSelector": undefined,
+    "weight": 3,
+  },
+  "@@selector-common-name": {
+    "dependencies": {
+      "root": true,
+    },
+    "dependents": {
+      "2": {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 0,
+        "operation": "select",
+      },
+    },
+    "isSelector": true,
+    "weight": 2,
+  },
+  "@@selector-common-name-2": {
+    "dependencies": {
+      "root": true,
+    },
+    "dependents": {
+      "1": {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 0,
+        "operation": "select",
+      },
+    },
+    "isSelector": true,
+    "weight": 2,
+  },
+  "root": {
+    "dependencies": {},
+    "dependents": {
+      "@@selector-common-name": {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 0,
+        "operation": "get",
+      },
+      "@@selector-common-name-2": {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 0,
+        "operation": "get",
+      },
+    },
+    "isSelector": undefined,
+    "weight": 1,
+  },
+}
+`;
+
+exports[`selection same-name selectors share the namespace when destroyed and recreated at different times 4`] = `
+{
+  "1": {
+    "dependencies": {
+      "@@selector-common-name-2": true,
+    },
+    "dependents": {
+      "no-3": {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 3,
+        "operation": "addDependent",
+      },
+    },
+    "isSelector": undefined,
+    "weight": 3,
+  },
+  "@@selector-common-name-2": {
+    "dependencies": {
+      "root": true,
+    },
+    "dependents": {
+      "1": {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 0,
+        "operation": "select",
+      },
+    },
+    "isSelector": true,
+    "weight": 2,
+  },
+  "root": {
+    "dependencies": {},
+    "dependents": {
+      "@@selector-common-name-2": {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 0,
+        "operation": "get",
+      },
+    },
+    "isSelector": undefined,
+    "weight": 1,
+  },
+}
+`;

--- a/packages/react/test/utils/ecosystem.ts
+++ b/packages/react/test/utils/ecosystem.ts
@@ -1,23 +1,30 @@
 import { act } from '@testing-library/react'
 import { createEcosystem } from '@zedux/react'
 
-export const ecosystem = createEcosystem()
+export const ecosystem = createEcosystem({ id: 'test' })
 
 let idCounter = 0
 
-export const generateIdMock = jest.fn(function generateIdMock(
-  this: typeof ecosystem._idGenerator,
-  prefix: string
-) {
-  return `${prefix}-${idCounter++}`
-})
+export const generateIdMock = jest.fn(
+  (prefix: string) => `${prefix}-${idCounter++}`
+)
 
-ecosystem._idGenerator.generateId = generateIdMock.bind(ecosystem._idGenerator)
+const now = 123456789
+
+export const nowMock = jest.fn((highRes?: boolean) =>
+  highRes ? performance.now() : now
+)
+
+ecosystem._idGenerator.generateId = generateIdMock
+ecosystem._idGenerator.now = nowMock
 
 afterAll(() => ecosystem.destroy())
 
 afterEach(() => {
+  idCounter = 0
+
   act(() => {
     ecosystem.reset()
+    ecosystem.setOverrides([])
   })
 })


### PR DESCRIPTION
## Description

In the process of filling out the test suite, I've found several checks (`if` statements, optional chaining operators, etc) that are completely unnecessary. Most of these are due to TS not knowing a situation is impossible. Prefer type casts to reduce build size and improve code branch coverage.

Also optimize a little more code for build size