### PR TITLE
feat(react)!: move auto-batching from `api()` to `injectCallback()`

### DIFF
--- a/docs/docs/advanced/batching.mdx
+++ b/docs/docs/advanced/batching.mdx
@@ -5,15 +5,15 @@ title: Batching
 
 Zedux flushes updates synchronously. It needs to do this to keep user input in sync with state for optimal UX. But this can lead to unnecessary evaluations when setting the state of multiple stores at once.
 
-These extra evaluations are often an unnecessary performance loss. They can also be unexpected, leading to values seeming out of sync during the in-between evaluations. This is a form of "state tearing" and can even lead to bugs in rare cases.
+These extra evaluations are sometimes an unnecessary performance loss. They can also be unexpected, leading to values seeming out of sync during the in-between evaluations. This is a form of "state tearing" and can even lead to bugs in rare cases.
 
 To combat all this, Zedux offers batching APIs. It also batches some things by default.
 
 :::tip you will learn:
 
-- How to batch a known set of updates
-- How to batch an unknown number of updates
-- When Zedux automatically batches updates and how to disable it.
+- How to batch a known set of updates.
+- How to batch open-endedly.
+- When Zedux automatically batches updates.
 
 :::
 
@@ -35,9 +35,9 @@ ecosystem.batch(() => {
 
 `ecosystem.batch()` prevents the scheduler from flushing until the callback completes. This is the simplest way to batch updates.
 
-## Batching Unknown Updates
+## Open-Ended Batching
 
-Sometimes it isn't convenient to wrap a bunch of `.setState()` calls in a single `ecosystem.batch()` call. For these situations, you can set the `meta` property of the dispatched action to [`internalTypes.batch`](../api/utils/internalTypes#batch).
+Sometimes it isn't convenient to wrap synchronous dispatches in a single `ecosystem.batch()` call. For these situations, you can set the `meta` property of the dispatched action to [`internalTypes.batch`](../api/utils/internalTypes#batch).
 
 ```ts
 // before:
@@ -63,48 +63,64 @@ aStore.setStateDeep({ newValue })
 
 There are a few situations where Zedux batches updates automatically. Some of this batching you can't control - it's an integral part of Zedux's graph algorithm. But there is one place where you can control it:
 
-### Atom Exports
+### `injectCallback`
 
-By default, Zedux wraps all of an [atom's exported functions](../api/classes/AtomInstance#exports) in [`ecosystem.batch()`](../api/classes/Ecosystem#batch) calls. This wrapping adds a little overhead, but prevents rare cases of state tearing as we'll soon see.
-
-To prevent this overhead, batch state updates yourself and pass `false` as the 2nd param to `api()` to prevent Zedux from automatically wrapping your exported functions.
+Zedux wraps all calls to an injected callback in [`ecosystem.batch()`](../api/classes/Ecosystem#batch) calls.
 
 ```ts
 const automaticBatchingAtom = atom('automaticBatching', () => {
   const store = injectStore(0)
 
-  return api(store).setExports({
-    updateTwice: () => {
-      store.setState(state => state + 1)
-      store.setState(state => state + 1)
-    },
-  })
+  const updateTwice = injectCallback(() => {
+    store.setState(state => state + 1)
+    store.setState(state => state + 1)
+  }, [])
+
+  return api(store).setExports({ updateTwice })
 })
 
 const manualBatchingAtom = atom('manualBatching', () => {
   const { ecosystem } = injectAtomGetters()
   const store = injectStore(0)
 
-  // just pass false to turn off automatic batching
+  // use `injectMemo` to "turn off" automatic batching:
   // highlight-next-line
-  return api(store, false).setExports({
-    updateTwice: () => {
-      ecosystem.batch(() => {
-        store.setState(state => state + 1)
-        store.setState(state => state + 1)
-      })
-    },
-  })
+  const updateTwice = injectMemo(() => {
+    ecosystem.batch(() => {
+      store.setState(state => state + 1)
+      store.setState(state => state + 1)
+    })
+  }, [])
+
+  return api(store, false).setExports({ updateTwice })
 })
 ```
 
-Both of these atoms behave exactly the same. However, `manualBatchingAtom` prevents Zedux from checking and wrapping the atom's exports, saving a _tiny bit_ of overhead at the cost of boilerplate.
+Both of these atoms behave exactly the same. You typically shouldn't need to worry about this, but if you don't want to batch updates, you can usually ditch injectors altogether and use an inline function - no need for `injectMemo()`:
+
+```ts
+const noBatchingAtom = atom('noBatching', () => {
+  const { ecosystem } = injectAtomGetters()
+  const store = injectStore(0)
+
+  // create an inline function:
+  // highlight-next-line
+  const updateTwice = () => {
+    store.setState(state => state + 1)
+    store.setState(state => state + 1)
+  }
+
+  return api(store, false).setExports({ updateTwice })
+})
+```
+
+As long as the callback doesn't reference anything unstable (the `store` reference is stable in this example), inline callbacks are fine in Zedux.
 
 ## Why Batch?
 
-Since Zedux only deals with local state, batching updates in Zedux doesn't improve performance as much as you might think. Batching is much more important in UI or data fetching libraries where network speed and I/O are bottlenecks.
+Since Zedux only deals with local state, batching updates in Zedux doesn't improve performance as much as you might think. Batching is much more important in UI or fetching libraries where network speed and I/O are bottlenecks.
 
-Allowing an atom to reevaluate an extra time is usually not a big deal performance-wise. So why would Zedux wrap exported functions by default? Or why would you ever care to call `ecosystem.batch()` yourself?
+Allowing an atom to reevaluate an extra time is usually not a big deal performance-wise. So why would you ever care to use `injectCallback()` or call `ecosystem.batch()`?
 
 Turns out, there are rare situations where _not_ batching can lead to state "tearing" bugs. Since Zedux flushes all updates synchronously by default, you may encounter situations where setting state in one place leads to an atom reevaluating before you have a chance to update another piece of state that you're expecting to be in sync with the first piece.
 
@@ -120,8 +136,7 @@ const switcherAtom = ion('switcher', ({ get, getInstance }) => {
   const countersInstance = getInstance(countersAtom)
   const value = get(countersInstance)[key]
 
-  // pass `false` to `api()` to prevent automatic batching:
-  return api(value, false).setExports({
+  return api(value).setExports({
     switchAndIncrement: () => {
       const newKey = internalStore.getState() === 'even' ? 'odd' : 'even'
       internalStore.setState(newKey)
@@ -165,9 +180,9 @@ const switcherAtom = ion('switcher', ({ get, getInstance }) => {
     history.current.push({ key, value })
   }
 
-  // removing this `false` fixes everything:
-  return api(value, false).setExports({
+  return api(value).setExports({
     history,
+    // wrapping this function in `injectCallback()` fixes everything:
     switchAndIncrement: () => {
       const newKey = internalStore.getState() === 'even' ? 'odd' : 'even'
       internalStore.setState(newKey)
@@ -197,11 +212,11 @@ In this simple case, it's easy to update the logic to also check against `value`
 
 The better solution is to use batching to make sure the state you want to update is fully updated everywhere before any atoms evaluate.
 
-Since this example uses an export, simply removing the `false` passed to `api()` turns automatic batching back on, fixing everything (try it in the above sandbox!).
+Simply wrapping `switchAndIncrement` in `injectCallback()` "turns on" automatic batching, fixing everything (try it in the above sandbox!).
 
 ## Recap
 
 - Use `ecosystem.batch()` to batch a specific set of updates.
 - Set an action's `meta` property to `internalTypes.batch` to batch open-endedly.
-- Prevent Zedux from automatically batching an atom's exported functions by passing `false` as the 2nd param to `api()`.
+- Use `injectCallback()` to automatically batch updates.
 - Batching can prevent state tearing bugs. But you typically won't need to worry about it, especially if you structure side effects well.

--- a/docs/docs/advanced/ssr.mdx
+++ b/docs/docs/advanced/ssr.mdx
@@ -10,7 +10,7 @@ This guide assumes knowledge of the [persistence guide](persistence). It's recom
 [The persistence guide](persistence) showed how to get an ecosystem's state snapshot and use it to rehydrate the entire ecosystem. There is only a little more to learn to get a full-fledged SSR setup going.
 
 :::tip you will learn:
-How to use Zedux in a server-rendered app
+How to use Zedux in a server-rendered app.
 :::
 
 ## SSR Setup

--- a/docs/docs/api/injectors/injectCallback.mdx
+++ b/docs/docs/api/injectors/injectCallback.mdx
@@ -9,7 +9,28 @@ import { Legend, Item, Link, Tabs, Ts, tab1, tab2 } from '@site/src/all'
 import { injectCallback } from '@zedux/react'
 ```
 
-An [injector](../glossary#injector) that memoizes a function. Really just a shorthand for [`injectMemo()`](injectMemo) where the memoized value itself is a function. The returned function reference will only change when the passed dependencies change.
+An [injector](../glossary#injector) that memoizes a function and wraps it in an [`ecosystem.batch()`](../classes/Ecosystem#batch) call. This is essentially a shorthand for the following:
+
+```ts
+const { ecosystem } = injectAtomGetters()
+const setTwoStores = injectMemo(
+  () => (stateA, stateB) => {
+    ecosystem.batch(() => {
+      storeA.setState(stateA)
+      storeB.setState(stateB)
+    })
+  },
+  []
+)
+
+// equivalent using injectCallback:
+const setTwoStores = injectCallback((stateA, stateB) => {
+  storeA.setState(stateA)
+  storeB.setState(stateB)
+}, [])
+```
+
+The returned function reference will only change when the passed dependencies change on subsequent evaluations.
 
 Can be useful when exporting functions from an atom to ensure that you're only exporting stable references.
 
@@ -44,11 +65,14 @@ Miscellaneous:
 ```ts
 import { injectCallback, injectMemo } from '@zedux/react'
 
-// These are equivalent:
 const add = injectCallback((a: number, b: number) => a + b, [])
-const add = injectMemo(() => (a: number, b: number) => a + b, [])
+const withDeps = injectCallback(myFn, [depA, depB])
 
-const withDeps = injectCallback(fn, [depA, depB])
+// to prevent automatic batching, use `injectMemo` instead ...
+const withoutBatching = injectMemo(() => myFn, [depA, depB])
+
+// ... or use an inline function if memoization isn't needed:
+const inlineCallback = myFn
 ```
 
 ## Signature
@@ -63,8 +87,8 @@ const withDeps = injectCallback(fn, [depA, depB])
 
 <Legend>
   <Item name="callback">
-    Required. The function to memoize. This function reference will be discarded
-    when deps are the same.
+    Required. The function to memoize and auto-batch. This function reference
+    will be discarded when deps are the same.
   </Item>
   <Item name="deps">
     <p>

--- a/docs/docs/walkthrough/atom-apis.mdx
+++ b/docs/docs/walkthrough/atom-apis.mdx
@@ -157,7 +157,7 @@ function Age() {
 ```
 
 :::tip
-`injectCallback` is the injector equivalent of `useCallback`. We used it here with empty deps (`[]`) to remind us that this is an export and its reference can't change. This means we can't use any dynamic values inside the callback - notice that we call `store.getState()` inside the callback instead of setting it to a variable outside the callback and passing that as a dep.
+`injectCallback` is the injector equivalent of `useCallback`. We used it here with empty deps (`[]`) to remind us that this is an export and its reference can't change. This means we can't use any dynamic values inside the callback - only stable references. `injectCallback` also automatically [batches](../advanced/batching) all state updates in the callback.
 :::
 
 This is poor man's async handling. Let's upgrade to Suspense.

--- a/packages/react/src/classes/AtomApi.ts
+++ b/packages/react/src/classes/AtomApi.ts
@@ -17,8 +17,7 @@ export class AtomApi<
   public value: State | StoreType
 
   constructor(
-    value: AtomApi<State, Exports, StoreType, PromiseType> | StoreType | State,
-    public readonly wrap = true
+    value: AtomApi<State, Exports, StoreType, PromiseType> | StoreType | State
   ) {
     this.promise = undefined as PromiseType
     this.value = value as StoreType | State
@@ -44,25 +43,17 @@ export class AtomApi<
   public setExports<NewExports extends Record<string, any>>(
     exports: NewExports
   ): AtomApi<State, NewExports, StoreType, PromiseType> {
-    ;((this as unknown) as AtomApi<
-      State,
-      NewExports,
-      StoreType,
-      PromiseType
-    >).exports = exports
+    ;(
+      this as unknown as AtomApi<State, NewExports, StoreType, PromiseType>
+    ).exports = exports
 
-    return (this as unknown) as AtomApi<
-      State,
-      NewExports,
-      StoreType,
-      PromiseType
-    > // for chaining
+    return this as unknown as AtomApi<State, NewExports, StoreType, PromiseType> // for chaining
   }
 
   public setPromise<T>(
     promise: Promise<T>
   ): AtomApi<State, Exports, StoreType, Promise<T>> {
-    this.promise = (promise as unknown) as PromiseType
+    this.promise = promise as unknown as PromiseType
 
     return this as AtomApi<State, Exports, StoreType, Promise<T>> // for chaining
   }

--- a/packages/react/src/classes/instances/AtomInstance.ts
+++ b/packages/react/src/classes/instances/AtomInstance.ts
@@ -411,22 +411,7 @@ export class AtomInstance<G extends AtomGenerics> extends AtomInstanceBase<
 
       // Exports can only be set on initial evaluation
       if (this.status === 'Initializing' && api.exports) {
-        const exports = api.exports
-
-        // wrap exported functions in ecosystem.batch by default
-        this.exports = api.wrap
-          ? Object.keys(exports).reduce((obj, key: keyof G['Exports']) => {
-              const val = exports[key]
-              obj[key] =
-                typeof val === 'function'
-                  ? (((...args: any) =>
-                      this.ecosystem.batch(() =>
-                        val(...args)
-                      )) as G['Exports'][typeof key])
-                  : val
-              return obj
-            }, {} as G['Exports'])
-          : exports
+        this.exports = api.exports
       }
 
       // if api.value is a promise, we ignore api.promise

--- a/packages/react/src/factories/api.ts
+++ b/packages/react/src/factories/api.ts
@@ -23,15 +23,11 @@ export const api: {
     Exports extends Record<string, any> = Record<string, never>,
     PromiseType extends AtomApiPromise = undefined
   >(
-    value: AtomApi<StoreStateType<StoreType>, Exports, StoreType, PromiseType>,
-    wrap?: boolean
+    value: AtomApi<StoreStateType<StoreType>, Exports, StoreType, PromiseType>
   ): AtomApi<StoreStateType<StoreType>, Exports, StoreType, PromiseType>
 
   // Custom Stores (normal)
-  <StoreType extends Store<any> = Store<any>>(
-    value: StoreType,
-    wrap?: boolean
-  ): AtomApi<
+  <StoreType extends Store<any> = Store<any>>(value: StoreType): AtomApi<
     StoreStateType<StoreType>,
     Record<string, never>,
     StoreType,
@@ -53,12 +49,11 @@ export const api: {
     Exports extends Record<string, any> = Record<string, never>,
     PromiseType extends AtomApiPromise = undefined
   >(
-    value: AtomApi<State, Exports, undefined, PromiseType>,
-    wrap?: boolean
+    value: AtomApi<State, Exports, undefined, PromiseType>
   ): AtomApi<State, Exports, undefined, PromiseType>
 
   // No Store (normal)
-  <State = undefined>(value: State, wrap?: boolean): AtomApi<
+  <State = undefined>(value: State): AtomApi<
     State,
     Record<string, never>,
     undefined,
@@ -72,8 +67,7 @@ export const api: {
     StoreType extends Store<State> = Store<State>,
     PromiseType extends AtomApiPromise = undefined
   >(
-    value: State | StoreType | AtomApi<State, Exports, StoreType, PromiseType>,
-    wrap?: boolean
+    value: State | StoreType | AtomApi<State, Exports, StoreType, PromiseType>
   ): AtomApi<State, Exports, StoreType, PromiseType>
 } = <
   State = undefined,
@@ -81,13 +75,8 @@ export const api: {
   StoreType extends Store<State> | undefined = undefined,
   PromiseType extends AtomApiPromise = undefined
 >(
-  value?: AtomApi<State, Exports, StoreType, PromiseType> | StoreType | State,
-  wrap?: boolean
+  value?: AtomApi<State, Exports, StoreType, PromiseType> | StoreType | State
 ) =>
   new AtomApi(
-    value as
-      | AtomApi<State, Exports, StoreType, PromiseType>
-      | StoreType
-      | State,
-    wrap
+    value as AtomApi<State, Exports, StoreType, PromiseType> | StoreType | State
   )

--- a/packages/react/src/injectors/injectCallback.ts
+++ b/packages/react/src/injectors/injectCallback.ts
@@ -1,7 +1,26 @@
 import { InjectorDeps } from '../types'
+import { injectAtomGetters } from './injectAtomGetters'
 import { injectMemo } from './injectMemo'
 
+/**
+ * Memoizes a callback function and wraps it in an `ecosystem.batch()` call.
+ *
+ * To memoize a callback without automatic batching, use `injectMemo` instead:
+ *
+ * ```ts
+ * injectMemo(() => myCallback, [])
+ * ```
+ */
 export const injectCallback = <Args extends any[] = [], Ret = any>(
   callback: (...args: Args) => Ret,
   deps?: InjectorDeps
-) => injectMemo(() => callback, deps)
+) => {
+  const { ecosystem } = injectAtomGetters()
+
+  return injectMemo(
+    () =>
+      (...args: Args) =>
+        ecosystem.batch(() => callback(...args)),
+    deps
+  )
+}

--- a/packages/react/test/integrations/batching.test.tsx
+++ b/packages/react/test/integrations/batching.test.tsx
@@ -2,6 +2,7 @@ import {
   api,
   atom,
   injectAtomGetters,
+  injectCallback,
   injectRef,
   injectStore,
   internalTypes,
@@ -9,7 +10,7 @@ import {
 import { ecosystem } from '../utils/ecosystem'
 
 describe('batching', () => {
-  test('exports batch updates by default', () => {
+  test('injectCallback() batches updates by default', () => {
     const evaluations: number[] = []
 
     const atom1 = atom('1', () => {
@@ -18,10 +19,10 @@ describe('batching', () => {
       evaluations.push(store.getState())
 
       return api(store).setExports({
-        update: () => {
+        update: injectCallback(() => {
           store.setState(1)
           store.setState(2)
-        },
+        }, []),
       })
     })
 
@@ -34,7 +35,7 @@ describe('batching', () => {
     expect(evaluations).toEqual([0, 2])
   })
 
-  test('api(..., wrap: false) prevents exports from batching updates', () => {
+  test("inline callbacks don't batch updates", () => {
     const evaluations: number[] = []
 
     const atom1 = atom('1', () => {
@@ -42,7 +43,7 @@ describe('batching', () => {
 
       evaluations.push(store.getState())
 
-      return api(store, false).setExports({
+      return api(store).setExports({
         update: () => {
           store.setState(1)
           store.setState(2)

--- a/packages/react/test/integrations/injectors.test.tsx
+++ b/packages/react/test/integrations/injectors.test.tsx
@@ -45,13 +45,13 @@ describe('injectors', () => {
 
   test('React-esque injectors mimic React hook functionality', () => {
     const ref = {}
-    const cbs: (() => void)[] = []
+    const cbs: string[] = []
     const cleanups: string[] = []
     const effects: string[] = []
     const refs: (typeof ref)[] = []
     const vals: string[] = []
-    const cbA = () => {}
-    const cbB = () => {}
+    const cbA = () => 'aa'
+    const cbB = () => 'bb'
 
     const atom1 = atom('1', () => {
       const store = injectStore('a')
@@ -68,7 +68,7 @@ describe('injectors', () => {
       const cb3 = injectCallback(store.getState() === 'a' ? cbA : cbB, [
         store.getState(),
       ])
-      cbs.push(cb1, cb2, cb3)
+      cbs.push(cb1(), cb2(), cb3())
 
       injectEffect(() => {
         effects.push(store.getState())
@@ -84,7 +84,7 @@ describe('injectors', () => {
     instance.setState('b')
 
     expect(vals).toEqual(['a', 'a', 'a', 'b', 'a', 'b'])
-    expect(cbs).toEqual([cbA, cbA, cbA, cbB, cbA, cbB])
+    expect(cbs).toEqual(['aa', 'aa', 'aa', 'bb', 'aa', 'bb'])
     expect(effects).toEqual(['b'])
     expect(cleanups).toEqual([])
     expect(refs).toEqual([ref, ref])
@@ -92,7 +92,7 @@ describe('injectors', () => {
     instance.setState('c')
 
     expect(vals).toEqual(['a', 'a', 'a', 'b', 'a', 'b', 'c', 'a', 'c'])
-    expect(cbs).toEqual([cbA, cbA, cbA, cbB, cbA, cbB, cbB, cbA, cbB])
+    expect(cbs).toEqual(['aa', 'aa', 'aa', 'bb', 'aa', 'bb', 'bb', 'aa', 'bb'])
     expect(effects).toEqual(['b', 'c'])
     expect(cleanups).toEqual(['c'])
     expect(refs).toEqual([ref, ref, ref])


### PR DESCRIPTION
## Description

Automatically wrapping exported functions in `ecosystem.batch()` calls has some unwanted overhead. It also falls short in that those callbacks are sometimes called locally e.g. in `injectEffect()`. In this case they _won't_ batch, which is very confusing.

Make `injectCallback()` the auto-batcher instead. Auto-batching can be turned on by simply using it and turned off by not. It also makes `injectCallback()` finally hold a place in the codebase. It's been basically useless in Zedux till now - memoizing callbacks is not as important in Zedux as it is in React. Now it has a real use.

Also update tests and docs for the new functionality.

## Breaking Change

This is technically a breaking change. Exported functions that were relying on auto-batching and not using `injectCallback()` will not batch now, and injected callbacks will. This means updates will potentially happen in a different order and could even lead to bugs (very, very rarely - not likely - these can only happen if you have brittle side effects relying on event order).