### PR TITLE
docs: fix docusaurus editUrl location and point it to a `/edit/` path

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -121,7 +121,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/Omnistac/zedux/tree/master/',
+          editUrl: 'https://github.com/Omnistac/zedux/edit/master/docs/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
## Description

The docusaurus `editUrl` config is pointing to the repo root when it needs to point to the `/docs` path. Fix that. Also point the url to the github `/edit/` path instead of `/tree/`.

Resolves #24 