### PR TITLE
feat: make atoms package fully framework agnostic

### DIFF
--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -1,5 +1,4 @@
 import { createStore, is, isPlainObject } from '@zedux/core'
-import React, { createContext } from 'react'
 import { internalStore } from '../store/index'
 import {
   AnyAtomInstance,
@@ -63,9 +62,15 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
   public _idGenerator = new IdGenerator()
   public _instances: Record<string, AnyAtomInstance> = {}
   public _mods: Record<Mod, number> = { ...defaultMods }
-  public _reactContexts: Record<string, React.Context<any>> = {}
   public _refCount = 0
   public _scheduler: Scheduler = new Scheduler(this)
+
+  /**
+   * Only for use by internal addon packages - lets us attach anything we want
+   * to the ecosystem. For example, the React package uses this to store React
+   * Context objects
+   */
+  public _storage: Record<string, any> = {}
 
   private cleanup?: MaybeCleanup
   private isInitialized = false
@@ -835,20 +840,6 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
     // mods have already been notified of the instance's status changing to
     // Destroyed by this point. No need to notify anything of this mutation.
     delete this._instances[id]
-  }
-
-  /**
-   * Should only be used internally
-   */
-  public _getReactContext(atom: AnyAtomTemplate) {
-    const existingContext = this._reactContexts[atom.key]
-
-    if (existingContext) return existingContext
-
-    const newContext = createContext(undefined)
-    this._reactContexts[atom.key] = newContext
-
-    return newContext as React.Context<any>
   }
 
   /**

--- a/packages/react/src/components/AtomProvider.tsx
+++ b/packages/react/src/components/AtomProvider.tsx
@@ -1,6 +1,7 @@
 import { AnyAtomInstance } from '@zedux/atoms'
 import React, { FC, ReactNode } from 'react'
 import { useEcosystem } from '../hooks/useEcosystem'
+import { getReactContext } from '../utils'
 
 /**
  * Provides an atom instance over React context.
@@ -37,7 +38,7 @@ export const AtomProvider: FC<
   const allInstances = instances || ([instance] as AnyAtomInstance[])
 
   if (allInstances.length === 1) {
-    const context = ecosystem._getReactContext(allInstances[0].template)
+    const context = getReactContext(ecosystem, allInstances[0].template)
 
     return (
       <context.Provider value={allInstances[0]}>{children}</context.Provider>
@@ -45,7 +46,7 @@ export const AtomProvider: FC<
   }
 
   const [parentInstance, ...childInstances] = allInstances
-  const context = ecosystem._getReactContext(parentInstance.template)
+  const context = getReactContext(ecosystem, parentInstance.template)
 
   return (
     <context.Provider value={parentInstance}>

--- a/packages/react/src/hooks/useAtomContext.ts
+++ b/packages/react/src/hooks/useAtomContext.ts
@@ -7,6 +7,7 @@ import {
 import { is } from '@zedux/core'
 import { useContext } from 'react'
 import { useEcosystem } from './useEcosystem'
+import { getReactContext } from '../utils'
 
 /**
  * A React hook that accepts an atom template and returns an atom instance of
@@ -50,7 +51,7 @@ export const useAtomContext: {
 ) => {
   const ecosystem = useEcosystem()
   const instance: AtomInstanceType<A> | undefined = useContext(
-    ecosystem._getReactContext(template)
+    getReactContext(ecosystem, template)
   )
 
   if (!defaultParams || is(instance, AtomInstanceBase)) {
@@ -63,7 +64,7 @@ export const useAtomContext: {
     return instance as AtomInstanceType<A>
   }
 
-  if (typeof defaultParams === 'boolean') {
+  if (defaultParams === true) {
     if (DEV) {
       throw new ReferenceError(
         `Zedux: useAtomContext - No atom instance was provided for atom "${template.key}".`

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,4 +1,5 @@
-import { createContext } from 'react'
+import { AnyAtomTemplate, Ecosystem } from '@zedux/atoms'
+import React, { createContext } from 'react'
 
 export const ecosystemContext = createContext('@@global')
 
@@ -13,3 +14,17 @@ export const Static = 4
 // export const Deferred = 8
 
 export const destroyed = Symbol.for(`@@zedux/destroyed`)
+
+export const getReactContext = (
+  ecosystem: Ecosystem,
+  atom: AnyAtomTemplate
+) => {
+  const reactStorage: Record<
+    string,
+    React.Context<any>
+  > = (ecosystem._storage.react ||= {})
+
+  return (reactStorage[atom.key] ||= createContext(
+    undefined
+  ) as React.Context<any>)
+}


### PR DESCRIPTION
## Description

The atoms package still has one usage of React - creating and storing React context objects in the ecosystem. Move that logic to the atoms package and provide a general storage mechanism for internal packages to store anything at the ecosystem level.

## Affects

atoms, react