### PR TITLE
feat(atoms)!: implement AtomApiGenerics type map and all its helpers

### DIFF
--- a/docs/docs/advanced/more-patterns.mdx
+++ b/docs/docs/advanced/more-patterns.mdx
@@ -78,7 +78,9 @@ A common pattern is creating a helper function to create pre-configured atoms:
 ```ts
 const mapAtom = <State extends Map<any, any>, Params extends any[]>(
   key: string,
-  stateFactory: (...params: Params) => State | Store<State> | AtomApi<State>,
+  stateFactory: (
+    ...params: Params
+  ) => State | Store<State> | AnyAtomApi<{ State: State }>,
   config?: AtomConfig<State>
 ) => {
   return atom(key, stateFactory, {

--- a/docs/docs/api/factories/api.mdx
+++ b/docs/docs/api/factories/api.mdx
@@ -48,42 +48,67 @@ return api(val, false).setExports(myManuallyBatchedExports)
     Exports extends Record<string, any> = Record<string, never>,
     PromiseType extends AtomApiPromise = undefined
   >(
-    value: AtomApi<StoreStateType<StoreType>, Exports, StoreType, PromiseType>,
-    wrap?: boolean
-  ): AtomApi<StoreStateType<StoreType>, Exports, StoreType, PromiseType>\n
+    value: AtomApi<{
+      Exports: Exports
+      Promise: PromiseType
+      State: StoreStateType<StoreType>
+      Store: StoreType
+    }>
+  ): AtomApi<{
+    Exports: Exports
+    Promise: PromiseType
+    State: StoreStateType<StoreType>
+    Store: StoreType
+  }>\n
   // Custom Stores (normal)
-  <StoreType extends Store<any> = Store<any>>(
-    value: StoreType,
-    wrap?: boolean
-  ): AtomApi<
-    StoreStateType<StoreType>,
-    Record<string, never>,
-    StoreType,
-    undefined
-  >\n
+  <StoreType extends Store<any> = Store<any>>(value: StoreType): AtomApi<{
+    Exports: Record<string, never>
+    Promise: undefined
+    State: StoreStateType<StoreType>
+    Store: StoreType
+  }>\n
   // No Value
-  (): AtomApi<undefined, Record<string, never>, undefined, undefined>\n
+  (): AtomApi<{
+    Exports: Record<string, never>
+    Promise: undefined
+    State: undefined
+    Store: undefined
+  }>\n
   <
     State = undefined,
     Exports extends Record<string, any> = Record<string, never>,
     PromiseType extends AtomApiPromise = undefined
-  >(): AtomApi<State, Exports, undefined, PromiseType>\n
+  >(): AtomApi<{
+    Exports: Exports
+    Promise: PromiseType
+    State: State
+    Store: undefined
+  }>\n
   // No Store (AtomApi cloning)
   <
     State = undefined,
     Exports extends Record<string, any> = Record<string, never>,
     PromiseType extends AtomApiPromise = undefined
   >(
-    value: AtomApi<State, Exports, undefined, PromiseType>,
-    wrap?: boolean
-  ): AtomApi<State, Exports, undefined, PromiseType>\n
+    value: AtomApi<{
+      Exports: Exports
+      Promise: PromiseType
+      State: State
+      Store: undefined
+    }>
+  ): AtomApi<{
+    Exports: Exports
+    Promise: PromiseType
+    State: State
+    Store: undefined
+  }>\n
   // No Store (normal)
-  <State = undefined>(value: State, wrap?: boolean): AtomApi<
-    State,
-    Record<string, never>,
-    undefined,
-    undefined
-  >\n
+  <State = undefined>(value: State): AtomApi<{
+    Exports: Record<string, never>
+    Promise: undefined
+    State: State
+    Store: undefined
+  }>\n
   // Catch-all
   <
     State = undefined,
@@ -91,9 +116,21 @@ return api(val, false).setExports(myManuallyBatchedExports)
     StoreType extends Store<State> = Store<State>,
     PromiseType extends AtomApiPromise = undefined
   >(
-    value: State | StoreType | AtomApi<State, Exports, StoreType, PromiseType>,
-    wrap?: boolean
-  ): AtomApi<State, Exports, StoreType, PromiseType>
+    value:
+      | State
+      | StoreType
+      | AtomApi<{
+          Exports: Exports
+          Promise: PromiseType
+          State: State
+          Store: StoreType
+        }>
+  ): AtomApi<{
+    Exports: Exports
+    Promise: PromiseType
+    State: State
+    Store: StoreType
+  }>
 }`)}
 </Tabs>
 

