### PR TITLE
feat(react)!: useAtomConsumer -> useAtomContext

### DIFF
--- a/docs/docs/api/classes/AtomInstance.mdx
+++ b/docs/docs/api/classes/AtomInstance.mdx
@@ -107,14 +107,14 @@ function Parent() {
 }
 ```
 
-Consume provided instances with [`useAtomConsumer()`](../hooks/useAtomConsumer)
+Consume provided instances with [`useAtomContext()`](../hooks/useAtomContext)
 
 ```ts
-import { useAtomConsumer } from '@zedux/react'
+import { useAtomContext } from '@zedux/react'
 import { myAtom } from './atoms'
 
 function Child() {
-  const instance = useAtomConsumer(myAtom)
+  const instance = useAtomContext(myAtom)
 }
 ```
 

--- a/docs/docs/api/components/AtomProvider.mdx
+++ b/docs/docs/api/components/AtomProvider.mdx
@@ -11,7 +11,7 @@ import { AtomProvider } from '@zedux/react'
 
 A component that provides one or more [atom instances](../classes/AtomInstance) over React context.
 
-To consume the provided instances, use [`useAtomConsumer()`](../hooks/useAtomConsumer).
+To consume the provided instances, use [`useAtomContext()`](../hooks/useAtomContext).
 
 ## Example
 
@@ -29,7 +29,7 @@ const secondsAtom = atom('seconds', (start: number) => {
 })
 
 function Child() {
-  const instance = useAtomConsumer(secondsAtom) // no need to pass params
+  const instance = useAtomContext(secondsAtom) // no need to pass params
   const state = useAtomValue(instance) // subscribe
 
   return <div>Child's Seconds: {state}</div>

--- a/docs/docs/api/hooks/useAtomContext.mdx
+++ b/docs/docs/api/hooks/useAtomContext.mdx
@@ -1,12 +1,12 @@
 ---
-id: useAtomConsumer
-title: useAtomConsumer
+id: useAtomContext
+title: useAtomContext
 ---
 
 import { Legend, Item, Link, Tabs, Ts, tab1, tab2 } from '@site/src/all'
 
 ```ts
-import { useAtomConsumer } from '@zedux/react'
+import { useAtomContext } from '@zedux/react'
 ```
 
 A React hook that accepts an [atom template](../classes/AtomTemplate) and returns an [instance](../classes/AtomInstance) of that atom template that has been provided over React context via [`<AtomProvider>`](../components/AtomProvider).
@@ -25,7 +25,7 @@ This is one of the few hooks that does not have an injector equivalent (there is
 
 ## Example
 
-```tsx live ecosystemId=useAtomConsumer/example resultVar=Parent
+```tsx live ecosystemId=useAtomContext/example resultVar=Parent
 const secondsAtom = atom('seconds', () => {
   const store = injectStore(0)
 
@@ -39,7 +39,7 @@ const secondsAtom = atom('seconds', () => {
 })
 
 function Child() {
-  const instance = useAtomConsumer(secondsAtom)
+  const instance = useAtomContext(secondsAtom)
   const state = useAtomValue(instance)
 
   return <div>Child Seconds: {state}</div>
@@ -59,22 +59,22 @@ function Parent() {
 Miscellaneous:
 
 ```ts
-const instance = useAtomConsumer(myAtom)
+const instance = useAtomContext(myAtom)
 
-const defaulted = useAtomConsumer(myAtom, ['param 1', 'param 2'])
+const defaulted = useAtomContext(myAtom, ['param 1', 'param 2'])
 
 // if the atom doesn't take params, pass an empty array for the default params:
-const defaultedNoParams = useAtomConsumer(myAtom, [])
+const defaultedNoParams = useAtomContext(myAtom, [])
 
 // passing `true` makes Zedux throw an error if no instance was provided:
