### PR TITLE
fix(react): prevent `controller.abort()` from isolating the `abort` fn

### DIFF
--- a/packages/react/src/injectors/injectPromise.ts
+++ b/packages/react/src/injectors/injectPromise.ts
@@ -109,9 +109,8 @@ export const injectPromise: {
     }
 
     if (promise === refs.current.promise) return refs.current.promise
-    ;(prevController?.abort as ((reason?: any) => void) | undefined)?.(
-      'updated'
-    )
+
+    if (prevController) (prevController as any).abort('updated')
 
     if (!dataOnly) {
       // preserve previous data and error using setStateDeep:
@@ -137,8 +136,7 @@ export const injectPromise: {
   injectEffect(
     () => () => {
       const controller = refs.current.controller
-      if (!controller) return
-      ;(controller as any).abort('destroyed')
+      if (controller) (controller as any).abort('destroyed')
     },
     []
   )


### PR DESCRIPTION
## Description

The optional chaining of the `controller.abort('update')` calls in `injectPromise()` are causing builds to extract the `abort` function to its own variable, losing the `controller` `this` scope when invoked. This causes an `Illegal invocation` error.

Use an if statement instead and change the type cast location to match the other `controller.abort()` call.