--- a/docs/docs/api/factories/atom.mdx
+++ b/docs/docs/api/factories/atom.mdx
@@ -61,9 +61,12 @@ function App() {
     Exports extends Record<string, any> = Record<string, never>
   >(
     key: string,
-    value: (
-      ...params: Params
-    ) => AtomApi<Promise<State>, Exports, undefined, any>,
+    value: (...params: Params) => AtomApi<{
+      Exports: Exports
+      Promise: any
+      State: Promise<State>
+      Store: undefined
+    }>,
     config?: AtomConfig<State>
   ): AtomTemplate<{
     State: PromiseState<State>
@@ -80,11 +83,14 @@ function App() {
     PromiseType extends AtomApiPromise = undefined
   >(
     key: string,
-    value: (
-      ...params: Params
-    ) =>
+    value: (...params: Params) =>
       | StoreType
-      | AtomApi<StoreStateType<Store>, Exports, StoreType, PromiseType>,
+      | AtomApi<{
+          Exports: Exports
+          Promise: PromiseType
+          State: StoreStateType<Store>
+          Store: StoreType
+        }>,
     config?: AtomConfig<StoreStateType<StoreType>>
   ): AtomTemplate<{
     State: StoreStateType<StoreType>

--- a/docs/docs/api/factories/ion.mdx
+++ b/docs/docs/api/factories/ion.mdx
@@ -70,7 +70,12 @@ Ions used to have 4 parameters. Back then, the 4th param was the optional config
     value: (
       getters: AtomGetters,
       ...params: Params
-    ) => AtomApi<Promise<State>, Exports, undefined, any>,
+    ) => AtomApi<{
+      Exports: Exports
+      Promise: any
+      State: Promise<State>
+      Store: undefined
+    }>,
     config?: AtomConfig<State>
   ): IonTemplate<{
     State: PromiseState<State>
@@ -92,7 +97,12 @@ Ions used to have 4 parameters. Back then, the 4th param was the optional config
       ...params: Params
     ) =>
       | StoreType
-      | AtomApi<StoreStateType<Store>, Exports, StoreType, PromiseType>,
+      | AtomApi<{
+          Exports: Exports
+          Promise: PromiseType
+          State: StoreStateType<Store>
+          Store: StoreType
+        }>,
     config?: AtomConfig<StoreStateType<StoreType>>
   ): IonTemplate<{
     State: StoreStateType<StoreType>
@@ -112,7 +122,14 @@ Ions used to have 4 parameters. Back then, the 4th param was the optional config
     get: (
       getters: AtomGetters,
       ...params: Params
-    ) => AtomApi<State, Exports, undefined, PromiseType> | State,
+    ) =>
+      | AtomApi<{
+          Exports: Exports
+          Promise: PromiseType
+          State: State
+          Store: undefined
+        }>
+      | State,
     config?: AtomConfig<State>
   ): IonTemplate<{
     State: State

--- a/docs/docs/api/injectors/injectPromise.mdx
+++ b/docs/docs/api/injectors/injectPromise.mdx
@@ -73,24 +73,23 @@ It also gives you access to the promise and store so you can compose them with o
   <T>(
     promiseFactory: (controller?: AbortController) => Promise<T>,
     deps: InjectorDeps,
-    config: {
-      initialState?: T
-      dataOnly: true
-    } & InjectStoreConfig
-  ): AtomApi<T, Record<string, any>, Store<T>, Promise<T>>
+    config: { initialState?: T; dataOnly: true } & InjectStoreConfig
+  ): AtomApi<{
+    Exports: Record<string, any>
+    Promise: Promise<T>
+    State: T
+    Store: Store<T>
+  }>\n
   <T>(
     promiseFactory: (controller?: AbortController) => Promise<T>,
     deps?: InjectorDeps,
-    config?: {
-      initialState?: T
-      dataOnly?: boolean
-    } & InjectStoreConfig
-  ): AtomApi<
-    PromiseState<T>,
-    Record<string, any>,
-    Store<PromiseState<T>>,
-    Promise<T>
-  >
+    config?: { initialState?: T; dataOnly?: boolean } & InjectStoreConfig
+  ): AtomApi<{
+    Exports: Record<string, any>
+    Promise: Promise<T>
+    State: PromiseState<T>
+    Store: Store<PromiseState<T>>
+  }>
 }`)}
 </Tabs>
 

--- a/packages/atoms/src/classes/instances/AtomInstance.ts
+++ b/packages/atoms/src/classes/instances/AtomInstance.ts
@@ -12,6 +12,7 @@ import {
 } from '@zedux/core'
 import {
   AtomGenerics,
+  AtomGenericsToAtomApiGenerics,
   Cleanup,
   EvaluationReason,
   EvaluationSourceType,
@@ -72,7 +73,7 @@ export class AtomInstance<G extends AtomGenerics> extends AtomInstanceBase<
   AtomTemplateBase<G, AtomInstance<G>>
 > {
   public status: LifecycleStatus = 'Initializing'
-  public api?: AtomApi<G['State'], G['Exports'], G['Store'], G['Promise']>
+  public api?: AtomApi<AtomGenericsToAtomApiGenerics<G>>
   public exports: G['Exports']
   public nextReasons: EvaluationReason[] = []
   public prevReasons?: EvaluationReason[]
@@ -394,20 +395,12 @@ export class AtomInstance<G extends AtomGenerics> extends AtomInstanceBase<
       const val = (
         _value as (
           ...params: G['Params']
-        ) =>
-          | G['Store']
-          | G['State']
-          | AtomApi<G['State'], G['Exports'], G['Store'], G['Promise']>
+        ) => G['Store'] | G['State'] | AtomApi<AtomGenericsToAtomApiGenerics<G>>
       )(...this.params)
 
       if (!is(val, AtomApi)) return val as G['Store'] | G['State']
 
-      const api = (this.api = val as AtomApi<
-        G['State'],
-        G['Exports'],
-        G['Store'],
-        G['Promise']
-      >)
+      const api = (this.api = val as AtomApi<AtomGenericsToAtomApiGenerics<G>>)
 
       // Exports can only be set on initial evaluation
       if (this.status === 'Initializing' && api.exports) {

--- a/packages/atoms/src/factories/api.ts
+++ b/packages/atoms/src/factories/api.ts
@@ -23,25 +23,45 @@ export const api: {
     Exports extends Record<string, any> = Record<string, never>,
     PromiseType extends AtomApiPromise = undefined
   >(
-    value: AtomApi<StoreStateType<StoreType>, Exports, StoreType, PromiseType>
-  ): AtomApi<StoreStateType<StoreType>, Exports, StoreType, PromiseType>
+    value: AtomApi<{
+      Exports: Exports
+      Promise: PromiseType
+      State: StoreStateType<StoreType>
+      Store: StoreType
+    }>
+  ): AtomApi<{
+    Exports: Exports
+    Promise: PromiseType
+    State: StoreStateType<StoreType>
+    Store: StoreType
+  }>
 
   // Custom Stores (normal)
-  <StoreType extends Store<any> = Store<any>>(value: StoreType): AtomApi<
-    StoreStateType<StoreType>,
-    Record<string, never>,
-    StoreType,
-    undefined
-  >
+  <StoreType extends Store<any> = Store<any>>(value: StoreType): AtomApi<{
+    Exports: Record<string, never>
+    Promise: undefined
+    State: StoreStateType<StoreType>
+    Store: StoreType
+  }>
 
   // No Value
-  (): AtomApi<undefined, Record<string, never>, undefined, undefined>
+  (): AtomApi<{
+    Exports: Record<string, never>
+    Promise: undefined
+    State: undefined
+    Store: undefined
+  }>
 
   <
     State = undefined,
     Exports extends Record<string, any> = Record<string, never>,
     PromiseType extends AtomApiPromise = undefined
-  >(): AtomApi<State, Exports, undefined, PromiseType>
+  >(): AtomApi<{
+    Exports: Exports
+    Promise: PromiseType
+    State: State
+    Store: undefined
+  }>
 
   // No Store (AtomApi cloning)
   <
@@ -49,16 +69,26 @@ export const api: {
     Exports extends Record<string, any> = Record<string, never>,
     PromiseType extends AtomApiPromise = undefined
   >(
-    value: AtomApi<State, Exports, undefined, PromiseType>
-  ): AtomApi<State, Exports, undefined, PromiseType>
+    value: AtomApi<{
+      Exports: Exports
+      Promise: PromiseType
+      State: State
+      Store: undefined
+    }>
+  ): AtomApi<{
+    Exports: Exports
+    Promise: PromiseType
+    State: State
+    Store: undefined
+  }>
 
   // No Store (normal)
-  <State = undefined>(value: State): AtomApi<
-    State,
-    Record<string, never>,
-    undefined,
-    undefined
-  >
+  <State = undefined>(value: State): AtomApi<{
+    Exports: Record<string, never>
+    Promise: undefined
+    State: State
+    Store: undefined
+  }>
 
   // Catch-all
   <
@@ -67,16 +97,45 @@ export const api: {
     StoreType extends Store<State> = Store<State>,
     PromiseType extends AtomApiPromise = undefined
   >(
-    value: State | StoreType | AtomApi<State, Exports, StoreType, PromiseType>
-  ): AtomApi<State, Exports, StoreType, PromiseType>
+    value:
+      | State
+      | StoreType
+      | AtomApi<{
+          Exports: Exports
+          Promise: PromiseType
+          State: State
+          Store: StoreType
+        }>
+  ): AtomApi<{
+    Exports: Exports
+    Promise: PromiseType
+    State: State
+    Store: StoreType
+  }>
 } = <
   State = undefined,
   Exports extends Record<string, any> = Record<string, never>,
   StoreType extends Store<State> | undefined = undefined,
   PromiseType extends AtomApiPromise = undefined
 >(
-  value?: AtomApi<State, Exports, StoreType, PromiseType> | StoreType | State
+  value?:
+    | AtomApi<{
+        Exports: Exports
+        Promise: PromiseType
+        State: State
+        Store: StoreType
+      }>
+    | StoreType
+    | State
 ) =>
   new AtomApi(
-    value as AtomApi<State, Exports, StoreType, PromiseType> | StoreType | State
+    value as
+      | AtomApi<{
+          Exports: Exports
+          Promise: PromiseType
+          State: State
+          Store: StoreType
+        }>
+      | StoreType
+      | State
   )

--- a/packages/atoms/src/factories/atom.ts
+++ b/packages/atoms/src/factories/atom.ts
@@ -16,9 +16,12 @@ export const atom: {
     Exports extends Record<string, any> = Record<string, never>
   >(
     key: string,
-    value: (
-      ...params: Params
-    ) => AtomApi<Promise<State>, Exports, undefined, any>,
+    value: (...params: Params) => AtomApi<{
+      Exports: Exports
+      Promise: any
+      State: Promise<State>
+      Store: undefined
+    }>,
     config?: AtomConfig<State>
   ): AtomTemplate<{
     State: PromiseState<State>
@@ -36,11 +39,14 @@ export const atom: {
     PromiseType extends AtomApiPromise = undefined
   >(
     key: string,
-    value: (
-      ...params: Params
-    ) =>
+    value: (...params: Params) =>
       | StoreType
-      | AtomApi<StoreStateType<Store>, Exports, StoreType, PromiseType>,
+      | AtomApi<{
+          Exports: Exports
+          Promise: PromiseType
+          State: StoreStateType<Store>
+          Store: StoreType
+        }>,
     config?: AtomConfig<StoreStateType<StoreType>>
   ): AtomTemplate<{
     State: StoreStateType<StoreType>

--- a/packages/atoms/src/factories/ion.ts
+++ b/packages/atoms/src/factories/ion.ts
@@ -20,7 +20,12 @@ export const ion: {
     value: (
       getters: AtomGetters,
       ...params: Params
-    ) => AtomApi<Promise<State>, Exports, undefined, any>,
+    ) => AtomApi<{
+      Exports: Exports
+      Promise: any
+      State: Promise<State>
+      Store: undefined
+    }>,
     config?: AtomConfig<State>
   ): IonTemplate<{
     State: PromiseState<State>
@@ -43,7 +48,12 @@ export const ion: {
       ...params: Params
     ) =>
       | StoreType
-      | AtomApi<StoreStateType<Store>, Exports, StoreType, PromiseType>,
+      | AtomApi<{
+          Exports: Exports
+          Promise: PromiseType
+          State: StoreStateType<Store>
+          Store: StoreType
+        }>,
     config?: AtomConfig<StoreStateType<StoreType>>
   ): IonTemplate<{
     State: StoreStateType<StoreType>
@@ -64,7 +74,14 @@ export const ion: {
     get: (
       getters: AtomGetters,
       ...params: Params
-    ) => AtomApi<State, Exports, undefined, PromiseType> | State,
+    ) =>
+      | AtomApi<{
+          Exports: Exports
+          Promise: PromiseType
+          State: State
+          Store: undefined
+        }>
+      | State,
     config?: AtomConfig<State>
   ): IonTemplate<{
     State: State

--- a/packages/atoms/src/injectors/injectPromise.ts
+++ b/packages/atoms/src/injectors/injectPromise.ts
@@ -61,18 +61,23 @@ export const injectPromise: {
     promiseFactory: (controller?: AbortController) => Promise<T>,
     deps: InjectorDeps,
     config: { initialState?: T; dataOnly: true } & InjectStoreConfig
-  ): AtomApi<T, Record<string, any>, Store<T>, Promise<T>>
+  ): AtomApi<{
+    Exports: Record<string, any>
+    Promise: Promise<T>
+    State: T
+    Store: Store<T>
+  }>
 
   <T>(
     promiseFactory: (controller?: AbortController) => Promise<T>,
     deps?: InjectorDeps,
     config?: { initialState?: T; dataOnly?: boolean } & InjectStoreConfig
-  ): AtomApi<
-    PromiseState<T>,
-    Record<string, any>,
-    Store<PromiseState<T>>,
-    Promise<T>
-  >
+  ): AtomApi<{
+    Exports: Record<string, any>
+    Promise: Promise<T>
+    State: PromiseState<T>
+    Store: Store<PromiseState<T>>
+  }>
 } = <T>(
   promiseFactory: (controller?: AbortController) => Promise<T>,
   deps?: InjectorDeps,

--- a/packages/atoms/src/types/atoms.ts
+++ b/packages/atoms/src/types/atoms.ts
@@ -1,9 +1,21 @@
 import { Store } from '@zedux/core'
-import { AtomTemplateBase } from '../classes/templates/AtomTemplateBase'
 import { AtomInstance } from '../classes/instances/AtomInstance'
 import { AtomInstanceBase } from '../classes/instances/AtomInstanceBase'
+import { AtomTemplateBase } from '../classes/templates/AtomTemplateBase'
+import { AtomApi } from '../classes/AtomApi'
 
-type AnyAtomGenerics = { [K in keyof AtomGenerics]: any }
+export type AtomApiGenericsPartial<G extends Partial<AtomApiGenerics>> = Omit<
+  AnyAtomApiGenerics,
+  keyof G
+> &
+  G
+
+export type AnyAtomApiGenerics = { [K in keyof AtomGenerics]: any }
+
+export type AnyAtomGenerics = { [K in keyof AtomGenerics]: any }
+
+export type AnyAtomApi<G extends Partial<AtomApiGenerics> | 'any' = 'any'> =
+  AtomApi<G extends Partial<AtomApiGenerics> ? AtomApiGenericsPartial<G> : any>
 
 export type AnyAtomInstance<G extends Partial<AtomGenerics> | 'any' = 'any'> =
   AtomInstance<G extends Partial<AtomGenerics> ? AtomGenericsPartial<G> : any>
@@ -13,6 +25,15 @@ export type AnyAtomTemplate<G extends Partial<AtomGenerics> | 'any' = 'any'> =
     G extends Partial<AtomGenerics> ? AtomGenericsPartial<G> : any,
     AnyAtomInstance<G>
   >
+
+export type AtomApiGenerics = Omit<AtomGenerics, 'Params' | 'Store'> & {
+  Store: Store<any> | undefined
+}
+
+export type AtomGenericsToAtomApiGenerics<G extends AtomGenerics> = Omit<
+  G,
+  'Params' | 'Store'
+> & { Store: G['Store'] | undefined }
 
 export interface AtomGenerics {
   Exports: Record<string, any>
@@ -30,12 +51,15 @@ export type AtomGenericsPartial<G extends Partial<AtomGenerics>> = Omit<
 
 export type AtomApiPromise = Promise<any> | undefined
 
-export type AtomExportsType<A extends AnyAtomTemplate | AnyAtomInstance> =
-  A extends AtomTemplateBase<infer G, any>
-    ? G['Exports']
-    : A extends AtomInstance<infer G>
-    ? G['Exports']
-    : never
+export type AtomExportsType<
+  A extends AnyAtomApi | AnyAtomTemplate | AnyAtomInstance
+> = A extends AtomTemplateBase<infer G, any>
+  ? G['Exports']
+  : A extends AtomInstance<infer G>
+  ? G['Exports']
+  : A extends AtomApi<infer G>
+  ? G['Exports']
+  : never
 
 export type AtomInstanceType<A extends AnyAtomTemplate> =
   A extends AtomTemplateBase<any, infer T> ? T : never
@@ -47,26 +71,35 @@ export type AtomParamsType<A extends AnyAtomTemplate | AnyAtomInstance> =
     ? G['Params']
     : never
 
-export type AtomPromiseType<A extends AnyAtomTemplate | AnyAtomInstance> =
-  A extends AtomTemplateBase<infer G, AtomInstance<infer G>>
-    ? G['Promise']
-    : A extends AtomInstance<infer G>
-    ? G['Promise']
-    : never
+export type AtomPromiseType<
+  A extends AnyAtomApi | AnyAtomTemplate | AnyAtomInstance
+> = A extends AtomTemplateBase<infer G, AtomInstance<infer G>>
+  ? G['Promise']
+  : A extends AtomInstance<infer G>
+  ? G['Promise']
+  : A extends AtomApi<infer G>
+  ? G['Promise']
+  : never
 
-export type AtomStateType<A extends AnyAtomTemplate | AnyAtomInstance> =
-  A extends AtomTemplateBase<infer G, AtomInstance<infer G>>
-    ? G['State']
-    : A extends AtomInstance<infer G>
-    ? G['State']
-    : never
+export type AtomStateType<
+  A extends AnyAtomApi | AnyAtomTemplate | AnyAtomInstance
+> = A extends AtomTemplateBase<infer G, AtomInstance<infer G>>
+  ? G['State']
+  : A extends AtomInstance<infer G>
+  ? G['State']
+  : A extends AtomApi<infer G>
+  ? G['State']
+  : never
 
-export type AtomStoreType<A extends AnyAtomTemplate | AnyAtomInstance> =
-  A extends AtomTemplateBase<infer G, AtomInstance<infer G>>
-    ? G['Store']
-    : A extends AtomInstance<infer G>
-    ? G['Store']
-    : never
+export type AtomStoreType<
+  A extends AnyAtomApi | AnyAtomTemplate | AnyAtomInstance
+> = A extends AtomTemplateBase<infer G, AtomInstance<infer G>>
+  ? G['Store']
+  : A extends AtomInstance<infer G>
+  ? G['Store']
+  : A extends AtomApi<infer G>
+  ? G['Store']
+  : never
 
 export type AtomTemplateType<
   A extends AtomInstanceBase<any, AtomTemplateBase<any, AtomInstance<any>>>

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -6,6 +6,7 @@ import {
   AnyAtomInstance,
   AnyAtomTemplate,
   AtomGenerics,
+  AtomGenericsToAtomApiGenerics,
   AtomInstanceType,
   AtomParamsType,
   AtomStateType,
@@ -147,10 +148,7 @@ export type AtomSelectorOrConfig<T = any, Args extends any[] = []> =
 
 export type AtomStateFactory<G extends AtomGenerics> = (
   ...params: G['Params']
-) =>
-  | AtomApi<G['State'], G['Exports'], G['Store'] | undefined, G['Promise']>
-  | G['Store']
-  | G['State']
+) => AtomApi<AtomGenericsToAtomApiGenerics<G>> | G['Store'] | G['State']
 
 export type AtomTuple<A extends AnyAtomTemplate> = [A, AtomParamsType<A>]
 
@@ -268,10 +266,7 @@ export interface InjectStoreConfig {
 export type IonStateFactory<G extends AtomGenerics> = (
   getters: AtomGetters,
   ...params: G['Params']
-) =>
-  | AtomApi<G['State'], G['Exports'], G['Store'], G['Promise']>
-  | G['Store']
-  | G['State']
+) => AtomApi<AtomGenericsToAtomApiGenerics<G>> | G['Store'] | G['State']
 
 export type LifecycleStatus = 'Active' | 'Destroyed' | 'Initializing' | 'Stale'
 
@@ -299,6 +294,11 @@ export type PartialAtomInstance = Omit<
   AnyAtomInstance,
   'api' | 'exports' | 'promise' | 'store'
 >
+
+// from Matt Pocock https://twitter.com/mattpocockuk/status/1622730173446557697
+export type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & AnyNonNullishValue
 
 export interface PromiseState<T> {
   data?: T

--- a/packages/react/test/types.test.tsx
+++ b/packages/react/test/types.test.tsx
@@ -1,4 +1,4 @@
-import { Store, StoreStateType } from '@zedux/core'
+import { Store, StoreStateType, createStore } from '@zedux/core'
 import {
   AnyAtomInstance,
   AnyAtomTemplate,
@@ -695,12 +695,12 @@ describe('types', () => {
       val4: string
       val5: boolean
       val6: () => boolean
-      val7: AtomApi<
-        PromiseState<number>,
-        Record<string, any>,
-        Store<PromiseState<number>>,
-        Promise<number>
-      >
+      val7: AtomApi<{
+        Exports: Record<string, any>
+        Promise: Promise<number>
+        State: PromiseState<number>
+        Store: Store<PromiseState<number>>
+      }>
     }>()
   })
 
@@ -712,5 +712,23 @@ describe('types', () => {
     const promise = getPromise(exampleAtom, ['a'])
 
     expectTypeOf<typeof promise>().resolves.toBeNumber()
+  })
+
+  test('AtomApi types helpers', () => {
+    const store = createStore(null, 'a')
+    const withEverything = api(store)
+      .addExports({ a: 1 })
+      .setPromise(Promise.resolve(true))
+
+    expectTypeOf<AtomExportsType<typeof withEverything>>().toEqualTypeOf<{
+      a: number
+    }>()
+    expectTypeOf<AtomPromiseType<typeof withEverything>>().toEqualTypeOf<
+      Promise<boolean>
+    >()
+    expectTypeOf<AtomStateType<typeof withEverything>>().toBeString()
+    expectTypeOf<AtomStoreType<typeof withEverything>>().toEqualTypeOf<
+      Store<string>
+    >()
   })
 })


### PR DESCRIPTION
## Description

The AtomApi class has almost all the same generics as Atoms. Update it to use a new `AtomApiGenerics` type map, similar to the `AtomGenerics` type map. Add an `AnyAtomApi` type helper. Update all relevant type helpers to accept `AnyAtomApi` too. Also update docs, improve the `.addExports()` method return type, prettify the return types of the AtomApi methods, and add a new test.

## Breaking Change

This is technically a breaking change, but only for TS users. No code is changing in the builds.

Now when typing AtomApis manually, use the type map instead of ordered generics:

```ts
- type Example = AtomApi<State, Exports, StoreType, PromiseType>
+ type Example = AtomApi<{ Exports: Exports; Promise: PromiseType; State: State; Store: StoreType }>
```