### PR TITLE
release: v0.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## v0.5.11 (Apr 20, 2023)
+
+### New Features:
+
+- `react`: export SelectorCache class (#14)
+- `react`: make selectors trigger statusChanged mod events on init and destroy (#15)
+- `react`: make timestamp generation easily overridable; fix statusChanged event order (#17)
+- `react`: make useAtomConsumer log instead of throw an error when instance is Destroyed
+- `react`: simplify inline selector detection (#22)
+- `react`: wrap scheduler run in try...finally; add handling for destroyed instances (#21)
+
+### Fixes:
+
+- `react`: make DEV mode React component id generation work in SpiderMonkey (#20)
+- `react`: prevent `controller.abort()` from isolating the `abort` fn (#27)
+- `react`: remove dehydrated state generic from ssr atom config options for now (#16)
+- `react`: restore Active status when an atom instance is revived (#13)
+- `core`, `react`: improve `state.on` and `Observable` types (#12)
+
 ## v0.5.10 (Apr 13, 2023)
 
 ### Fixes:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zedux",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "A Molecular State Engine for React",
   "type": "module",
   "author": "Joshua Claunch (bowheart <bowheart31@gmail.com>)",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/core",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "A high-level, declarative, composable form of Redux",
   "main": "./dist/zedux.umd.js",
   "module": "./dist/esm/index.js",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/immer",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "Official Immer integration for Zedux's store and atomic APIs",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "devDependencies": {
-    "@zedux/react": "^0.5.10",
+    "@zedux/react": "^0.5.11",
     "immer": "^9.0.21"
   },
   "exports": {
@@ -41,7 +41,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/react": "^0.5.10",
+    "@zedux/react": "^0.5.11",
     "immer": ">=9.0.19"
   },
   "repository": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/react",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/core": "^0.5.10"
+    "@zedux/core": "^0.5.11"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",


### PR DESCRIPTION
## Description

Increment monorepo package versions and update the CHANGELOG for version 0.5.11.

This PR was generated by the release script at https://github.com/Omnistac/zedux/tree/master/scripts/release.js

The packages will be published to npm and a GitHub release will be created after this PR merges.