### PR TITLE
feat(react)!: reuse names that can be shared between instances & selectors

### DIFF
--- a/docs/docs/api/classes/AtomInstance.mdx
+++ b/docs/docs/api/classes/AtomInstance.mdx
@@ -37,6 +37,38 @@ export const AddDependentConfigParam = () => (
   </Item>
 )
 
+export const EvaluationReasonParams = ({ type = 'atom instance' }) => (
+  <>
+    <Item name="nextReasons">
+      <p>
+        An array that tracks the batched{' '}
+        <Link to="../types/EvaluationReason">EvaluationReasons</Link> that will
+        lead to the {type} reevaluating.
+      </p>
+      <p>
+        If the {type} is currently evaluating, this is the list of reasons
+        explaining why and is what{' '}
+        <Link to="Ecosystem#why">
+          <code>ecosystem.why()</code>
+        </Link>{' '}
+        will return.
+      </p>
+      <p>
+        This will be empty if no reevaluation is currently scheduled or if this
+        is the first evaluation of the {type}.
+      </p>
+    </Item>
+    <Item name="prevReasons">
+      <p>
+        An array that tracks the batched{' '}
+        <Link to="../types/EvaluationReason">EvaluationReasons</Link> describing
+        why the {type} last evaluated. This will be empty if the last evaluation
+        was the first.
+      </p>
+    </Item>
+  </>
+)
+
 All standard atoms (aka "atom instances") are actually instances of this class. When Zedux instantiates [atom templates](AtomTemplate) (and [ion templates](IonTemplate)), it's just creating instances of this class.
 
 ## Creation
@@ -135,6 +167,7 @@ ecosystem.getInstance(
   ['c']
 ).id // 'b-["c"]'`}</Ts>
   </Item>
+  <EvaluationReasonParams />
   <Item name="params">
     <p>
       A reference to the raw, unserialized params that were used to create this

--- a/docs/docs/api/classes/SelectorCache.mdx
+++ b/docs/docs/api/classes/SelectorCache.mdx
@@ -4,6 +4,7 @@ title: SelectorCache
 ---
 
 import { Legend, Item, Link, Tabs, Ts, tab1, tab2 } from '@site/src/all'
