### PR TITLE
fix(react): make DEV mode React component id generation work in SpiderMonkey

### DIFF
--- a/packages/react/src/classes/IdGenerator.ts
+++ b/packages/react/src/classes/IdGenerator.ts
@@ -87,8 +87,11 @@ export class IdGenerator {
       .map(line =>
         line
           .trim()
+          // V8/JavaScriptCore:
           .replace('at ', '')
           .replace(/ \(.*\)/, '')
+          // SpiderMonkey:
+          .replace(/@.*/, '')
       )
 
     const componentName = lines
@@ -97,7 +100,7 @@ export class IdGenerator {
 
         const identifiers = line.split('.')
         const fn = identifiers[identifiers.length - 1]
-        return fn[0].toUpperCase() === fn[0]
+        return fn[0]?.toUpperCase() === fn[0]
       })
       ?.split(' ')[0]
 


### PR DESCRIPTION
## Description

Firefox generates stack traces differently from Chrome/Safari. This makes `generateReactComponentId` throw an error. Make `generateReactComponentId` more resilient and handle Firefox specifically. These ids are unimportant but give better Dev X so we want to try to support them in DEV when possible.

Resolves #19