### PR TITLE
feat(atoms): improve graph perf by removing unnecessary `Object.keys()` calls

### DIFF
--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -202,6 +202,7 @@ export interface EcosystemGraphNode {
   dependencies: Record<string, true>
   dependents: Record<string, DependentEdge>
   isSelector?: boolean
+  refCount: number
   weight: number
 }
 

--- a/packages/react/test/integrations/__snapshots__/selection.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/selection.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
       },
     },
     "isSelector": undefined,
+    "refCount": 1,
     "weight": 3,
   },
   "@@selector-common-name-0": {
@@ -30,6 +31,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
       },
     },
     "isSelector": true,
+    "refCount": 1,
     "weight": 2,
   },
   "root": {
@@ -43,6 +45,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
       },
     },
     "isSelector": undefined,
+    "refCount": 1,
     "weight": 1,
   },
 }
@@ -63,6 +66,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
       },
     },
     "isSelector": undefined,
+    "refCount": 1,
     "weight": 3,
   },
   "@@selector-common-name-2": {
@@ -78,6 +82,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
       },
     },
     "isSelector": true,
+    "refCount": 1,
     "weight": 2,
   },
   "root": {
@@ -91,6 +96,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
       },
     },
     "isSelector": undefined,
+    "refCount": 1,
     "weight": 1,
   },
 }
@@ -111,6 +117,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
       },
     },
     "isSelector": undefined,
+    "refCount": 1,
     "weight": 3,
   },
   "2": {
@@ -126,6 +133,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
       },
     },
     "isSelector": undefined,
+    "refCount": 1,
     "weight": 3,
   },
   "@@selector-common-name-2": {
@@ -141,6 +149,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
       },
     },
     "isSelector": true,
+    "refCount": 1,
     "weight": 2,
   },
   "@@selector-common-name-4": {
@@ -156,6 +165,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
       },
     },
     "isSelector": true,
+    "refCount": 1,
     "weight": 2,
   },
   "root": {
@@ -175,6 +185,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
       },
     },
     "isSelector": undefined,
+    "refCount": 2,
     "weight": 1,
   },
 }
@@ -195,6 +206,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
       },
     },
     "isSelector": undefined,
+    "refCount": 1,
     "weight": 3,
   },
   "@@selector-common-name-4": {
@@ -210,6 +222,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
       },
     },
     "isSelector": true,
+    "refCount": 1,
     "weight": 2,
   },
   "root": {
@@ -223,6 +236,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
       },
     },
     "isSelector": undefined,
+    "refCount": 1,
     "weight": 1,
   },
 }

--- a/packages/react/test/integrations/graph.test.tsx
+++ b/packages/react/test/integrations/graph.test.tsx
@@ -152,6 +152,7 @@ describe('graph', () => {
           },
         },
         isSelector: undefined,
+        refCount: 1,
         weight: 1,
       },
       atom2: {
@@ -165,12 +166,14 @@ describe('graph', () => {
           },
         },
         isSelector: undefined,
+        refCount: 1,
         weight: 1,
       },
       ion1: {
         dependencies: { atom1: true, atom2: true },
         dependents: {},
         isSelector: undefined,
+        refCount: 0,
         weight: 1, // static dependencies don't affect the weight
       },
     })
@@ -211,6 +214,7 @@ describe('graph', () => {
           },
         },
         isSelector: undefined,
+        refCount: 1,
         weight: 1,
       },
       'b-["b"]': {
@@ -224,6 +228,7 @@ describe('graph', () => {
           },
         },
         isSelector: undefined,
+        refCount: 1,
         weight: 1,
       },
       d: {
@@ -233,6 +238,7 @@ describe('graph', () => {
         },
         dependents: {},
         isSelector: undefined,
+        refCount: 0,
         weight: 3,
       },
     })
@@ -253,12 +259,14 @@ describe('graph', () => {
           },
         },
         isSelector: undefined,
+        refCount: 1,
         weight: 1,
       },
       'b-["b"]': {
         dependencies: {},
         dependents: {},
         isSelector: undefined,
+        refCount: 0,
         weight: 1,
       },
       c: {
@@ -272,6 +280,7 @@ describe('graph', () => {
           },
         },
         isSelector: undefined,
+        refCount: 1,
         weight: 1,
       },
       d: {
@@ -281,6 +290,7 @@ describe('graph', () => {
         },
         dependents: {},
         isSelector: undefined,
+        refCount: 0,
         weight: 3,
       },
     })


### PR DESCRIPTION
## Description

There are several places where we don't have to call `Object.keys()`. In some stress tests, these can be called a lot, resulting in lots of overhead.

Remove 2 of these `Object.keys()` calls in the graph - when scheduling and unscheduling node destruction. Instead add a `refCount` counter that we manually keep in sync with the dependents count.