### PR TITLE
feat(react): wrap scheduler run in try...finally; add handling for destroyed instances

### DIFF
--- a/packages/react/src/classes/Ecosystem.ts
+++ b/packages/react/src/classes/Ecosystem.ts
@@ -394,7 +394,16 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
     atom: A | AnyAtomInstance,
     params?: AtomParamsType<A>
   ) {
-    if (is(atom, AtomInstanceBase)) return atom
+    if (is(atom, AtomInstanceBase)) {
+      // if the passed atom instance is Destroyed, get(/create) the
+      // non-Destroyed instance
+      return (atom as AnyAtomInstance).status === 'Destroyed'
+        ? this.getInstance(
+            (atom as AnyAtomInstance).template,
+            (atom as AnyAtomInstance).params
+          )
+        : atom
+    }
 
     const id = (atom as A).getInstanceId(this, params)
 

--- a/packages/react/src/classes/Scheduler.ts
+++ b/packages/react/src/classes/Scheduler.ts
@@ -182,17 +182,20 @@ export class Scheduler implements SchedulerInterface {
     // let counter = 0
 
     this[runningKey] = true
-    while (jobs.length) {
-      const job = (nows.length ? nows : jobs).shift() as Job
-      job.task()
+    try {
+      while (jobs.length) {
+        const job = (nows.length ? nows : jobs).shift() as Job
+        job.task()
 
-      // this "break" idea could only break for "full" jobs, not "now" jobs
-      // if (!(++counter % 20) && performance.now() - this._runStartTime >= 100) {
-      //   setTimeout(() => this.runJobs())
-      //   break
-      // }
+        // this "break" idea could only break for "full" jobs, not "now" jobs
+        // if (!(++counter % 20) && performance.now() - this._runStartTime >= 100) {
+        //   setTimeout(() => this.runJobs())
+        //   break
+        // }
+      }
+    } finally {
+      this[runningKey] = false
     }
-    this[runningKey] = false
 
     if (this._runAfterNows) {
       this._runAfterNows = false


### PR DESCRIPTION
## Description

We can be a little more robust when we hit a fatal error. Make the scheduler not hang forever in a running-but-not-running state. Also make `ecosystem.getInstance()` find/create the new, non-Destroyed instance when a Destroyed instance is passed.