+import { EvaluationReasonParams } from './AtomInstance.mdx'
 
 Every time an [ecosystem](Ecosystem)'s [`.selectors`](Selectors) manager caches an atom selector, the "cached selector" is really just an instance of this class. Thus, an instance of this class is what's returned from various Selectors class methods like [`.getCache()`](Selectors#getcache) and [`.findAll()`](Selectors#findall).
 
@@ -61,33 +62,7 @@ const cacheItem = ecosystem.selectors.getCache(getOddNumbers)
       SelectorCaches you're using outside React/atoms.
     </p>
   </Item>
-  <Item name="nextEvaluationReasons">
-    <p>
-      An array that tracks the batched{' '}
-      <Link to="../types/EvaluationReason">EvaluationReasons</Link> that will
-      lead to the selector reevaluating.
-    </p>
-    <p>
-      If the selector is currently evaluating, this is the list of reasons
-      explaining why and is what{' '}
-      <Link to="Ecosystem#why">
-        <code>ecosystem.why()</code>
-      </Link>{' '}
-      will return.
-    </p>
-    <p>
-      This will be empty if no reevaluation is currently scheduled or if this is
-      the first evaluation of the selector.
-    </p>
-  </Item>
-  <Item name="prevEvaluationReasons">
-    <p>
-      An array that tracks the batched{' '}
-      <Link to="../types/EvaluationReason">EvaluationReasons</Link> describing
-      why the selector last evaluated. This will be empty if the last evaluation
-      was the first.
-    </p>
-  </Item>
+  <EvaluationReasonParams type="selector" />
   <Item name="result">
     <p>
       The cached return value of the atom selector. Selectors don't use{' '}

--- a/docs/docs/api/classes/ZeduxPlugin.mdx
+++ b/docs/docs/api/classes/ZeduxPlugin.mdx
@@ -195,12 +195,21 @@ Every ZeduxPlugin has just two properties:
     </p>
     <p>Payload shape:</p>
     <Ts>{`{
-  cache?: SelectorCache
-  instance?: AnyAtomInstance
+  node: AnyAtomInstance | SelectorCache
   time: number
 }`}</Ts>
     <p>
-      Either <code>cache</code> or <code>instance</code> will always be set.{' '}
+      <code>node</code> is either an instance of{' '}
+      <Link to="AtomInstance">
+        <code>AtomInstance</code>
+      </Link>{' '}
+      or{' '}
+      <Link to="SelectorCache">
+        <code>SelectorCache</code>
+      </Link>
+      .
+    </p>
+    <p>
       <code>time</code> will be a DOMHighResTimestamp measured in milliseconds.
     </p>
     <p>
@@ -212,8 +221,8 @@ Every ZeduxPlugin has just two properties:
       >
         <code>performance.now()</code>
       </a>{' '}
-      in the browser. In other envs, it will fall back to using a non-high-res
-      timestamp via <code>Date.now()</code>.
+      when available in the global scope. In other envs, it will fall back to
+      using a non-high-res timestamp via <code>Date.now()</code>.
     </p>
   </Item>
   <Item name="instanceReused">

--- a/packages/react/src/classes/Ecosystem.ts
+++ b/packages/react/src/classes/Ecosystem.ts
@@ -19,7 +19,7 @@ import {
   PartialAtomInstance,
   Selectable,
 } from '../types'
-import { External, InstanceStackItem, SelectorStackItem } from '../utils'
+import { External } from '../utils'
 import { pluginActions } from '../utils/plugin-actions'
 import { EvaluationStack } from './EvaluationStack'
 import { Graph } from './Graph'
@@ -742,15 +742,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
    * array if this is the first evaluation of the instance or selector.
    */
   public why() {
-    const item = this._evaluationStack.read()
-
-    if (!item) return
-
-    if ((item as SelectorStackItem).cache) {
-      return (item as SelectorStackItem).cache.nextEvaluationReasons
-    }
-
-    return (item as InstanceStackItem).instance._nextEvaluationReasons
+    return this._evaluationStack.read()?.node.nextReasons
   }
 
   /**

--- a/packages/react/src/classes/instances/AtomInstanceBase.ts
+++ b/packages/react/src/classes/instances/AtomInstanceBase.ts
@@ -29,7 +29,6 @@ export abstract class AtomInstanceBase<
 
   public abstract _createdAt: number
   public abstract _injectors?: InjectorDescriptor[]
-  public abstract _prevEvaluationReasons?: EvaluationReason[]
   public abstract _promiseError?: Error
   public abstract _promiseStatus?: PromiseStatus
 

--- a/packages/react/src/injectors/injectWhy.ts
+++ b/packages/react/src/injectors/injectWhy.ts
@@ -9,4 +9,4 @@ import { readInstance } from '../classes/EvaluationStack'
  * const reasons = ecosystem.why()
  * ```
  */
-export const injectWhy = () => readInstance()._nextEvaluationReasons
+export const injectWhy = () => readInstance().nextReasons

--- a/packages/react/src/utils/plugin-actions.ts
+++ b/packages/react/src/utils/plugin-actions.ts
@@ -31,14 +31,10 @@ export const pluginActions = {
     'edgeRemoved'
   >('edgeRemoved'),
   evaluationFinished: actionFactory<
-    | {
-        instance: AnyAtomInstance
-        time: number
-      }
-    | {
-        cache: SelectorCache
-        time: number
-      },
+    {
+      node: AnyAtomInstance | SelectorCache
+      time: number
+    },
     'evaluationFinished'
   >('evaluationFinished'),
   instanceReused: actionFactory<{

--- a/packages/react/src/utils/types.ts
+++ b/packages/react/src/utils/types.ts
@@ -13,24 +13,14 @@ export type InjectorDescriptor<T = any> = T extends undefined
       type: string
     }
 
-export interface StackItemBase {
+export interface StackItem {
   /**
-   * The id of the instance or SelectorCache
+   * The atom instance or selector cache that's currently evaluating
    */
-  id: string
+  node: AnyAtomInstance | SelectorCache
 
   /**
-   * the high-def timestamp of when the item was pushed onto the stack
+   * The high-def timestamp of when the item was pushed onto the stack
    */
   start?: number
 }
-
-export interface InstanceStackItem extends StackItemBase {
-  instance: AnyAtomInstance
-}
-
-export interface SelectorStackItem extends StackItemBase {
-  cache: SelectorCache
-}
-
-export type StackItem = InstanceStackItem | SelectorStackItem

--- a/packages/react/test/units/Selectors.test.tsx
+++ b/packages/react/test/units/Selectors.test.tsx
@@ -13,8 +13,8 @@ describe('the Selectors class', () => {
     const cache3 = {
       args: [],
       id: '@@selector-selector3',
-      nextEvaluationReasons: [],
-      prevEvaluationReasons: [],
+      nextReasons: [],
+      prevReasons: [],
       result: 'abcd',
       selectorRef: selector3,
     }
@@ -25,16 +25,16 @@ describe('the Selectors class', () => {
       '@@selector-selector1': {
         args: [],
         id: '@@selector-selector1',
-        nextEvaluationReasons: [],
-        prevEvaluationReasons: [],
+        nextReasons: [],
+        prevReasons: [],
         result: 'ab',
         selectorRef: selector1,
       },
       '@@selector-selector2': {
         args: [],
         id: '@@selector-selector2',
-        nextEvaluationReasons: [],
-        prevEvaluationReasons: [],
+        nextReasons: [],
+        prevReasons: [],
         result: 'abc',
         selectorRef: selector2,
       },


### PR DESCRIPTION
## Description

We can simplify quite a bit of logic by reusing some property names between atom instances and selectors. Change the `evaluationFinished` mod to simply use `node` instead of different `instance` and `cache` keys.

Change `prevEvaluationReasons` and `_prevEvaluationResons` to simply `prevReasons`.

Change `nextEvaluationReasons` and `_nextEvaluationReasons` to simply `nextReasons`.

This includes making those fields non-underscore-prefixed in the `AtomInstance` class and therefore adding documentation for them.

This is a breaking change - the `evaluationFinished` mod event's payload shape has changed and some already-public fields in the `SelectorCache` class are renamed:

- `evaluationFinishedAction.payload.cache` -> `evaluationFinishedAction.payload.node`
- `evaluationFinishedAction.payload.instance` -> `evaluationFinishedAction.payload.node`
- `selectorCache.prevEvaluationReasons` -> `selectorCache.prevReasons`
- `selectorCache.nextEvaluationReasons` -> `selectorCache.nextReasons`