### PR TITLE
fix(atoms): make it easier for TS to infer AtomApi types from chained methods

### DIFF
--- a/packages/atoms/src/classes/AtomApi.ts
+++ b/packages/atoms/src/classes/AtomApi.ts
@@ -27,8 +27,8 @@ export class AtomApi<G extends AtomApiGenerics> {
 
   public addExports<NewExports extends Record<string, any>>(
     exports: NewExports
-  ): Prettify<
-    AtomApi<
+  ): AtomApi<
+    Prettify<
       Omit<G, 'Exports'> & {
         Exports: (G['Exports'] extends Record<string, never>
           ? unknown
@@ -52,7 +52,7 @@ export class AtomApi<G extends AtomApiGenerics> {
 
   public setExports<NewExports extends Record<string, any>>(
     exports: NewExports
-  ): Prettify<AtomApi<Omit<G, 'Exports'> & { Exports: NewExports }>> {
+  ): AtomApi<Prettify<Omit<G, 'Exports'> & { Exports: NewExports }>> {
     ;(
       this as unknown as AtomApi<Omit<G, 'Exports'> & { Exports: NewExports }>
     ).exports = exports
@@ -64,7 +64,7 @@ export class AtomApi<G extends AtomApiGenerics> {
 
   public setPromise<T>(
     promise: Promise<T>
-  ): Prettify<AtomApi<Omit<G, 'Promise'> & { Promise: Promise<T> }>> {
+  ): AtomApi<Prettify<Omit<G, 'Promise'> & { Promise: Promise<T> }>> {
     this.promise = promise as unknown as G['Promise']
 
     return this as AtomApi<Omit<G, 'Promise'> & { Promise: Promise<T> }> // for chaining


### PR DESCRIPTION
## Description

TS struggles breaking down an AtomApi's type when chained methods (e.g. `.setPromise()`, `.setExports()`, etc) are called and extra layers are added (e.g. put the whole thing in a function called in a component and pass more inferred types - at least that's the general idea).

The `Prettify` helper doesn't need to wrap the whole class. Make it only wrap the Omit. This apparently drastically reduces the work TS has to do.