### PR TITLE
release: v1.0.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## v1.0.0-rc.0 (Apr 24, 2023)
+
+### New Features:
+
+- **Breaking Change** `atoms`: `defaultTtl` -> `atomDefaults.ttl` (#38)
+- **Breaking Change** `atoms`: implement AtomApiGenerics type map and all its helpers (#40)
+- **Breaking Change** `react`: AtomInstanceProvider -> AtomProvider (#32)
+- **Breaking Change** `react`: make `instance.invalidate()` a normal method (#29)
+- **Breaking Change** `react`: move auto-batching from `api()` to `injectCallback()` (#31)
+- **Breaking Change** `react`: reuse names that can be shared between instances & selectors (#30)
+- **Breaking Change** `react`: useAtomConsumer -> useAtomContext (#33)
+- **Breaking Change** `atoms`, `immer`: don't export `createInjector` - replace with `injectSelf` (#35)
+- **Breaking Change** `atoms`, `core`, `machines`: break out state machines into their own `@zedux/machines` package (#36)
+- **Breaking Change** `atoms`, `core`, `immer`, `machines`, `react`: internalTypes -> zeduxTypes (#37)
+- `atoms`, `react`: break the atomic model into its own @zedux/atoms package (#34)
+
 ## v0.5.11 (Apr 20, 2023)
 
 ### New Features:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zedux",
-  "version": "0.5.11",
+  "version": "1.0.0-rc.0",
   "description": "A Molecular State Engine for React",
   "type": "module",
   "author": "Joshua Claunch (bowheart <bowheart31@gmail.com>)",

--- a/packages/atoms/package.json
+++ b/packages/atoms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/atoms",
-  "version": "0.5.11",
+  "version": "1.0.0-rc.0",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/core": "^0.5.11"
+    "@zedux/core": "^1.0.0-rc.0"
   },
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/core",
-  "version": "0.5.11",
+  "version": "1.0.0-rc.0",
   "description": "A high-level, declarative, composable form of Redux",
   "main": "./dist/zedux.umd.js",
   "module": "./dist/esm/index.js",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/immer",
-  "version": "0.5.11",
+  "version": "1.0.0-rc.0",
   "description": "Official Immer integration for Zedux's store and atomic APIs",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "devDependencies": {
-    "@zedux/atoms": "^0.5.11",
+    "@zedux/atoms": "^1.0.0-rc.0",
     "immer": "^9.0.21"
   },
   "exports": {
@@ -41,7 +41,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/atoms": "^0.5.11",
+    "@zedux/atoms": "^1.0.0-rc.0",
     "immer": ">=9.0.19"
   },
   "repository": {

--- a/packages/machines/package.json
+++ b/packages/machines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/machines",
-  "version": "0.5.11",
+  "version": "1.0.0-rc.0",
   "description": "Simple native state machine implementation for Zedux atoms",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "devDependencies": {
-    "@zedux/atoms": "^0.5.11"
+    "@zedux/atoms": "^1.0.0-rc.0"
   },
   "exports": {
     ".": {
@@ -41,7 +41,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/atoms": "^0.5.11"
+    "@zedux/atoms": "^1.0.0-rc.0"
   },
   "repository": {
     "directory": "packages/machines",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/react",
-  "version": "0.5.11",
+  "version": "1.0.0-rc.0",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/atoms": "^0.5.11"
+    "@zedux/atoms": "^1.0.0-rc.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",


### PR DESCRIPTION
## Description

Increment monorepo package versions and update the CHANGELOG for version 1.0.0-rc.0.

This PR was generated by the release script at https://github.com/Omnistac/zedux/tree/master/scripts/release.js

The packages will be published to npm and a GitHub release will be created after this PR merges.