-const guaranteed = useAtomConsumer(myAtom, true)
+const guaranteed = useAtomContext(myAtom, true)
 ```
 
 ## Signature
 
 <Tabs>
-  {tab1(`useAtomConsumer = (template, defaultParamsOrThrow?) => atomInstance`)}
-  {tab2(`declare const useAtomConsumer: {
+  {tab1(`useAtomContext = (template, defaultParamsOrThrow?) => atomInstance`)}
+  {tab2(`declare const useAtomContext: {
   <A extends AnyAtomTemplate>(template: A): AtomInstanceType<A> | undefined
   <A extends AnyAtomTemplate>(
     template: A,
@@ -101,7 +101,7 @@ const guaranteed = useAtomConsumer(myAtom, true)
     </ul>
     <p>
       If an array (<code>defaultParams</code>) is passed,{' '}
-      <code>useAtomConsumer()</code> will use it to find or create an atom
+      <code>useAtomContext()</code> will use it to find or create an atom
       instance if none was provided above the current component via an{' '}
       <Link to="../components/AtomProvider">
         <code>&lt;AtomProvider&gt;</code>
@@ -109,12 +109,12 @@ const guaranteed = useAtomConsumer(myAtom, true)
       . If the atom doesn't take params, pass an empty array.
     </p>
     <p>
-      If <code>true</code> is passed, <code>useAtomConsumer()</code> will throw
+      If <code>true</code> is passed, <code>useAtomContext()</code> will throw
       an error if the current component is rendered outside a matching{' '}
       <code>&lt;AtomProvider&gt;</code>. This is the recommended overload.
       Example:
     </p>
-    <Ts>{`const instance = useAtomConsumer(myAtom, true)`}</Ts>
+    <Ts>{`const instance = useAtomContext(myAtom, true)`}</Ts>
   </Item>
   <Item name="Returns">
     <p>
@@ -124,7 +124,7 @@ const guaranteed = useAtomConsumer(myAtom, true)
     <p>
       If no instance was provided and default params were passed, returns the
       instance matching the given params. If the instance doesn't exist yet,{' '}
-      <code>useAtomConsumer()</code> uses the passed template and default params
+      <code>useAtomContext()</code> uses the passed template and default params
       to create it.
     </p>
     <p>

--- a/docs/docs/api/hooks/useAtomInstance.mdx
+++ b/docs/docs/api/hooks/useAtomInstance.mdx
@@ -16,7 +16,7 @@ Since the dependency is static, the component that uses this hook will not reren
 
 To make the dependency dynamic, pass the returned atom instance to a dynamic hook like [`useAtomValue()`](useAtomValue), [`useAtomState()`](useAtomState), or [`useAtomSelector()`](useAtomSelector).
 
-You can also pass an atom instance directly to register a static graph dependency on instances received from other sources, e.g. from [`useAtomConsumer()`](useAtomConsumer). You typically won't need to do this.
+You can also pass an atom instance directly to register a static graph dependency on instances received from other sources, e.g. from [`useAtomContext()`](useAtomContext). You typically won't need to do this.
 
 ## Examples
 

--- a/docs/docs/walkthrough/react-context.mdx
+++ b/docs/docs/walkthrough/react-context.mdx
@@ -46,52 +46,52 @@ return (
 
 ## Consuming
 
-Consume provided instances with [`useAtomConsumer()`](../api/hooks/useAtomConsumer)
+Consume provided instances with [`useAtomContext()`](../api/hooks/useAtomContext)
 
 ```ts
-import { useAtomConsumer } from '@zedux/react'
+import { useAtomContext } from '@zedux/react'
 
 function Child() {
-  const instance = useAtomConsumer(myAtom)
+  const instance = useAtomContext(myAtom)
   ...
 }
 ```
 
 ### If an Instance Wasn't Provided
 
-If a component uses `useAtomConsumer()` but no instance was provided by any parent, `useAtomConsumer()` returns undefined.
+If a component uses `useAtomContext()` but no instance was provided by any parent, `useAtomContext()` returns undefined.
 
 ```ts
-const instance = useAtomConsumer(myAtom)
+const instance = useAtomContext(myAtom)
 instance.invalidate() // error! Cannot read properties of undefined
 ```
 
 TypeScript users will be warned of this. But to get around it, you'd have to put checks before everything you try to do with that instance. Sounds like a fast-track to annoyance.
 
-Fortunately (on purpose), `useAtomConsumer()` has two overloads that help with this:
+Fortunately (on purpose), `useAtomContext()` has two overloads that help with this:
 
 #### Case #1: I want a default atom instance to be created, if none was provided.
 
-You can provide an array of params to `useAtomConsumer()`. These params must match the params of the atom. If no atom instance was provided, Zedux will use the passed default params to locate an existing atom instance or create a new instance if it doesn't exist yet.
+You can provide an array of params to `useAtomContext()`. These params must match the params of the atom. If no atom instance was provided, Zedux will use the passed default params to locate an existing atom instance or create a new instance if it doesn't exist yet.
 
 ```ts
-const instance = useAtomConsumer(myAtom, ['default instance params'])
+const instance = useAtomContext(myAtom, ['default instance params'])
 instance.invalidate() // all good! Even TS is happy
 ```
 
 If the atom doesn't take params, you must still pass an empty array for Zedux to find/create a default instance.
 
 ```ts
-const paramlessInstance = useAtomConsumer(myAtom, [])
+const paramlessInstance = useAtomContext(myAtom, [])
 instance.invalidate() // 😊
 ```
 
 #### Case #2: I don't ever want an instance to not be provided. Throw an error if I forget!
 
-Instead of an array of default parameters, you can pass `true` as the second param to `useAtomConsumer()`. This tells Zedux to throw an error if no atom instance was provided.
+Instead of an array of default parameters, you can pass `true` as the second param to `useAtomContext()`. This tells Zedux to throw an error if no atom instance was provided.
 
 ```ts
-const instance = useAtomConsumer(myAtom, true)
+const instance = useAtomContext(myAtom, true)
 instance.invalidate() // all good again! TS smiles upon you
 ```
 
@@ -118,7 +118,7 @@ function Parent() {
 }
 
 function Child() {
-  const instance = useAtomConsumer(myAtom, true) // doesn't subscribe
+  const instance = useAtomContext(myAtom, true) // doesn't subscribe
   const value = useAtomValue(instance) // subscribes
   ...
 }
@@ -130,7 +130,7 @@ Full live example:
 const providedAtom = atom('provided', 'the state!')
 
 function Child() {
-  const instance = useAtomConsumer(providedAtom)
+  const instance = useAtomContext(providedAtom)
   const [state, setState] = useAtomState(instance) // subscribe to changes
 
   return (
@@ -163,7 +163,7 @@ A common pattern is to pass the provided atom instance to an Atom Getter inside 
 
 ```tsx
 function Child() {
-  const instance = useAtomConsumer(myAtom, true) // doesn't subscribe
+  const instance = useAtomContext(myAtom, true) // doesn't subscribe
 
   // subscribe, but only cause a rerender when `someField` changes:
   // highlight-next-line
@@ -181,14 +181,14 @@ The primary purpose of providing atom instances over React context is to give a 
 
 ```ts
 function Child() {
-  // without useAtomConsumer, you need to pass the right params every time you use the atom:
+  // without useAtomContext, you need to pass the right params every time you use the atom:
   const instance = useAtomInstance(myAtom, [
     'my',
     { specific: { params: 'here' } },
   ])
 
   // compare:
-  const instance = useAtomConsumer(myAtom, true)
+  const instance = useAtomContext(myAtom, true)
 }
 ```
 
@@ -237,7 +237,7 @@ function UserThumbnail({ id }) {
 
 function OnlineStatus() {
   // no need to pass `id` prop!
-  const userData = useAtomConsumer(userData, true)
+  const userData = useAtomContext(userData, true)
 
   return <div>{userData.isOnline ? <GreenDot /> : <RedDot />}</div>
 }
@@ -274,7 +274,7 @@ const todoAtom = ion('todo', ({ get, getInstance }, id: number) => {
 })
 
 function Todo() {
-  const todoInstance = useAtomConsumer(todoAtom, true)
+  const todoInstance = useAtomContext(todoAtom, true)
   const [text, setText] = useAtomState(todoInstance)
   const isEditing = useAtomValue(isEditingTodosAtom)
 
@@ -322,9 +322,9 @@ function TodoList() {
 ## Recap
 
 - Atom instances can be provided over React context via [`<AtomProvider>`](../api/components/AtomProvider).
-- Atom instances can be consumed from React context via [`useAtomConsumer()`](../api/hooks/useAtomConsumer).
-  - `useAtomConsumer(myAtom, [...defaultParams])` creates an atom instance with `defaultParams` if no instance was provided.
-  - `useAtomConsumer(myAtom, true)` throws an error if no atom instance was provided.
+- Atom instances can be consumed from React context via [`useAtomContext()`](../api/hooks/useAtomContext).
+  - `useAtomContext(myAtom, [...defaultParams])` creates an atom instance with `defaultParams` if no instance was provided.
+  - `useAtomContext(myAtom, true)` throws an error if no atom instance was provided.
 - You can subscribe any component to a consumed atom instance by using [`useAtomValue()`](../api/hooks/useAtomValue) or any other hook that creates a [dynamic graph dependency](../api/glossary#dynamic-graph-dependency).
 - Use `useAtomSelector()` with a provided instance to selectively subscribe to updates.
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -82,7 +82,7 @@ module.exports = {
         type: 'category',
         label: 'Hooks',
         items: [
-          'api/hooks/useAtomConsumer',
+          'api/hooks/useAtomContext',
           'api/hooks/useAtomInstance',
           'api/hooks/useAtomSelector',
           'api/hooks/useAtomState',

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -58,7 +58,7 @@ On top of these, `@zedux/react` exports the following APIs:
 
 ### Hooks
 
-- [`useAtomConsumer()`](https://omnistac.github.io/zedux/docs/api/hooks/useAtomConsumer)
+- [`useAtomContext()`](https://omnistac.github.io/zedux/docs/api/hooks/useAtomContext)
 - [`useAtomInstance()`](https://omnistac.github.io/zedux/docs/api/hooks/useAtomInstance)
 - [`useAtomSelector()`](https://omnistac.github.io/zedux/docs/api/hooks/useAtomSelector)
 - [`useAtomState()`](https://omnistac.github.io/zedux/docs/api/hooks/useAtomState)

--- a/packages/react/src/components/AtomProvider.tsx
+++ b/packages/react/src/components/AtomProvider.tsx
@@ -6,7 +6,7 @@ import { useEcosystem } from '../hooks'
  * Provides an atom instance over React context.
  *
  * Provided atom instances can be consumed in child components via
- * `useAtomConsumer()`. The atom instance can then be passed to other hooks like
+ * `useAtomContext()`. The atom instance can then be passed to other hooks like
  * `useAtomValue()` or `useAtomState()` to create a dynamic dependency on the
  * consumed instance.
  *

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,4 +1,4 @@
-export * from './useAtomConsumer'
+export * from './useAtomContext'
 export * from './useAtomInstance'
 export * from './useAtomSelector'
 export * from './useAtomState'

--- a/packages/react/src/hooks/useAtomContext.ts
+++ b/packages/react/src/hooks/useAtomContext.ts
@@ -4,7 +4,7 @@ import { AtomInstanceBase } from '../classes'
 import { AnyAtomTemplate, AtomInstanceType, AtomParamsType } from '../types'
 import { useEcosystem } from './useEcosystem'
 
-export const useAtomConsumer: {
+export const useAtomContext: {
   <A extends AnyAtomTemplate>(template: A): AtomInstanceType<A> | undefined
 
   <A extends AnyAtomTemplate>(
@@ -28,7 +28,7 @@ export const useAtomConsumer: {
   if (!defaultParams || is(instance, AtomInstanceBase)) {
     if (DEV && instance?.status === 'Destroyed') {
       console.error(
-        `Zedux: useAtomConsumer - A destroyed atom instance was provided with key "${instance.id}". This is not supported. Provide an active atom instance instead.`
+        `Zedux: useAtomContext - A destroyed atom instance was provided with key "${instance.id}". This is not recommended. Provide an active atom instance instead e.g. by calling \`useAtomInstance()\` in the providing component.`
       )
     }
 
@@ -38,7 +38,7 @@ export const useAtomConsumer: {
   if (typeof defaultParams === 'boolean') {
     if (DEV) {
       throw new ReferenceError(
-        `Zedux: useAtomConsumer - No atom instance was provided for atom "${template.key}".`
+        `Zedux: useAtomContext - No atom instance was provided for atom "${template.key}".`
       )
     }
 

--- a/packages/react/test/integrations/react-context.test.tsx
+++ b/packages/react/test/integrations/react-context.test.tsx
@@ -1,7 +1,7 @@
 import {
   atom,
   AtomProvider,
-  useAtomConsumer,
+  useAtomContext,
   useAtomInstance,
   useAtomValue,
 } from '@zedux/react'
@@ -17,7 +17,7 @@ describe('React context', () => {
     let counter = 0
 
     function Grandchild() {
-      const val = useAtomValue(useAtomConsumer(atom1, true))
+      const val = useAtomValue(useAtomContext(atom1, true))
 
       return <div data-testid={counter++}>{val}</div>
     }
@@ -57,8 +57,8 @@ describe('React context', () => {
     let counter = 0
 
     function Child() {
-      const val1 = useAtomValue(useAtomConsumer(atom1, true))
-      const val2 = useAtomValue(useAtomConsumer(atom2, ['c']))
+      const val1 = useAtomValue(useAtomContext(atom1, true))
+      const val2 = useAtomValue(useAtomContext(atom2, ['c']))
 
       return (
         <div data-testid={counter++}>
@@ -93,7 +93,7 @@ describe('React context', () => {
     const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
     function Child() {
-      const val = useAtomValue(useAtomConsumer(atom1, true))
+      const val = useAtomValue(useAtomContext(atom1, true))
 
       return <div data-testid="0">{val}</div>
     }
@@ -143,12 +143,12 @@ describe('React context', () => {
     spy.mockReset()
   })
 
-  test('useAtomConsumer() can be given default params that are used if no instance was provided', async () => {
+  test('useAtomContext() can be given default params that are used if no instance was provided', async () => {
     jest.useFakeTimers()
     const atom1 = atom('1', (id: string) => id)
 
     function Test() {
-      const instance = useAtomConsumer(atom1, ['a'])
+      const instance = useAtomContext(atom1, ['a'])
       const val = useAtomValue(instance)
 
       return <div data-testid="text">{val}</div>
@@ -168,13 +168,13 @@ describe('React context', () => {
     expect(div.innerHTML).toBe('aa')
   })
 
-  test('useAtomConsumer() logs an error if a Destroyed instance was provided', async () => {
+  test('useAtomContext() logs an error if a Destroyed instance was provided', async () => {
     jest.useFakeTimers()
     const mock = mockConsole('error')
     const atom1 = atom('1', (id: string) => id)
 
     function Child() {
-      const instance = useAtomConsumer(atom1, true)
+      const instance = useAtomContext(atom1, true)
       const val = useAtomValue(instance)
 
       return <div data-testid="text">{val}</div>
@@ -209,13 +209,13 @@ describe('React context', () => {
     )
   })
 
-  test('useAtomConsumer() throws an error if 2nd param is true and no instance was provided', async () => {
+  test('useAtomContext() throws an error if 2nd param is true and no instance was provided', async () => {
     jest.useFakeTimers()
     const mock = mockConsole('error')
     const atom1 = atom('1', (id: string) => id)
 
     function Test() {
-      const instance = useAtomConsumer(atom1, true)
+      const instance = useAtomContext(atom1, true)
       const val = useAtomValue(instance)
 
       return <div data-testid="text">{val}</div>

--- a/packages/react/test/snippets/context.tsx
+++ b/packages/react/test/snippets/context.tsx
@@ -6,7 +6,7 @@ import {
   injectAtomValue,
   injectEffect,
   injectStore,
-  useAtomConsumer,
+  useAtomContext,
   useAtomInstance,
   useAtomValue,
 } from '@zedux/react'
@@ -67,9 +67,9 @@ const atom4 = atom(
 )
 
 function One() {
-  const atom3val = useAtomValue(useAtomConsumer(atom3, ['1']))
+  const atom3val = useAtomValue(useAtomContext(atom3, ['1']))
   const atom2val = useAtomValue(atom2)
-  const atom1val = useAtomValue(useAtomConsumer(atom1, []))
+  const atom1val = useAtomValue(useAtomContext(atom1, []))
 
   return (
     <>
@@ -82,7 +82,7 @@ function One() {
 
 function Two() {
   const atom4val = useAtomValue(atom4)
-  const atom3val = useAtomValue(useAtomConsumer(atom3, ['1']))
+  const atom3val = useAtomValue(useAtomContext(atom3, ['1']))
 
   return (
     <>

--- a/packages/react/test/snippets/ions.tsx
+++ b/packages/react/test/snippets/ions.tsx
@@ -3,7 +3,7 @@ import {
   atom,
   AtomProvider,
   AtomInstanceType,
-  useAtomConsumer,
+  useAtomContext,
   useAtomInstance,
   useAtomValue,
 } from '@zedux/react'
@@ -32,7 +32,7 @@ const upperCaseAtom = ion(
 )
 
 function Child() {
-  const testInstance = useAtomConsumer(testAtom, [])
+  const testInstance = useAtomContext(testAtom, [])
   const { update } = testInstance.exports
   const upperCase = useAtomValue(upperCaseAtom, [testInstance])
 

--- a/packages/react/test/snippets/selectors.tsx
+++ b/packages/react/test/snippets/selectors.tsx
@@ -6,7 +6,7 @@ import {
   injectAtomSelector,
   injectEffect,
   injectStore,
-  useAtomConsumer,
+  useAtomContext,
   useAtomInstance,
   useAtomSelector,
   useAtomValue,
@@ -62,7 +62,7 @@ function UnstableChild() {
 }
 
 function Child() {
-  const testInstance = useAtomConsumer(testAtom, [])
+  const testInstance = useAtomContext(testAtom, [])
   const { update } = testInstance.exports
   const upperCase = useAtomValue(upperCaseAtom, [testInstance])
 


### PR DESCRIPTION
## Description

Zedux using the word `Consumer` instead of `Context` is an unnecessary discrepancy between Zedux's API and React's. Rename `useAtomConsumer` to `useAtomContext`.

Also update all docs and tests.

## Breaking Change

This is a breaking change. Import and use `useAtomContext` instead of `useAtomConsumer` now:

```ts
- import { useAtomConsumer } from '@zedux/react' // before
+ import { useAtomContext } from '@zedux/react' // after

- const instance = useAtomConsumer(myAtom) // before
+ const instance = useAtomContext(myAtom) // after
```