### PR TITLE
refactor(core): improve store update perf in non-composed stores by ~28%

### DIFF
--- a/packages/core/test/integrations/store-composition.test.ts
+++ b/packages/core/test/integrations/store-composition.test.ts
@@ -330,4 +330,46 @@ describe('store composition', () => {
       'parent',
     ])
   })
+
+  test('composed stores wait when using setStateDeep too', () => {
+    const greatGrandchild111 = createStore(null, 'a')
+    const grandchild11 = createStore({ greatGrandchild111 })
+    const grandchild12 = createStore(null, 'b')
+    const grandchild21 = createStore(null, 'c')
+    const child1 = createStore({ grandchild11, grandchild12 })
+    const child2 = createStore({ grandchild21 })
+    const parent = createStore({ child1, child2 })
+
+    const stores = {
+      greatGrandchild111,
+      grandchild11,
+      grandchild12,
+      grandchild21,
+      child1,
+      child2,
+      parent,
+    }
+
+    const calls: string[] = []
+
+    Object.entries(stores)
+      // subscription order shouldn't matter:
+      .sort(() => Math.random() - 0.5)
+      .forEach(([name, store]) => {
+        store.subscribe(() => calls.push(name))
+      })
+
+    child1.setStateDeep({
+      grandchild11: {
+        greatGrandchild111: 'aa',
+      },
+    })
+
+    expect(calls).toEqual([
+      'greatGrandchild111',
+      'grandchild11',
+      'child1',
+      'parent',
+    ])
+  })
 })


### PR DESCRIPTION
## Description

All store updates currently go through the scheduler. Most updates don't need to - the scheduler is only used to sort out updates between composed stores. Most stores in a real app don't use store composition, so going through the scheduler is an unnecessary performance loss in most situations.

The scheduler is very fast, but skipping it is even faster, by about ~28% according to the following tests:

```ts
import { createStore } from '@zedux/core'

const store = createStore(null, 0)
const start = performance.now()

for (let i = 1; i < 1000000; i++) {
  store.setState(i)
}

console.log('time:', performance.now() - start)
```

```ts
import { atom, createEcosystem } from '@zedux/atoms'

const ecosystem = createEcosystem()
const atom1 = atom('1', 0)
const instance1 = ecosystem.getInstance(atom1)

const start = performance.now()

for (let i = 1; i < 1000000; i++) {
  instance1.setState(i)
}

console.log('time:', performance.now() - start)
```

The latter taking ~103ms on a typical run before this change and ~74ms after. That's a ~28% perf improvement. It does add 2 extra checks in the case of composed stores, but that perf difference is barely noticeable. Overall, I'd say this change is easily worth it.