### PR TITLE
fix: improve overloads of atom-template-accepting functions for paramless atoms

### DIFF
--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -286,6 +286,10 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
     params: AtomParamsType<A>
   ): AtomInstanceType<A> | undefined
 
+  public find<A extends AnyAtomTemplate<{ Params: [] }>>(
+    template: A
+  ): AtomInstanceType<A> | undefined
+
   public find<A extends AnyAtomTemplate>(
     template: ParamlessTemplate<A>
   ): AtomInstanceType<A> | undefined
@@ -346,6 +350,10 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
     params: AtomParamsType<A>
   ): AtomStateType<A>
 
+  public get<A extends AnyAtomTemplate<{ Params: [] }>>(
+    template: A
+  ): AtomStateType<A>
+
   public get<A extends AnyAtomTemplate>(
     template: ParamlessTemplate<A>
   ): AtomStateType<A>
@@ -376,6 +384,10 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
     template: A,
     params: AtomParamsType<A>,
     edgeInfo?: GraphEdgeInfo
+  ): AtomInstanceType<A>
+
+  public getInstance<A extends AnyAtomTemplate<{ Params: [] }>>(
+    template: A
   ): AtomInstanceType<A>
 
   public getInstance<A extends AnyAtomTemplate>(

--- a/packages/atoms/src/injectors/injectAtomInstance.ts
+++ b/packages/atoms/src/injectors/injectAtomInstance.ts
@@ -41,6 +41,8 @@ export const injectAtomInstance: {
     config?: InjectAtomInstanceConfig
   ): AtomInstanceType<A>
 
+  <A extends AnyAtomTemplate<{ Params: [] }>>(template: A): AtomInstanceType<A>
+
   <A extends AnyAtomTemplate>(
     template: ParamlessTemplate<A>
   ): AtomInstanceType<A>

--- a/packages/atoms/src/injectors/injectAtomState.ts
+++ b/packages/atoms/src/injectors/injectAtomState.ts
@@ -15,6 +15,11 @@ export const injectAtomState: {
     params: AtomParamsType<A>
   ): StateHookTuple<AtomStateType<A>, AtomExportsType<A>>
 
+  <A extends AnyAtomTemplate<{ Params: [] }>>(template: A): StateHookTuple<
+    AtomStateType<A>,
+    AtomExportsType<A>
+  >
+
   <A extends AnyAtomTemplate>(template: ParamlessTemplate<A>): StateHookTuple<
     AtomStateType<A>,
     AtomExportsType<A>

--- a/packages/atoms/src/injectors/injectAtomValue.ts
+++ b/packages/atoms/src/injectors/injectAtomValue.ts
@@ -13,6 +13,8 @@ export const injectAtomValue: {
     params: AtomParamsType<A>
   ): AtomStateType<A>
 
+  <A extends AnyAtomTemplate<{ Params: [] }>>(template: A): AtomStateType<A>
+
   <A extends AnyAtomTemplate>(template: ParamlessTemplate<A>): AtomStateType<A>
 
   <I extends AnyAtomInstance>(instance: I): AtomStateType<I>

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -40,6 +40,8 @@ export interface AtomGettersBase {
     params: AtomParamsType<A>
   ): AtomStateType<A>
 
+  get<A extends AnyAtomTemplate<{ Params: [] }>>(template: A): AtomStateType<A>
+
   get<A extends AnyAtomTemplate>(
     template: ParamlessTemplate<A>
   ): AtomStateType<A>
@@ -55,6 +57,10 @@ export interface AtomGettersBase {
     template: A,
     params: AtomParamsType<A>,
     edgeInfo?: GraphEdgeInfo
+  ): AtomInstanceType<A>
+
+  getInstance<A extends AnyAtomTemplate<{ Params: [] }>>(
+    template: A
   ): AtomInstanceType<A>
 
   getInstance<A extends AnyAtomTemplate>(

--- a/packages/react/src/hooks/useAtomInstance.ts
+++ b/packages/react/src/hooks/useAtomInstance.ts
@@ -52,6 +52,8 @@ export const useAtomInstance: {
     config?: ZeduxHookConfig
   ): AtomInstanceType<A>
 
+  <A extends AnyAtomTemplate<{ Params: [] }>>(template: A): AtomInstanceType<A>
+
   <A extends AnyAtomTemplate>(
     template: ParamlessTemplate<A>
   ): AtomInstanceType<A>

--- a/packages/react/src/hooks/useAtomState.ts
+++ b/packages/react/src/hooks/useAtomState.ts
@@ -50,6 +50,11 @@ export const useAtomState: {
     config?: Omit<ZeduxHookConfig, 'subscribe'>
   ): StateHookTuple<AtomStateType<A>, AtomExportsType<A>>
 
+  <A extends AnyAtomTemplate<{ Params: [] }>>(template: A): StateHookTuple<
+    AtomStateType<A>,
+    AtomExportsType<A>
+  >
+
   <A extends AnyAtomTemplate>(template: ParamlessTemplate<A>): StateHookTuple<
     AtomStateType<A>,
     AtomExportsType<A>

--- a/packages/react/src/hooks/useAtomValue.ts
+++ b/packages/react/src/hooks/useAtomValue.ts
@@ -15,6 +15,8 @@ export const useAtomValue: {
     config?: Omit<ZeduxHookConfig, 'subscribe'>
   ): AtomStateType<A>
 
+  <A extends AnyAtomTemplate<{ Params: [] }>>(template: A): AtomStateType<A>
+
   <A extends AnyAtomTemplate>(template: ParamlessTemplate<A>): AtomStateType<A>
 
   <I extends AnyAtomInstance>(

--- a/packages/react/test/types.test.tsx
+++ b/packages/react/test/types.test.tsx
@@ -599,6 +599,15 @@ describe('types', () => {
 
     // @ts-expect-error all params required, so params must be passed
     ecosystem.get(allRequiredParamsAtom)
+
+    function noParams<A extends AnyAtomTemplate<{ Params: [] }>>(atom: A) {
+      return ecosystem.get(atom)
+    }
+
+    // @ts-expect-error optional params not allowed
+    noParams(someOptionalParamsAtom)
+
+    expectTypeOf(noParams(atom('no-params-test', null))).toMatchTypeOf<null>()
   })
 
   test('accepting instances', () => {


### PR DESCRIPTION
## Description

The `ParamlessTemplate` type helper is good enough in most situations, however there are some exceptions. Namely, when declaring a function that accepts only paramless atom templates (singletons) for simplicity reasons, the types don't "just work" and require an extra cast:

```ts
function noParams<A extends AnyAtomTemplate<{ Params: [] }>>(atom: A) {
  return myEcosystem.get(atom) // Error! Even though we know the params are `[]`
}
```

This PR fixes that. The above code will no longer error.

## Affects

atoms, react