### PR TITLE
fix(react): use `useSyncExternalStore` shim for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pnpm add @zedux/react # pnpm
 
 The React package (`@zedux/react`) contains everything you need to use Zedux in a React app - the [core store model](https://www.npmjs.com/package/@zedux/core), the [core atomic model](https://www.npmjs.com/package/@zedux/atoms), and the React-specific APIs.
 
-`@zedux/react` has a peer dependency on React and is compatible with React 18+ only, as it uses the new `useSyncExternalStore` hook.
+`@zedux/react` has a peer dependency on React. It's heavily tested on React 18+ and makes use of the [`useSyncExternalStore()` shim](https://www.npmjs.com/package/use-sync-external-store) to support React versions 16.3.0 and up.
 
 ## Intro
 

--- a/docs/docs/walkthrough/quick-start.mdx
+++ b/docs/docs/walkthrough/quick-start.mdx
@@ -19,7 +19,7 @@ pnpm add @zedux/react # pnpm
 
 The React package (`@zedux/react`) contains everything you need to use Zedux in a React app - the [core store model](https://www.npmjs.com/package/@zedux/core), the [core atomic model](https://www.npmjs.com/package/@zedux/atoms), and the React-specific APIs.
 
-`@zedux/react` has a peer dependency on React and is compatible with React 18+ only, as it uses the new `useSyncExternalStore` hook.
+`@zedux/react` has a peer dependency on React. It's heavily tested on React 18+ and makes use of the [`useSyncExternalStore()` shim](https://www.npmjs.com/package/use-sync-external-store) to support React versions 16.3.0 and up.
 
 ## Meet the Atoms
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,12 +10,14 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/atoms": "^1.0.0"
+    "@zedux/atoms": "^1.0.0",
+    "use-sync-external-store": "^1.2.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@types/react-dom": "^18.0.11",
+    "@types/use-sync-external-store": "^0.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/react/src/components/EcosystemProvider.tsx
+++ b/packages/react/src/components/EcosystemProvider.tsx
@@ -1,5 +1,6 @@
 import { createEcosystem, Ecosystem, EcosystemConfig } from '@zedux/atoms'
-import React, { ReactNode, useMemo, useSyncExternalStore } from 'react'
+import React, { ReactNode, useMemo } from 'react'
+import { useSyncExternalStore } from 'use-sync-external-store/shim'
 import { ecosystemContext } from '../utils'
 
 /**

--- a/packages/react/src/hooks/useAtomInstance.ts
+++ b/packages/react/src/hooks/useAtomInstance.ts
@@ -5,7 +5,8 @@ import {
   AtomParamsType,
   ParamlessTemplate,
 } from '@zedux/atoms'
-import { useMemo, useSyncExternalStore } from 'react'
+import { useMemo } from 'react'
+import { useSyncExternalStore } from 'use-sync-external-store/shim'
 import { ZeduxHookConfig } from '../types'
 import { destroyed, External, Static } from '../utils'
 import { useEcosystem } from './useEcosystem'

--- a/packages/react/src/hooks/useAtomSelector.ts
+++ b/packages/react/src/hooks/useAtomSelector.ts
@@ -4,7 +4,8 @@ import {
   haveDepsChanged,
   SelectorCache,
 } from '@zedux/atoms'
-import { MutableRefObject, useMemo, useRef, useSyncExternalStore } from 'react'
+import { MutableRefObject, useMemo, useRef } from 'react'
+import { useSyncExternalStore } from 'use-sync-external-store/shim'
 import { destroyed, External } from '../utils'
 import { useEcosystem } from './useEcosystem'
 import { useReactComponentId } from './useReactComponentId'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1440,6 +1440,11 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
   integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
 
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
+
 "@types/yargs-parser@*":
   version "20.2.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.0.tgz#dd3e6699ba3237f0348cd085e4698780204842f9"
@@ -5779,6 +5784,11 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+use-sync-external-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 util-deprecate@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
## Description

Some apps are still using React versions < 18. Prefer using the [`useSyncExternalStore` shim](https://www.npmjs.com/package/use-sync-external-store) for now.

## Considerations

This shim adds over 1kb to the minified build. I'd say it's worth it for now, but something to consider.

## Issues

Resolves #44