### PR TITLE
feat(react): simplify inline selector detection

### DIFF
--- a/packages/react/src/classes/Selectors.ts
+++ b/packages/react/src/classes/Selectors.ts
@@ -233,7 +233,7 @@ export class Selectors {
     }
 
     const selectorOrConfig = selectable as AtomSelectorOrConfig<T, Args>
-    const id = this.getCacheId(selectorOrConfig, args as Args)
+    const id = this.getCacheId(selectorOrConfig, args)
     let cache = this._items[id] as SelectorCache<T, Args>
 
     if (cache) return cache
@@ -243,7 +243,7 @@ export class Selectors {
     this._items[id] = cache as SelectorCache<any, any[]>
     this.ecosystem._graph.addNode(id, true)
 
-    this.runSelector(id, args as Args, true)
+    this.runSelector(id, args, true)
 
     return cache
   }
@@ -364,7 +364,7 @@ export class Selectors {
   public _swapRefs(
     oldRef: AtomSelectorOrConfig<any, any[]>,
     newRef: AtomSelectorOrConfig<any, any[]>,
-    args: any[]
+    args: any[] = []
   ) {
     const existingCache = this.find(oldRef, args)
     const baseKey = this._refBaseKeys.get(oldRef)
@@ -372,6 +372,7 @@ export class Selectors {
     if (!existingCache || !baseKey) return
 
     this._refBaseKeys.set(newRef, baseKey)
+    this._refBaseKeys.delete(oldRef)
     existingCache.selectorRef = newRef
     this.runSelector(existingCache.id, args)
   }

--- a/packages/react/src/hooks/useAtomSelector.ts
+++ b/packages/react/src/hooks/useAtomSelector.ts
@@ -1,10 +1,10 @@
-import { AtomSelectorConfig, AtomSelectorOrConfig } from '../types'
+import { AtomSelectorOrConfig } from '../types'
 import { MutableRefObject, useMemo, useRef, useSyncExternalStore } from 'react'
 import { destroyed, External, haveDepsChanged } from '../utils'
 import { useEcosystem } from './useEcosystem'
 import { useReactComponentId } from './useReactComponentId'
-import { Ecosystem } from '../classes/Ecosystem'
-import { SelectorCache } from '../classes/Selectors'
+import { Graph } from '../classes/Graph'
+import { SelectorCache, Selectors } from '../classes/Selectors'
 
 const glob = ((typeof globalThis !== 'undefined' && globalThis) || {}) as any
 const OPERATION = 'useAtomSelector'
@@ -24,69 +24,34 @@ const OPERATION = 'useAtomSelector'
  *
  * It's also better dev-X when the graph doesn't change unnecessarily.
  *
- * Inline selectors that haven't _actually_ changed must be exactly the same,
- * stringified. The stringified `resultsComparator` must also be exactly the
- * same. `argsComparator` doesn't matter since it only runs at the hook level.
- *
- * Importantly, an inline selector's graph node must have exactly one dependent
- * too - the React component that called `useAtomSelector(inlineSelector)`.
+ * An inline selector's graph node must have exactly one dependent - the React
+ * component that called `useAtomSelector(inlineSelector)`. It will also have
+ * the exact same ideal cache id, which we derive from the name of the selector
+ * function if possible.
  */
 const isRefDifferent = (
-  ecosystem: Ecosystem,
+  _graph: Graph,
+  selectors: Selectors,
   newSelector: AtomSelectorOrConfig<any, any>,
-  cacheRef: MutableRefObject<SelectorCache<any, any> | undefined>
+  cacheRef: MutableRefObject<SelectorCache<any, any>>
 ) => {
-  if (!cacheRef.current) return true
-
   const oldSelector = cacheRef.current.selectorRef
-
   if (newSelector === oldSelector) return false
 
-  const dependents = ecosystem._graph.nodes[cacheRef.current.id]?.dependents
-
-  if (dependents && Object.keys(dependents).length !== 1) return true
+  const { dependents } = _graph.nodes[cacheRef.current.id]
+  if (Object.keys(dependents).length !== 1) return true
 
   const newIsFunction = typeof newSelector === 'function'
   const oldIsFunction = typeof oldSelector === 'function'
 
   if (newIsFunction !== oldIsFunction) return true
 
-  const newKey = ecosystem.selectors._getIdealCacheId(newSelector)
-  const oldKey = ecosystem.selectors._getIdealCacheId(oldSelector)
+  const newKey = selectors._getIdealCacheId(newSelector)
+  const oldKey = selectors._getIdealCacheId(oldSelector)
 
-  if (newKey !== oldKey) return true
-
-  if (
-    !newIsFunction &&
-    !oldIsFunction &&
-    newSelector.resultsComparator !== oldSelector.resultsComparator
-  ) {
-    const newResultsComparatorStr =
-      newSelector.resultsComparator?.toString() || ''
-
-    const oldResultsComparatorStr =
-      oldSelector.resultsComparator?.toString() || ''
-
-    if (newResultsComparatorStr !== oldResultsComparatorStr) return true
-  }
-
-  // last thing to compare is the selectors themselves
-  if (newIsFunction && oldIsFunction) {
-    return newSelector.toString() !== oldSelector.toString()
-  }
-
-  // we know they're both objects at this point
-  if (
-    (newSelector as AtomSelectorConfig).selector ===
-    (oldSelector as AtomSelectorConfig).selector
-  ) {
-    return false
-  }
-
-  const newRefStr = (newSelector as AtomSelectorConfig).selector.toString()
-  const oldRefStr = (oldSelector as AtomSelectorConfig).selector.toString()
-
-  return newRefStr !== oldRefStr
+  // if this last check is false, we're confident enough that it's an inline
+  // selector. It isn't a big deal if it isn't; it's just a for _ideal_ Dev X
+  return newKey !== oldKey
 }
 
 /**
@@ -103,7 +68,7 @@ export const useAtomSelector = <T, Args extends any[]>(
   selectorOrConfig: AtomSelectorOrConfig<T, Args>,
   ...args: Args
 ): T => {
-  const ecosystem = useEcosystem()
+  const { _graph, selectors } = useEcosystem()
   const dependentKey = useReactComponentId()
   const cacheRef = useRef<SelectorCache<T, Args>>()
   const skipState = useRef<T>(destroyed as any)
@@ -111,22 +76,30 @@ export const useAtomSelector = <T, Args extends any[]>(
 
   const argsChanged =
     isConfig && selectorOrConfig.argsComparator && cacheRef.current?.args
-      ? selectorOrConfig.argsComparator(args, cacheRef.current.args)
+      ? !selectorOrConfig.argsComparator(args, cacheRef.current.args)
       : haveDepsChanged(cacheRef.current?.args, args)
 
   const resolvedArgs = argsChanged
     ? args
-    : cacheRef.current?.args || ([] as unknown as Args)
+    : // if args haven't changed, cacheRef has to exist. This cast is fine:
+      (cacheRef.current as SelectorCache<T, Args>).args
 
   const hasRefChanged = selectorOrConfig !== cacheRef.current?.selectorRef
   const isDifferent =
-    argsChanged || isRefDifferent(ecosystem, selectorOrConfig, cacheRef)
+    argsChanged ||
+    isRefDifferent(
+      _graph,
+      selectors,
+      selectorOrConfig,
+      // the argsChanged check guarantees `cacheRef.current` is defined here:
+      cacheRef as MutableRefObject<SelectorCache<any, any>>
+    )
 
   if (isDifferent) {
     // yes, this mutation is fine
-    cacheRef.current = ecosystem.selectors.getCache(
+    cacheRef.current = selectors.getCache(
       selectorOrConfig,
-      resolvedArgs
+      resolvedArgs as Args
     )
   }
 
@@ -144,7 +117,7 @@ export const useAtomSelector = <T, Args extends any[]>(
         if (glob.IS_REACT_ACT_ENVIRONMENT) onStoreChange()
 
         // this function must be idempotent
-        if (!ecosystem._graph.nodes[cache.id]?.dependents[dependentKey]) {
+        if (!_graph.nodes[cache.id]?.dependents[dependentKey]) {
           // React can unmount other components before calling this subscribe
           // function but after we got the cache above. Re-get the cache
           // if such unmountings destroyed it in the meantime:
@@ -157,7 +130,7 @@ export const useAtomSelector = <T, Args extends any[]>(
             return () => {} // let the next render register the graph edge
           }
 
-          ecosystem._graph.addEdge(
+          _graph.addEdge(
             dependentKey,
             cache.id,
             OPERATION,
@@ -182,20 +155,20 @@ export const useAtomSelector = <T, Args extends any[]>(
 
         return () => {
           // I don't think we need to unset any of the cache refs here
-          ecosystem._graph.removeEdge(dependentKey, cache.id)
+          _graph.removeEdge(dependentKey, cache.id)
         }
       },
       () => (isInvalidated ? destroyed : cache.result),
     ]
-  }, [ecosystem, cache])
+  }, [_graph, cache])
 
-  // if ref changed but is clearly the "same" selector, swap out the ref and
+  // if ref changed but is likely the "same" selector, swap out the ref and
   // invalidate the cache
   if (hasRefChanged && !isDifferent) {
-    ecosystem.selectors._swapRefs(
+    selectors._swapRefs(
       cache.selectorRef as AtomSelectorOrConfig<any, any[]>,
       selectorOrConfig as AtomSelectorOrConfig<any, any[]>,
-      resolvedArgs
+      resolvedArgs as Args
     )
     // prevent state update loop if new selector ref just returned a new result:
     skipState.current = cache.result as T


### PR DESCRIPTION
## Description

We don't need to be so picky about whether a selector is inline. The only danger we're trying to guard against is potentially giving selector graph nodes confusing names in very, very rare cases. Make these cases a tiny bit less rare and cut out a lot of ugly, non-performant code.