### PR TITLE
fix(atoms): improve id generation; prevent selector with args cache reuse edge case

### DIFF
--- a/docs/blog/atoms-the-happy-medium.md
+++ b/docs/blog/atoms-the-happy-medium.md
@@ -1,0 +1,27 @@
+---
+title: 'Atoms: The Happy Medium'
+image: /img/zedux-and-react.png
+tags: [introductory]
+---
+
+The React state management world has seen extremes.
+
+Flux gave us the bad extreme of module decoupling and the good extreme of unidirectional data flow.
+
+Redux gave us the bad extremes of boilerplate and indirection and the good extreme of debugging experience.
+
+RTK toned down Redux's boilerplate extreme and a little of its indirection.
+
+MobX gave us the bad extreme of implicitness, but found some happy mediums in other aspects like boilerplate and
+
+Zustand toned down RTK's boilerplate further at the cost of also toning down its debugging experience. Zustand's success came from finding a happy medium between no boilerplate (for example, React's `useState()` hook) and extreme boilerplate (old-school Redux).
+
+If `UI State <-> Server State` is a spectrum, React Query gave us the extreme of Server State management.
+
+RTK Query found a happy medium between UI State and Server State - though Redux still sits closer to the bad extreme of indirection.
+
+## Good Mediums
+
+Not all spectrums need happy mediums. On some spectrums, you _do_ want to land as close to an extreme as possible - `Slowness <-> Speed` and `Lightweight <-> Heavy` for example. However, a good library will likely need to sacrifice some size for speed. Or sacrifice some size _and_ speed in exchange for achieving some happy mediums on other spectrums.
+
+Here's a non-comprehensive list spectrums that require finding a balance

--- a/docs/blog/how-atoms-fixed-flux.md
+++ b/docs/blog/how-atoms-fixed-flux.md
@@ -1,0 +1,65 @@
+---
+title: 'How Atoms Fixed Flux'
+image: /img/zedux-and-react.png
+tags: [history, theory]
+---
+
+The atomic model introduced by [Recoil](https://github.com/facebookexperimental/Recoil) introduced a lot of new capabilities at the cost of introducing some foreign concepts.
+
+[Jotai](https://github.com/pmndrs/jotai) later simplified some of Recoil's APIs at the cost of some power and making debugging more difficult.
+
+[Zedux](https://github.com/Omnistac/zedux) later simplified the atomic model itself by removing asynchrony from the atom graph and using APIs that feel familiar to React devs.
+
+Other articles will focus on the differences between these tools. This article will focus on one big feature that all 3 have in common:
+
+They fixed Flux.
+
+## Flux
+
+If you don't know Flux, here's a quick gist:
+
+```
+Actions -> Dispatcher -> Stores -> Views
+```
+
+Flux apps have multiple stores. There is only one Dispatcher whose job is to feed actions to all the stores in a proper order. This proper order means dynamically sorting out dependencies between the stores. For example, take an ecommerce app setup:
+
+```
+UserStore <-> CartStore <-> PromosStore
+```
+
+When the user moves an item to their cart, the PromosStore needs to wait for CartStore's state to update before sending off a request to see the available coupons for the user's items.
+
+Or perhaps certain items can't ship to the user's area. In this case, the CartStore needs to read state from the UserStore to determine whether it should update. And what about the error message? The CartStore may need to update a NotificationsStore.
+
+Flux doesn't like these dependencies. From the [legacy React docs](https://legacy.reactjs.org/blog/2014/07/30/flux-actions-and-the-dispatcher.html#why-we-need-a-dispatcher):
+
+> The objects within a Flux application are highly decoupled, and adhere very strongly to the [Law of Demeter](https://en.wikipedia.org/wiki/Law_of_Demeter), the principle that each object within a system should know as little as possible about the other objects in the system.
+
+The theory behind this is solid. 100%. Soo ... why did Flux die?
+
+## State Dependencies
+
+Well turns out, dependencies between isolated state containers are inevitable. In fact, to keep code modular and DRY, you _should_ be reading from and relying on other stores frequently. A UserStore in particular may need to be read from often to enable features or prevent disallowed actions.
+
+A point that is rarely addressed in the state management world is that apps scale. The above ecommerce app example could someday have stores for OrderHistory, ShippingCalculator, DeliveryEstimate, etc. It is not impractical for a large app to have hundreds of stores.
+
+Flux only provides basic dependency helpers encourages you to manage dependencies outside the data layer as much as possible. Considering that the data layer is what defines those dependencies, this technical decoupling adds significant cognitive load when developing a Flux app.
+
+On top of this, there are many design considerations Flux didn't solve for - or at least, the theory was unclear. Where should side effects go? Don't selectors that combine state from many stores violate the Law of Demeter? Should you attach all the needed state from all stores to an action before dispatching? What if PromosStore needs to wait for CartStore to send an async request before updating - is it CartStore's job to dispatch another action with all the information PromosStore needs?
+
+Some of these answers were foggy. Side effects, for example, were typically placed inside the stores themselves. You can see this recommended even on the archived [Flux examples page](https://github.com/facebookarchive/flux/tree/4ee8c50865c357e005cb40ea03cdd403533aad26/examples). But what about purity? What about an RxJS flow that reads from many stores at many stages in the pipeline?
+
+Long story short, the Flux model breaks down very quickly. And it showed on even very small apps.
+
+## Later Iterations
+
+We all know how [Redux](https://github.com/reduxjs/redux) came roaring in to save the day. It ditched the concept of multiple stores in favor of a singleton model. Now everything can access everything else without any formal "dependencies". Redux also reduced Flux's boilerplate a little. Alright, a very little.
+
+RTK later simplified Redux's infamous boilerplate. Then Zustand removed some fluff at the cost of
+
+With modular state, dependency trees naturally get so complex and interwoven that the best solution we could think of was, "Just don't do it I guess."
+
+And it worked. It still works well enough for most apps. The Flux principles were so solid that simply removing the dependency nightmare fixed it.
+
+Or did it?

--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -88,7 +88,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
 
     Object.assign(this, config)
 
-    this.id ||= this._idGenerator.generateEcosystemId()
+    this.id ||= this._idGenerator.generateId('es')
 
     if (config.overrides) {
       this.setOverrides(config.overrides)

--- a/packages/atoms/src/classes/IdGenerator.ts
+++ b/packages/atoms/src/classes/IdGenerator.ts
@@ -2,35 +2,11 @@ import { is, isPlainObject } from '@zedux/core'
 import { AtomInstanceBase } from './instances/AtomInstanceBase'
 
 /**
- * When using SSR, only `generateNodeId` should be allowed to run. It is okay
- * for `generateAtomSelectorId` to run, but auto-id'd selectors won't be
- * hydratable on the client (usually fine for inline selectors). Ecosystem ids
- * must be set manually
- *
- * To prevent Zedux from auto-id'ing AtomSelectors, use a shared function
- * reference. When using AtomSelectorConfig objects, make sure the object
- * reference itself is shared. In both cases, the function must have a unique
- * name.
- *
- * ```ts
- * // examples that will be auto-id'd:
- * useAtomSelector(({ get }) => get(myAtom)) // inline function ref can't be shared and has no name
- * const mySelector = { // this object reference can be shared...
- *   selector: ({ get }) => get(myAtom) // ...but the function has a generic name
- * }
- *
- * // examples where ids will be generated predictably based on params:
- * const mySelector = ({ get }) => get(myAtom) // function has a name and ref can be shared
- * const mySelector = { // this ref can be shared...
- *   selector: function mySelector({ get }) { // ...and the function has a name
- *     return get(myAtom)
- *   }
- * }
- * const mySelector = { // this ref can be shared...
- *   name: 'mySelector', // ...and we set the `name` config option
- *   selector: ({ get }) => get(myAtom)
- * }
- * ```
+ * When using SSR, only graph node ids should be generated (via
+ * `generateNodeId`). It is okay for AtomSelector ids to be generated during
+ * SSR, but id'd selectors won't be hydratable on the client since those ids are
+ * not generated predictably (selectors shouldn't be hydrated anyway). Ecosystem
+ * ids must be set manually.
  */
 export class IdGenerator {
   public idCounter = 0
@@ -42,20 +18,9 @@ export class IdGenerator {
    */
   public weakCache = new WeakMap<any, string>()
 
-  public generateAtomSelectorId(name = '') {
-    if (!name) {
-      name = DEV ? 'unknownSelector' : 'as'
-    }
-
-    return this.generateId(`@@selector-${name}`)
-  }
-
-  public generateEcosystemId() {
-    return this.generateId('es')
-  }
-
   /**
-   * Generate a pretty-much-guaranteed unique id using the passed prefix.
+   * Generate an id that is guaranteed to be unique in this ecosystem and
+   * pretty-much-guaranteed to be unique globally.
    *
    * This method and `IdGenerator#now()` are the only methods in Zedux that
    * produce random values.
@@ -65,7 +30,8 @@ export class IdGenerator {
    * `<repo root>/packages/react/test/utils/ecosystem.ts` for an example.
    */
   public generateId = (prefix: string) =>
-    `${prefix}-${++this.idCounter}${Math.random().toString(16).slice(2, 14)}`
+    // we can slice from 2 to 12 if needed, but keeping it short for now:
+    `${prefix}-${++this.idCounter}${Math.random().toString(36).slice(2, 8)}`
 
   public generateNodeId() {
     return this.generateId('no')

--- a/packages/atoms/test/units/IdGenerator.test.tsx
+++ b/packages/atoms/test/units/IdGenerator.test.tsx
@@ -8,7 +8,7 @@ describe('IdGenerator', () => {
   test('.generateId() generates a random id using the prefix', () => {
     const generator = new IdGenerator()
 
-    expect(generator.generateId('a')).toMatch(/^a-1[a-zA-Z0-9]{12}$/)
-    expect(generator.generateId('bb')).toMatch(/^bb-2[a-zA-Z0-9]{12}$/)
+    expect(generator.generateId('a')).toMatch(/^a-1[a-z0-9]{6}$/)
+    expect(generator.generateId('bb')).toMatch(/^bb-2[a-z0-9]{6}$/)
   })
 })

--- a/packages/react/src/hooks/useAtomSelector.ts
+++ b/packages/react/src/hooks/useAtomSelector.ts
@@ -53,7 +53,7 @@ const isRefDifferent = (
   const oldKey = selectors._getIdealCacheId(oldSelector)
 
   // if this last check is false, we're confident enough that it's an inline
-  // selector. It isn't a big deal if it isn't; it's just a for _ideal_ Dev X
+  // selector. It isn't a big deal if it isn't; it's just for _ideal_ Dev X
   return newKey !== oldKey
 }
 

--- a/packages/react/test/integrations/__snapshots__/selection.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/selection.test.tsx.snap
@@ -4,10 +4,10 @@ exports[`selection same-name selectors share the namespace when destroyed and re
 {
   "1": {
     "dependencies": {
-      "@@selector-common-name": true,
+      "@@selector-common-name-0": true,
     },
     "dependents": {
-      "no-0": {
+      "no-1": {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 3,
@@ -17,7 +17,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "isSelector": undefined,
     "weight": 3,
   },
-  "@@selector-common-name": {
+  "@@selector-common-name-0": {
     "dependencies": {
       "root": true,
     },
@@ -35,7 +35,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
   "root": {
     "dependencies": {},
     "dependents": {
-      "@@selector-common-name": {
+      "@@selector-common-name-0": {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -52,10 +52,10 @@ exports[`selection same-name selectors share the namespace when destroyed and re
 {
   "2": {
     "dependencies": {
-      "@@selector-common-name": true,
+      "@@selector-common-name-2": true,
     },
     "dependents": {
-      "no-1": {
+      "no-3": {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 3,
@@ -65,7 +65,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "isSelector": undefined,
     "weight": 3,
   },
-  "@@selector-common-name": {
+  "@@selector-common-name-2": {
     "dependencies": {
       "root": true,
     },
@@ -83,7 +83,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
   "root": {
     "dependencies": {},
     "dependents": {
-      "@@selector-common-name": {
+      "@@selector-common-name-2": {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -100,6 +100,21 @@ exports[`selection same-name selectors share the namespace when destroyed and re
 {
   "1": {
     "dependencies": {
+      "@@selector-common-name-4": true,
+    },
+    "dependents": {
+      "no-5": {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 3,
+        "operation": "addDependent",
+      },
+    },
+    "isSelector": undefined,
+    "weight": 3,
+  },
+  "2": {
+    "dependencies": {
       "@@selector-common-name-2": true,
     },
     "dependents": {
@@ -113,22 +128,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "isSelector": undefined,
     "weight": 3,
   },
-  "2": {
-    "dependencies": {
-      "@@selector-common-name": true,
-    },
-    "dependents": {
-      "no-1": {
-        "callback": undefined,
-        "createdAt": 123456789,
-        "flags": 3,
-        "operation": "addDependent",
-      },
-    },
-    "isSelector": undefined,
-    "weight": 3,
-  },
-  "@@selector-common-name": {
+  "@@selector-common-name-2": {
     "dependencies": {
       "root": true,
     },
@@ -143,7 +143,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "isSelector": true,
     "weight": 2,
   },
-  "@@selector-common-name-2": {
+  "@@selector-common-name-4": {
     "dependencies": {
       "root": true,
     },
@@ -161,13 +161,13 @@ exports[`selection same-name selectors share the namespace when destroyed and re
   "root": {
     "dependencies": {},
     "dependents": {
-      "@@selector-common-name": {
+      "@@selector-common-name-2": {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
       },
-      "@@selector-common-name-2": {
+      "@@selector-common-name-4": {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -184,10 +184,10 @@ exports[`selection same-name selectors share the namespace when destroyed and re
 {
   "1": {
     "dependencies": {
-      "@@selector-common-name-2": true,
+      "@@selector-common-name-4": true,
     },
     "dependents": {
-      "no-3": {
+      "no-5": {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 3,
@@ -197,7 +197,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "isSelector": undefined,
     "weight": 3,
   },
-  "@@selector-common-name-2": {
+  "@@selector-common-name-4": {
     "dependencies": {
       "root": true,
     },
@@ -215,7 +215,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
   "root": {
     "dependencies": {},
     "dependents": {
-      "@@selector-common-name-2": {
+      "@@selector-common-name-4": {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,

--- a/packages/react/test/integrations/params.test.tsx
+++ b/packages/react/test/integrations/params.test.tsx
@@ -1,5 +1,5 @@
 import { AtomGetters, atom, createEcosystem } from '@zedux/react'
-import { ecosystem } from '../utils/ecosystem'
+import { ecosystem, generateIdMock } from '../utils/ecosystem'
 
 describe('params', () => {
   test('deeply nested params are stringified correctly', () => {
@@ -26,6 +26,7 @@ describe('params', () => {
       fn(get(atom1, [num => num.toString()]) + '2')
 
     const complexEcosystem = createEcosystem({ complexParams: true })
+    ecosystem._idGenerator.generateId = generateIdMock
 
     const reusedFn = (str: string) => Number(str)
     const value1 = complexEcosystem.selectors.getCache(selector1, [reusedFn])
@@ -35,7 +36,7 @@ describe('params', () => {
 
     expect(value1.result).toBe(1)
     expect(instanceKey).toMatch(/^1-\["anonFn-/)
-    expect(selectorKey).toMatch(/^@@selector-selector1-\["reusedFn-/)
+    expect(selectorKey).toMatch(/^@@selector-selector1-.*?-\["reusedFn-/)
 
     const value2 = complexEcosystem.selectors.getCache(selector2, [reusedFn])
 
@@ -53,11 +54,11 @@ describe('params', () => {
     // the instances received different function references
     expect(instanceKey1).not.toBe(instanceKey2)
 
-    expect(selectorKey1).toMatch(/^@@selector-selector1-\["reusedFn-/)
-    expect(selectorKey2).toMatch(/^@@selector-selector2-\["reusedFn-/)
+    expect(selectorKey1).toMatch(/^@@selector-selector1-.*?-\["reusedFn-/)
+    expect(selectorKey2).toMatch(/^@@selector-selector2-.*?-\["reusedFn-/)
 
     // the selectors received the same function reference
-    expect(selectorKey1.slice(20)).toBe(selectorKey2.slice(20))
+    expect(selectorKey1.slice(28)).toBe(selectorKey2.slice(28))
 
     complexEcosystem.destroy()
   })
@@ -81,6 +82,7 @@ describe('params', () => {
       converter.toNumber(get(atom1, [new (class extends Converter {})()]) + '2')
 
     const complexEcosystem = createEcosystem({ complexParams: true })
+    ecosystem._idGenerator.generateId = generateIdMock
 
     const reusedInstance = new Converter()
     const value1 = complexEcosystem.selectors.getCache(selector1, [
@@ -92,7 +94,7 @@ describe('params', () => {
 
     expect(value1.result).toBe(1)
     expect(instanceKey).toMatch(/^1-\["UnknownClass-/)
-    expect(selectorKey).toMatch(/^@@selector-selector1-\["Converter-/)
+    expect(selectorKey).toMatch(/^@@selector-selector1-.*?-\["Converter-/)
 
     const value2 = complexEcosystem.selectors.getCache(selector2, [
       reusedInstance,
@@ -112,11 +114,11 @@ describe('params', () => {
     // the instances received different function references
     expect(instanceKey1).not.toBe(instanceKey2)
 
-    expect(selectorKey1).toMatch(/^@@selector-selector1-\["Converter-/)
-    expect(selectorKey2).toMatch(/^@@selector-selector2-\["Converter-/)
+    expect(selectorKey1).toMatch(/^@@selector-selector1-.*?-\["Converter-/)
+    expect(selectorKey2).toMatch(/^@@selector-selector2-.*?-\["Converter-/)
 
     // the selectors received the same function reference
-    expect(selectorKey1.slice(20)).toBe(selectorKey2.slice(20))
+    expect(selectorKey1.slice(28)).toBe(selectorKey2.slice(28))
 
     complexEcosystem.destroy()
   })

--- a/packages/react/test/integrations/selection.test.tsx
+++ b/packages/react/test/integrations/selection.test.tsx
@@ -254,7 +254,7 @@ describe('selection', () => {
 
     const cache = ecosystem.selectors.getCache(selector)
 
-    expect(cache.id).toBe('@@selector-testName')
+    expect(cache.id).toBe('@@selector-testName-0')
   })
 
   test('same-name selectors share the namespace when destroyed and recreated at different times', () => {

--- a/packages/react/test/snippets/stress-testing.tsx
+++ b/packages/react/test/snippets/stress-testing.tsx
@@ -1,0 +1,32 @@
+import * as z from '@zedux/react'
+
+let evaluations = 0
+const ecosystem = z.createEcosystem()
+const circularAtom: z.AnyAtomTemplate<{ Params: [i: number]; State: number }> =
+  z.ion('circular', ({ get }, i: number) => {
+    evaluations++
+    if (i >= 200) return i
+
+    let result = 0
+    for (let j = 0; j < 100; j++) {
+      result += get(circularAtom, [(i + 1) * 1000 + j])
+    }
+
+    return result + get(circularAtom, [i + 1])
+  })
+
+const start1 = performance.now()
+const instance1 = ecosystem.getInstance(circularAtom, [0])
+const end1 = performance.now()
+console.log('creation time:', end1 - start1)
+
+const instance2 = ecosystem.getInstance(circularAtom, [200])
+
+const start2 = performance.now()
+for (let i = 0; i < 50; i++) {
+  const instance = ecosystem.getInstance(circularAtom, [(i + 1) * 1000 + 99])
+  instance.setState(state => state + 1)
+}
+const end2 = performance.now()
+
+console.log('update time:', end2 - start2, 'evaluations:', evaluations)

--- a/packages/react/test/units/Selectors.test.tsx
+++ b/packages/react/test/units/Selectors.test.tsx
@@ -12,7 +12,7 @@ describe('the Selectors class', () => {
     const cache = ecosystem.selectors.getCache(selector3)
     const cache3 = {
       args: [],
-      id: '@@selector-selector3',
+      id: '@@selector-selector3-0',
       nextReasons: [],
       prevReasons: [],
       result: 'abcd',
@@ -22,17 +22,17 @@ describe('the Selectors class', () => {
     expect(cache).toEqual(cache3)
 
     expect(ecosystem.selectors._items).toEqual({
-      '@@selector-selector1': {
+      '@@selector-selector1-2': {
         args: [],
-        id: '@@selector-selector1',
+        id: '@@selector-selector1-2',
         nextReasons: [],
         prevReasons: [],
         result: 'ab',
         selectorRef: selector1,
       },
-      '@@selector-selector2': {
+      '@@selector-selector2-1': {
         args: [],
-        id: '@@selector-selector2',
+        id: '@@selector-selector2-1',
         nextReasons: [],
         prevReasons: [],
         result: 'abc',
@@ -46,8 +46,8 @@ describe('the Selectors class', () => {
     const cache2a = ecosystem.selectors.getCache(selector2)
 
     expect(ecosystem.selectors._items).toEqual({
-      '@@selector-selector1': expect.any(Object),
-      '@@selector-selector2': expect.any(Object),
+      '@@selector-selector1-1': expect.any(Object),
+      '@@selector-selector2-0': expect.any(Object),
     })
 
     // trigger cleanup without adding a dependent first
@@ -59,10 +59,11 @@ describe('the Selectors class', () => {
     const cache1b = ecosystem.selectors.getCache(selector1)
     const cleanup = ecosystem.selectors.addDependent(cache1b)
 
-    ecosystem.selectors.destroyCache(cache2b)
+    ecosystem.selectors.destroyCache(cache2b) // destroys only selector2
 
     expect(ecosystem.selectors._items).toEqual({
-      '@@selector-selector1': expect.any(Object),
+      // id # is 3 by now 'cause #1 was destroyed with cache2a above
+      '@@selector-selector1-3': expect.any(Object),
     })
 
     cleanup()
@@ -74,9 +75,9 @@ describe('the Selectors class', () => {
     ecosystem.selectors.getCache(selector3)
 
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-selector1': 'ab',
-      '@@selector-selector2': 'abc',
-      '@@selector-selector3': 'abcd',
+      '@@selector-selector1-2': 'ab',
+      '@@selector-selector2-1': 'abc',
+      '@@selector-selector3-0': 'abcd', // selector3's id is created first
     })
   })
 
@@ -103,9 +104,9 @@ describe('the Selectors class', () => {
     expect(cache1.isDestroyed).toBeUndefined()
     expect(cache2.isDestroyed).toBeUndefined()
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-selector1': 'ab',
-      '@@selector-selector2': 'abc',
-      '@@selector-selector3': 'abcd',
+      '@@selector-selector1-2': 'ab',
+      '@@selector-selector2-1': 'abc',
+      '@@selector-selector3-0': 'abcd',
     })
 
     ecosystem.selectors.destroyCache(selector2, [], true) // destroys both 1 & 2
@@ -114,9 +115,9 @@ describe('the Selectors class', () => {
     expect(cache1.isDestroyed).toBe(true)
     expect(cache2.isDestroyed).toBe(true)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-selector1': 'ab',
-      '@@selector-selector2': 'abc',
-      '@@selector-selector3': 'abcd',
+      '@@selector-selector1-4': 'ab', // id # 4 - selector was recreated
+      '@@selector-selector2-3': 'abc', // id # 3 - selector was recreated
+      '@@selector-selector3-0': 'abcd',
     })
 
     ecosystem.selectors.destroyCache(selector3)
@@ -139,22 +140,30 @@ describe('the Selectors class', () => {
 
   test('findAll() accepts selector refs, caches, or string ids', () => {
     const cache = ecosystem.selectors.getCache(selector3)
-    const caches1 = ecosystem.selectors.findAll('2')
+    const allCaches = ecosystem.selectors.findAll()
+
+    expect(Object.keys(allCaches)).toEqual([
+      '@@selector-selector1-2',
+      '@@selector-selector2-1',
+      '@@selector-selector3-0', // the id for selector3 is generated first
+    ])
+
+    const caches1 = ecosystem.selectors.findAll('selector2')
 
     expect(caches1).toEqual({
-      '@@selector-selector2': ecosystem.selectors.getCache(selector2),
+      '@@selector-selector2-1': ecosystem.selectors.getCache(selector2),
     })
 
     const caches2 = ecosystem.selectors.findAll(selector3)
 
     expect(caches2).toEqual({
-      '@@selector-selector3': cache,
+      '@@selector-selector3-0': cache,
     })
 
     const caches3 = ecosystem.selectors.findAll(cache)
 
     expect(caches3).toEqual({
-      '@@selector-selector3': cache,
+      '@@selector-selector3-0': cache,
     })
   })
 
@@ -187,5 +196,43 @@ describe('the Selectors class', () => {
       expect.stringContaining('encountered an error while running selector'),
       expect.any(TypeError)
     )
+  })
+
+  test('different arg-accepting selectors with the exact same name and args create different cache entries', () => {
+    const selector1 = function commonName(_: AtomGetters, id: string) {
+      return `${id}b`
+    }
+
+    const selector2 = function commonName(_: AtomGetters, id: string) {
+      return `${id}c`
+    }
+
+    ecosystem.selectors.getCache(selector1, ['a'])
+    ecosystem.selectors.getCache(selector2, ['a'])
+
+    expect(ecosystem.selectors._items).toMatchInlineSnapshot(`
+      {
+        "@@selector-commonName-0-["a"]": SelectorCache {
+          "args": [
+            "a",
+          ],
+          "id": "@@selector-commonName-0-["a"]",
+          "nextReasons": [],
+          "prevReasons": [],
+          "result": "ab",
+          "selectorRef": [Function],
+        },
+        "@@selector-commonName-1-["a"]": SelectorCache {
+          "args": [
+            "a",
+          ],
+          "id": "@@selector-commonName-1-["a"]",
+          "nextReasons": [],
+          "prevReasons": [],
+          "result": "ac",
+          "selectorRef": [Function],
+        },
+      }
+    `)
   })
 })

--- a/packages/react/test/units/useAtomSelector.test.tsx
+++ b/packages/react/test/units/useAtomSelector.test.tsx
@@ -102,7 +102,7 @@ describe('useAtomSelector', () => {
     expect(div.innerHTML).toBe('0')
     expect(selector1).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-[0]': 0,
+      '@@selector-mockConstructor-1-[0]': 0,
     })
 
     act(() => {
@@ -113,7 +113,7 @@ describe('useAtomSelector', () => {
     expect(div.innerHTML).toBe('1')
     expect(selector1).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-[1]': 1,
+      '@@selector-mockConstructor-1-[1]': 1,
     })
   })
 
@@ -152,7 +152,7 @@ describe('useAtomSelector', () => {
     expect(selector1).not.toHaveBeenCalled()
     expect(selector2).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor': 2,
+      '@@selector-mockConstructor-1': 2,
     })
 
     act(() => {
@@ -164,7 +164,7 @@ describe('useAtomSelector', () => {
     expect(selector1).toHaveBeenCalledTimes(1)
     expect(selector2).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-1-[1]': 1,
+      '@@selector-mockConstructor-2-[1]': 1,
     })
   })
 
@@ -197,7 +197,7 @@ describe('useAtomSelector', () => {
     expect(div.innerHTML).toBe('1')
     expect(selector1).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor': 1,
+      '@@selector-mockConstructor-1': 1,
     })
 
     act(() => {
@@ -208,7 +208,7 @@ describe('useAtomSelector', () => {
     expect(div.innerHTML).toBe('1')
     expect(selector1).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-1': 1,
+      '@@selector-mockConstructor-2': 1,
     })
   })
 
@@ -243,7 +243,7 @@ describe('useAtomSelector', () => {
     expect(div.innerHTML).toBe('0')
     expect(selector1.selector).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-[0]': 0,
+      '@@selector-mockConstructor-1-[0]': 0,
     })
 
     act(() => {
@@ -254,7 +254,7 @@ describe('useAtomSelector', () => {
     expect(div.innerHTML).toBe('0')
     expect(selector1.selector).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-[0]': 0,
+      '@@selector-mockConstructor-1-[0]': 0,
     })
   })
 
@@ -294,7 +294,7 @@ describe('useAtomSelector', () => {
     expect(div.innerHTML).toBe('0')
     expect(selector1).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-[0]': 0,
+      '@@selector-mockConstructor-1-[0]': 0,
     })
 
     act(() => {
@@ -305,7 +305,7 @@ describe('useAtomSelector', () => {
     expect(div.innerHTML).toBe('0')
     expect(selector1).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-[0]': 0,
+      '@@selector-mockConstructor-1-[0]': 0,
     })
   })
 
@@ -343,7 +343,7 @@ describe('useAtomSelector', () => {
     expect(div.innerHTML).toBe('1')
     expect(selector1).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor': 1,
+      '@@selector-mockConstructor-1': 1,
     })
     expect(renders).toBe(1)
 
@@ -356,7 +356,7 @@ describe('useAtomSelector', () => {
     expect(div.innerHTML).toBe('1')
     expect(selector1).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor': 1,
+      '@@selector-mockConstructor-1': 1,
     })
     expect(renders).toBe(2)
   })
@@ -393,7 +393,7 @@ describe('useAtomSelector', () => {
     expect(selector1).not.toHaveBeenCalled()
     expect(selector2).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor': 2,
+      '@@selector-mockConstructor-0': 2,
     })
 
     act(() => {
@@ -405,8 +405,9 @@ describe('useAtomSelector', () => {
     expect(selector1).toHaveBeenCalledTimes(1)
     expect(selector2).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor': 2,
-      '@@selector-mockConstructor-2': 1,
+      '@@selector-mockConstructor-0': 2,
+      // id # 3 'cause Test component and `addDependent` generate ids 1 & 2:
+      '@@selector-mockConstructor-3': 1,
     })
   })
 })

--- a/packages/react/test/utils/console.ts
+++ b/packages/react/test/utils/console.ts
@@ -13,5 +13,7 @@ export const mockConsole = <K extends keyof typeof console>(
 }
 
 afterEach(() => {
-  cleanups.forEach(cleanup => cleanup())
+  while (cleanups.length) {
+    cleanups.pop()?.()
+  }
 })


### PR DESCRIPTION
## Description

There's an edge case with AtomSelector id generation where if two different selectors have the same name and take the same params, they'll reuse the same cache. Improving the code responsible for this has been a tech debt item since the selectors graph rework, but this is the first time we've run into a problem from it.

Improve id generation in the `IdGenerator`. Make new selector references always generate a new base key id hash for their ids so no conflicts like this can happen in the future. Make ids smaller _and_ more unique by using a radix of 36. Clean up some code, finally addressing this tech debt and fixing the cache reuse bug in the process.