### PR TITLE
feat(atoms)!: `defaultTtl` -> `atomDefaults.ttl`

### DIFF
--- a/docs/docs/api/classes/AtomTemplate.mdx
+++ b/docs/docs/api/classes/AtomTemplate.mdx
@@ -128,8 +128,8 @@ When creating your own, custom atom types, you'll usually want to extend this cl
     </p>
     <p>
       If not set, the{' '}
-      <Link to="Ecosystem#defaultttl">
-        ecosystem's <code>defaultTtl</code>
+      <Link to="Ecosystem#atomdefaults">
+        ecosystem's <code>atomDefaults.ttl</code>
       </Link>{' '}
       will be used. If the ecosystem doesn't set a default, instances of this
       atom will live forever by default. Setting this value will override any

--- a/docs/docs/api/classes/Ecosystem.mdx
+++ b/docs/docs/api/classes/Ecosystem.mdx
@@ -85,6 +85,24 @@ function Swapper() {
 All properties are readonly!
 
 <Legend>
+  <Item name="atomDefaults">
+    <p>
+      An object. This is set to the <code>atomDefaults</code> value you passed
+      via{' '}
+      <Link to="../types/EcosystemConfig#atomdefaults">EcosystemConfig</Link>{' '}
+      when creating this ecosystem.
+    </p>
+    <p>
+      This object currently has a single optional property - <code>ttl</code>.
+      This will be used as the ttl for all atom instances in the ecosystem that
+      don't specify their own.
+    </p>
+    <p>
+      If not set, <code>atomDefaults.ttl</code> defaults to <code>-1</code>,
+      which means all atom instances in the ecosystem will live forever by
+      default.
+    </p>
+  </Item>
   <Item name="complexParams">
     <p>
       A boolean. May be undefined. This is set to the <code>complexParams</code>{' '}
@@ -114,18 +132,6 @@ All properties are readonly!
         the <code>onReady</code> function
       </Link>{' '}
       as part of the reset.
-    </p>
-  </Item>
-  <Item name="defaultTtl">
-    <p>
-      A number. This is set to the <code>defaultTtl</code> value you passed via{' '}
-      <Link to="../types/EcosystemConfig#defaultttl">EcosystemConfig</Link> when
-      creating this ecosystem.
-    </p>
-    <p>The default ttl to use for all atom instances in the ecosystem.</p>
-    <p>
-      If not set, defaults to <code>-1</code>, which means all atom instances
-      will live forever by default.
     </p>
   </Item>
   <Item name="destroyOnUnmount">

--- a/docs/docs/api/types/AtomInstanceTtl.mdx
+++ b/docs/docs/api/types/AtomInstanceTtl.mdx
@@ -3,9 +3,9 @@ id: AtomInstanceTtl
 title: AtomInstanceTtl
 ---
 
-TTL (Time To Live) can be set at the [ecosystem](../classes/Ecosystem#defaultttl), [atom template](../classes/AtomTemplate#ttl), or [atom instance](../classes/AtomApi#setttl) levels. Setting a ttl at the atom instance level is the most specific and the most flexible. You can do so using an [AtomApi](../classes/AtomApi#setttl).
+TTL (Time To Live) can be set at the [ecosystem](../classes/Ecosystem#atomdefaults), [atom template](../classes/AtomTemplate#ttl), or [atom instance](../classes/AtomApi#setttl) levels. Setting a ttl at the atom instance level is the most specific and the most flexible. You can do so using an [AtomApi](../classes/AtomApi#setttl).
 
-A ttl set on an atom instance overrides any ttl on its atom template or ecosystem. A ttl set on an atom template overrides any `defaultTtl` on the ecosystem.
+A ttl set on an atom instance overrides any ttl on its atom template or ecosystem. A ttl set on an atom template overrides any `atomDefaults.ttl` on the ecosystem.
 
 ## Definition
 

--- a/docs/docs/api/types/EcosystemConfig.mdx
+++ b/docs/docs/api/types/EcosystemConfig.mdx
@@ -13,9 +13,11 @@ The config object passed to [the `createEcosystem()` factory](../factories/creat
 interface EcosystemConfig<
   Context extends Record<string, any> | undefined = any
 > {
+  atomDefaults?: {
+    ttl?: number
+  }
   complexParams?: boolean
   context?: Context
-  defaultTtl?: number
   destroyOnUnmount?: boolean
   flags?: string[]
   id?: string
@@ -46,13 +48,14 @@ All fields are optional. It is recommended to at least pass an id.
       <Link to="../classes/Ecosystem#context">context</Link> for the ecosystem.
     </p>
   </Item>
-  <Item name="defaultTtl">
+  <Item name="atomDefaults">
     <p>
-      A number. Default <code>-1</code> (meaning infinite). Will be set as the{' '}
+      An object. This object currently accepts a single optional property -{' '}
+      <code>ttl</code>. If specified, this <code>ttl</code> will be used as the{' '}
       <Link to="../classes/AtomTemplate#ttl">
         <code>ttl</code>
       </Link>{' '}
-      for all atoms that don't specify one.
+      for all atoms in the ecosystem that don't specify one.
     </p>
   </Item>
   <Item name="destroyOnUnmount">

--- a/docs/docs/walkthrough/configuring-atoms.mdx
+++ b/docs/docs/walkthrough/configuring-atoms.mdx
@@ -179,10 +179,10 @@ As you can imagine, this is extremely powerful. Some ideas for how to use this:
 
 ## Default TTL
 
-By default, all atom instances live forever. This default is fine for most apps. But in some cases, a default ttl of `0` or a short timeout might make more sense. Ecosystems have a config option for this, `defaultTtl`:
+By default, all atom instances live forever. This default is fine for most apps. But in some cases, a default ttl of `0` or a short timeout might make more sense. Ecosystems have a config option for this, `atomDefaults`. This is an object that can be given a `ttl` property to set a default TTL for all atoms in the ecosystem:
 
-```tsx live ecosystemId=defaultTtl-example noProvide=true resultVar=Parent
-const ttlTestAtom = atom('ttlTest', () => {
+```tsx live ecosystemId=atomDefaults-ttl-example noProvide=true resultVar=Parent
+const ttlExampleAtom = atom('ttlExample', () => {
   injectEffect(() => {
     // use the effect cleanup function to detect when this atom instance dies
     return () => {
@@ -194,7 +194,7 @@ const ttlTestAtom = atom('ttlTest', () => {
 }) // no ttl = use the ecosystem default
 
 function Child() {
-  useAtomInstance(ttlTestAtom)
+  useAtomInstance(ttlExampleAtom)
 
   return null
 }
@@ -203,7 +203,7 @@ function Parent() {
   const [isShowing, setIsShowing] = useState(false)
 
   return (
-    <EcosystemProvider defaultTtl={0} id="defaultTtl-example">
+    <EcosystemProvider atomDefaults={{ ttl: 0 }} id="atomDefaults-ttl-example">
       <button onClick={() => setIsShowing(state => !state)}>
         {isShowing ? 'destroy' : 'create'}
       </button>
@@ -213,23 +213,23 @@ function Parent() {
 }
 ```
 
-`defaultTtl` is a number in milliseconds.
+`atomDefaults.ttl` is a number in milliseconds.
 
 ## Config Priority
 
-Ecosystems have a `defaultTtl`, atoms have a `ttl` config option, and Atom APIs have a `setTtl` function. If you set ttl in multiple places, the "most specific" will take priority. Here's a little visual:
+Ecosystems have `atomDefaults.ttl`, atoms have a `ttl` config option, and Atom APIs have a `setTtl` function. If you set ttl in multiple places, the "most specific" will take priority. Here's a little visual:
 
 ![ecosystems -> atoms -> atom instances](/img/diagrams/config-specificity.png)
 
 Ecosystem config is the most general, atom template config is more specific, and atom instance config is the most specific. Thus for TTL, the "specificity order" is (from most to least specific):
 
 ```
-api().setTtl() -> ttl -> defaultTtl
+api().setTtl() -> ttl -> atomDefaults.ttl
 ```
 
 ## Recap
 
-- Set TTL using `.setTtl()` on an Atom API returned from a state factory, `ttl` on an atom config object, or `defaultTtl` in an ecosystem's config.
+- Set TTL using `.setTtl()` on an Atom API returned from a state factory, `ttl` on an atom config object, or `atomDefaults: { ttl }` in an ecosystem's config.
 - Set an atom's flags using the `flags` property on an atom config object.
 - Configure the currently-allowed flags with the `flags` property of an ecosystem's config.
 

--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -43,9 +43,9 @@ const mapOverrides = (overrides: AnyAtomTemplate[]) =>
 export class Ecosystem<Context extends Record<string, any> | undefined = any>
   implements AtomGettersBase
 {
+  public atomDefaults?: EcosystemConfig['atomDefaults']
   public complexParams?: boolean
   public context: Context
-  public defaultTtl = -1
   public destroyOnUnmount?: boolean
   public flags?: string[]
   public hydration?: Record<string, any>

--- a/packages/atoms/src/classes/instances/AtomInstance.ts
+++ b/packages/atoms/src/classes/instances/AtomInstance.ts
@@ -462,7 +462,7 @@ export class AtomInstance<G extends AtomGenerics> extends AtomInstanceBase<
 
   private _getTtl() {
     if (this.api?.ttl == null) {
-      return this.template.ttl ?? this.ecosystem.defaultTtl
+      return this.template.ttl ?? this.ecosystem.atomDefaults?.ttl
     }
 
     // this atom instance set its own ttl

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -178,9 +178,11 @@ export interface DependentEdge {
 export interface EcosystemConfig<
   Context extends Record<string, any> | undefined = any
 > {
+  atomDefaults?: {
+    ttl?: number
+  }
   complexParams?: boolean
   context?: Context
-  defaultTtl?: number
   destroyOnUnmount?: boolean
   flags?: string[]
   id?: string

--- a/packages/react/test/integrations/lifecycle.test.tsx
+++ b/packages/react/test/integrations/lifecycle.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent } from '@testing-library/react'
 import {
   api,
   atom,
+  createEcosystem,
   injectAtomValue,
   injectEffect,
   injectStore,
@@ -264,5 +265,19 @@ describe('ttl', () => {
     jest.runAllTimers()
 
     expect(instance1.status).toBe('Destroyed')
+  })
+
+  test('ecosystem `atomDefaults.ttl` is used as a default', () => {
+    const testEcosystem = createEcosystem({ atomDefaults: { ttl: 0 } })
+    const atom1 = atom('1', () => 'a')
+
+    const instance1 = testEcosystem.getInstance(atom1)
+    const cleanup = instance1.addDependent()
+
+    expect(Object.keys(testEcosystem._instances)).toEqual(['1'])
+
+    cleanup()
+
+    expect(Object.keys(testEcosystem._instances)).toEqual([])
   })
 })


### PR DESCRIPTION
## Description

We want to add more atom defaults at the ecosystem level in the future besides `defaultTtl`. Rework this atom config option. Make it an `atomDefaults` object with an optional `ttl` property (that's all for now).

## Breaking Change

This is a breaking change. The `defaultTtl` ecosystem config option doesn't exist anymore. Set `atomDefaults.ttl` instead:

```ts
- createEcosystem({ defaultTtl: 0 })
+ createEcosystem({ atomDefaults: { ttl: 0 } })

- <EcosystemProvider defaultTtl={0}><Child /></EcosystemProvider>
+ <EcosystemProvider atomDefaults={{ ttl: 0 }}><Child /></EcosystemProvider>
```