### PR TITLE
feat(react)!: AtomInstanceProvider -> AtomProvider

### DIFF
--- a/docs/docs/api/classes/AtomInstance.mdx
+++ b/docs/docs/api/classes/AtomInstance.mdx
@@ -90,19 +90,19 @@ function MyComponent() {
 
 ## Providing
 
-An atom instance can be provided over React context via [`<AtomInstanceProvider>`](../components/AtomInstanceProvider).
+An atom instance can be provided over React context via [`<AtomProvider>`](../components/AtomProvider).
 
 ```tsx
-import { AtomInstanceProvider, useAtomInstance } from '@zedux/react'
+import { AtomProvider, useAtomInstance } from '@zedux/react'
 import { myAtom } from './atoms'
 
 function Parent() {
   const instance = useAtomInstance(myAtom)
 
   return (
-    <AtomInstanceProvider instance={instance}>
+    <AtomProvider instance={instance}>
       <Child />
-    </AtomInstanceProvider>
+    </AtomProvider>
   )
 }
 ```

--- a/docs/docs/api/components/AtomProvider.mdx
+++ b/docs/docs/api/components/AtomProvider.mdx
@@ -1,12 +1,12 @@
 ---
-id: AtomInstanceProvider
-title: AtomInstanceProvider
+id: AtomProvider
+title: AtomProvider
 ---
 
 import { Legend, Item, Link, Tabs, Ts, tab1, tab2 } from '@site/src/all'
 
 ```ts
-import { AtomInstanceProvider } from '@zedux/react'
+import { AtomProvider } from '@zedux/react'
 ```
 
 A component that provides one or more [atom instances](../classes/AtomInstance) over React context.
@@ -15,7 +15,7 @@ To consume the provided instances, use [`useAtomConsumer()`](../hooks/useAtomCon
 
 ## Example
 
-```tsx live ecosystemId=AtomInstanceProvider/example resultVar=Parent
+```tsx live ecosystemId=AtomProvider/example resultVar=Parent
 const secondsAtom = atom('seconds', (start: number) => {
   const store = injectStore(start)
 
@@ -39,9 +39,9 @@ function Parent() {
   const instance = useAtomInstance(secondsAtom, [100])
 
   return (
-    <AtomInstanceProvider instance={instance}>
+    <AtomProvider instance={instance}>
       <Child />
-    </AtomInstanceProvider>
+    </AtomProvider>
   )
 }
 ```
@@ -49,14 +49,12 @@ function Parent() {
 Providing multiple instances:
 
 ```tsx
-<AtomInstanceProvider instances={[instanceA, instanceB]}>
-  {children}
-</AtomInstanceProvider>
+<AtomProvider instances={[instanceA, instanceB]}>{children}</AtomProvider>
 ```
 
 ## Props
 
-AtomInstanceProvider accepts **either** an `instance` prop with a single atom instance OR an `instances` prop with an array of instances. You must pass one or the other but not both.
+AtomProvider accepts **either** an `instance` prop with a single atom instance OR an `instances` prop with an array of instances. You must pass one or the other but not both.
 
 <Legend>
   <Item name="instance">
@@ -72,7 +70,7 @@ AtomInstanceProvider accepts **either** an `instance` prop with a single atom in
     </p>
     <p>
       Be careful reordering this list and adding/removing items since this will
-      make React destroy/recreate the entire component subtree inside <code>{`<AtomInstanceProvider>`}</code>
+      make React destroy/recreate the entire component subtree inside <code>{`<AtomProvider>`}</code>
       .
     </p>
   </Item>

--- a/docs/docs/api/hooks/useAtomConsumer.mdx
+++ b/docs/docs/api/hooks/useAtomConsumer.mdx
@@ -9,7 +9,7 @@ import { Legend, Item, Link, Tabs, Ts, tab1, tab2 } from '@site/src/all'
 import { useAtomConsumer } from '@zedux/react'
 ```
 
-A React hook that accepts an [atom template](../classes/AtomTemplate) and returns an [instance](../classes/AtomInstance) of that atom that has been provided over React context via [`<AtomInstanceProvider>`](../components/AtomInstanceProvider).
+A React hook that accepts an [atom template](../classes/AtomTemplate) and returns an [instance](../classes/AtomInstance) of that atom template that has been provided over React context via [`<AtomProvider>`](../components/AtomProvider).
 
 If no instance has been provided, this hook will return undefined. Pass default params as the second argument to tell Zedux to create an atom instance if one wasn't provided. Pass `true` as the second argument to tell Zedux to throw an error if you forgot to provide an instance.
 
@@ -49,9 +49,9 @@ function Parent() {
   const instance = useAtomInstance(secondsAtom)
 
   return (
-    <AtomInstanceProvider instance={instance}>
+    <AtomProvider instance={instance}>
       <Child />
-    </AtomInstanceProvider>
+    </AtomProvider>
   )
 }
 ```
@@ -103,16 +103,16 @@ const guaranteed = useAtomConsumer(myAtom, true)
       If an array (<code>defaultParams</code>) is passed,{' '}
       <code>useAtomConsumer()</code> will use it to find or create an atom
       instance if none was provided above the current component via an{' '}
-      <Link to="../components/AtomInstanceProvider">
-        <code>&lt;AtomInstanceProvider&gt;</code>
+      <Link to="../components/AtomProvider">
+        <code>&lt;AtomProvider&gt;</code>
       </Link>
       . If the atom doesn't take params, pass an empty array.
     </p>
     <p>
       If <code>true</code> is passed, <code>useAtomConsumer()</code> will throw
       an error if the current component is rendered outside a matching{' '}
-      <code>&lt;AtomInstanceProvider&gt;</code>. This is the recommended
-      overload. Example:
+      <code>&lt;AtomProvider&gt;</code>. This is the recommended overload.
+      Example:
     </p>
     <Ts>{`const instance = useAtomConsumer(myAtom, true)`}</Ts>
   </Item>
@@ -137,4 +137,4 @@ const guaranteed = useAtomConsumer(myAtom, true)
 ## See Also
 
 - [The React Context walkthrough](../../walkthrough/react-context)
-- [`<AtomInstanceProvider>`](../components/AtomInstanceProvider)
+- [`<AtomProvider>`](../components/AtomProvider)

--- a/docs/docs/api/hooks/useAtomInstance.mdx
+++ b/docs/docs/api/hooks/useAtomInstance.mdx
@@ -48,9 +48,9 @@ const instance = useAtomInstance(myAtom)
 const withParams = useAtomInstance(myAtom, ['param 1', 'param 2'])
 
 // the instance can be provided over React context:
-<AtomInstanceProvider instance={instance}>
+<AtomProvider instance={instance}>
   {children}
-</AtomInstanceProvider>
+</AtomProvider>
 ```
 
 ## Signature

--- a/docs/docs/walkthrough/react-context.mdx
+++ b/docs/docs/walkthrough/react-context.mdx
@@ -16,33 +16,31 @@ The important philosophy here is that Zedux uses React context for Dependency In
 
 ## Providing
 
-An atom instance can be provided over React context via [`<AtomInstanceProvider>`](../api/components/AtomInstanceProvider).
+An atom instance can be provided over React context via [`<AtomProvider>`](../api/components/AtomProvider).
 
 ```tsx
-import { AtomInstanceProvider, useAtomInstance } from '@zedux/react'
+import { AtomProvider, useAtomInstance } from '@zedux/react'
 
 function Parent() {
   const instance = useAtomInstance(myAtom)
 
   return (
-    <AtomInstanceProvider instance={instance}>
+    <AtomProvider instance={instance}>
       <Child />
-    </AtomInstanceProvider>
+    </AtomProvider>
   )
 }
 ```
 
 ### Multiple Instances
 
-To provide instances of multiple atoms from the same component, you could nest a bunch of `<AtomInstanceProvider>`s. But that isn't very aesthetically pleasing now, is it.
+To provide instances of multiple atoms from the same component, you could nest a bunch of `<AtomProvider>`s. But that isn't very aesthetically pleasing now, is it.
 
-To this end, `AtomInstanceProvider` accepts an `instances` prop, whose value is an array of instances to provide. Only provide either an `instance` or an `instances` prop, not both.
+To this end, `AtomProvider` accepts an `instances` prop, whose value is an array of instances to provide. Only provide either an `instance` or an `instances` prop, not both.
 
 ```tsx
 return (
-  <AtomInstanceProvider instances={[instanceA, instanceB]}>
-    {children}
-  </AtomInstanceProvider>
+  <AtomProvider instances={[instanceA, instanceB]}>{children}</AtomProvider>
 )
 ```
 
@@ -113,9 +111,9 @@ function Parent() {
   const value = useAtomValue(instance) // subscribes
 
   return (
-    <AtomInstanceProvider instance={instance}>
+    <AtomProvider instance={instance}>
       <Child />
-    </AtomInstanceProvider>
+    </AtomProvider>
   )
 }
 
@@ -147,10 +145,10 @@ function Parent() {
   const instance = useAtomInstance(providedAtom)
 
   return (
-    <AtomInstanceProvider instance={instance}>
+    <AtomProvider instance={instance}>
       <div>Parent State (not subscribed): {instance.getState()}</div>
       <Child />
-    </AtomInstanceProvider>
+    </AtomProvider>
   )
 }
 ```
@@ -229,11 +227,11 @@ function UserThumbnail({ id }) {
   const instance = useAtomInstance(userData, [id])
 
   return (
-    <AtomInstanceProvider instance={userInstance}>
+    <AtomProvider instance={userInstance}>
       <Avatar />
       <Nickname />
       <OnlineStatus />
-    </AtomInstanceProvider>
+    </AtomProvider>
   )
 }
 
@@ -311,9 +309,9 @@ function TodoList() {
       {!isEditing && <button onClick={() => setIsEditing(true)}>Edit</button>}
       {instances.map(instance => (
         // vvv  Provide a different instance for each item  vvv
-        <AtomInstanceProvider key={instance.id} instance={instance}>
+        <AtomProvider key={instance.id} instance={instance}>
           <Todo />
-        </AtomInstanceProvider>
+        </AtomProvider>
       ))}
       {isEditing && <button onClick={saveAllChanges}>Save Changes</button>}
     </>
@@ -323,7 +321,7 @@ function TodoList() {
 
 ## Recap
 
-- Atom instances can be provided over React context via [`<AtomInstanceProvider>`](../api/components/AtomInstanceProvider).
+- Atom instances can be provided over React context via [`<AtomProvider>`](../api/components/AtomProvider).
 - Atom instances can be consumed from React context via [`useAtomConsumer()`](../api/hooks/useAtomConsumer).
   - `useAtomConsumer(myAtom, [...defaultParams])` creates an atom instance with `defaultParams` if no instance was provided.
   - `useAtomConsumer(myAtom, true)` throws an error if no atom instance was provided.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -60,7 +60,7 @@ module.exports = {
         type: 'category',
         label: 'Components',
         items: [
-          'api/components/AtomInstanceProvider',
+          'api/components/AtomProvider',
           'api/components/EcosystemProvider',
         ],
       },

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -53,7 +53,7 @@ On top of these, `@zedux/react` exports the following APIs:
 
 ### Components
 
-- [`<AtomInstanceProvider>`](https://omnistac.github.io/zedux/docs/api/components/AtomInstanceProvider)
+- [`<AtomProvider>`](https://omnistac.github.io/zedux/docs/api/components/AtomProvider)
 - [`<EcosystemProvider>`](https://omnistac.github.io/zedux/docs/api/components/EcosystemProvider)
 
 ### Hooks

--- a/packages/react/src/components/AtomProvider.tsx
+++ b/packages/react/src/components/AtomProvider.tsx
@@ -14,7 +14,7 @@ import { useEcosystem } from '../hooks'
  * dependency on the provided instance via `useAtomInstance()` or manual
  * graphing inside `useEffect()`.
  */
-export const AtomInstanceProvider: FC<
+export const AtomProvider: FC<
   | {
       children?: ReactNode
       instance: AnyAtomInstance
@@ -30,7 +30,7 @@ export const AtomInstanceProvider: FC<
 
   if (DEV && !instance && !instances) {
     throw new Error(
-      'Zedux: AtomInstanceProvider requires either an `instance` or `instances` prop'
+      'Zedux: AtomProvider requires either an `instance` or `instances` prop'
     )
   }
 
@@ -49,9 +49,7 @@ export const AtomInstanceProvider: FC<
 
   return (
     <context.Provider value={parentInstance}>
-      <AtomInstanceProvider instances={childInstances}>
-        {children}
-      </AtomInstanceProvider>
+      <AtomProvider instances={childInstances}>{children}</AtomProvider>
     </context.Provider>
   )
 }

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,2 +1,2 @@
-export * from './AtomInstanceProvider'
+export * from './AtomProvider'
 export * from './EcosystemProvider'

--- a/packages/react/test/integrations/react-context.test.tsx
+++ b/packages/react/test/integrations/react-context.test.tsx
@@ -1,6 +1,6 @@
 import {
   atom,
-  AtomInstanceProvider,
+  AtomProvider,
   useAtomConsumer,
   useAtomInstance,
   useAtomValue,
@@ -32,12 +32,12 @@ describe('React context', () => {
 
       return (
         <>
-          <AtomInstanceProvider instance={instance1}>
+          <AtomProvider instance={instance1}>
             <Child />
-          </AtomInstanceProvider>
-          <AtomInstanceProvider instance={instance2}>
+          </AtomProvider>
+          <AtomProvider instance={instance2}>
             <Child />
-          </AtomInstanceProvider>
+          </AtomProvider>
         </>
       )
     }
@@ -74,9 +74,9 @@ describe('React context', () => {
 
       return (
         <>
-          <AtomInstanceProvider instances={[instance1, instance2]}>
+          <AtomProvider instances={[instance1, instance2]}>
             <Child />
-          </AtomInstanceProvider>
+          </AtomProvider>
         </>
       )
     }
@@ -102,9 +102,9 @@ describe('React context', () => {
       return (
         <>
           {/** @ts-expect-error missing prop */}
-          <AtomInstanceProvider>
+          <AtomProvider>
             <Child />
-          </AtomInstanceProvider>
+          </AtomProvider>
         </>
       )
     }
@@ -137,7 +137,7 @@ describe('React context', () => {
 
     const div = await findByTestId('1')
 
-    expect(div.innerHTML).toMatch(/AtomInstanceProvider.*requires.*prop/i)
+    expect(div.innerHTML).toMatch(/AtomProvider.*requires.*prop/i)
     expect(spy).toHaveBeenCalledTimes(3)
 
     spy.mockReset()
@@ -185,9 +185,9 @@ describe('React context', () => {
       const instance = ecosystem.getInstance(atom1, ['a'])
 
       return (
-        <AtomInstanceProvider instance={instance}>
+        <AtomProvider instance={instance}>
           <Child />
-        </AtomInstanceProvider>
+        </AtomProvider>
       )
     }
 

--- a/packages/react/test/snippets/context.tsx
+++ b/packages/react/test/snippets/context.tsx
@@ -1,6 +1,6 @@
 import {
   atom,
-  AtomInstanceProvider,
+  AtomProvider,
   createEcosystem,
   EcosystemProvider,
   injectAtomValue,
@@ -110,9 +110,9 @@ function Parent() {
   const instance3 = useAtomInstance(atom3, ['1'])
 
   return (
-    <AtomInstanceProvider instances={[instance1, instance3]}>
+    <AtomProvider instances={[instance1, instance3]}>
       <Child />
-    </AtomInstanceProvider>
+    </AtomProvider>
   )
 }
 

--- a/packages/react/test/snippets/ions.tsx
+++ b/packages/react/test/snippets/ions.tsx
@@ -1,7 +1,7 @@
 import {
   api,
   atom,
-  AtomInstanceProvider,
+  AtomProvider,
   AtomInstanceType,
   useAtomConsumer,
   useAtomInstance,
@@ -55,9 +55,9 @@ function Greeting() {
   const testInstance = useAtomInstance(testAtom)
 
   return (
-    <AtomInstanceProvider instance={testInstance}>
+    <AtomProvider instance={testInstance}>
       {view ? <div>the first view!</div> : <Child />}
       <button onClick={() => setView(curr => !curr)}>change view</button>
-    </AtomInstanceProvider>
+    </AtomProvider>
   )
 }

--- a/packages/react/test/snippets/selectors.tsx
+++ b/packages/react/test/snippets/selectors.tsx
@@ -1,7 +1,7 @@
 import {
   api,
   atom,
-  AtomInstanceProvider,
+  AtomProvider,
   AtomInstanceType,
   injectAtomSelector,
   injectEffect,
@@ -86,9 +86,9 @@ function Greeting() {
   const testInstance = useAtomInstance(testAtom)
 
   return (
-    <AtomInstanceProvider instance={testInstance}>
+    <AtomProvider instance={testInstance}>
       {view ? <div>the first view!</div> : <Child />}
       <button onClick={() => setView(curr => !curr)}>change view</button>
-    </AtomInstanceProvider>
+    </AtomProvider>
   )
 }


### PR DESCRIPTION
## Description

Since revising the concept of an "atom" in Zedux to mean "atom instance" instead of "atom template", the `AtomInstanceProvider` component is unnecessarily verbose. `AtomProvider` now means the same thing and looks so much cleaner.

We are keeping the word `instance` in most APIs to avoid confusion, but it isn't necessary here since `AtomProvider` has a required `instance` or `instances` prop.

## Breaking Change

This is a breaking change - the component has been renamed. Import and use `AtomProvider` now:

```tsx
- import { AtomInstanceProvider } from '@zedux/react' // before
+ import { AtomProvider } from '@zedux/react' // after

- <AtomInstanceProvider instance={instance}><Child /></AtomInstanceProvider> // before
+ <AtomProvider instance={instance}><Child /></AtomProvider> // after
```