### PR TITLE
fix(react): make React imports specify file extensions in esm builds

### DIFF
--- a/packages/react/src/components/EcosystemProvider.tsx
+++ b/packages/react/src/components/EcosystemProvider.tsx
@@ -1,6 +1,6 @@
 import { createEcosystem, Ecosystem, EcosystemConfig } from '@zedux/atoms'
 import React, { ReactNode, useMemo } from 'react'
-import { useSyncExternalStore } from 'use-sync-external-store/shim'
+import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 import { ecosystemContext } from '../utils'
 
 /**

--- a/packages/react/src/hooks/useAtomInstance.ts
+++ b/packages/react/src/hooks/useAtomInstance.ts
@@ -6,7 +6,7 @@ import {
   ParamlessTemplate,
 } from '@zedux/atoms'
 import { useMemo } from 'react'
-import { useSyncExternalStore } from 'use-sync-external-store/shim'
+import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 import { ZeduxHookConfig } from '../types'
 import { destroyed, External, Static } from '../utils'
 import { useEcosystem } from './useEcosystem'

--- a/packages/react/src/hooks/useAtomSelector.ts
+++ b/packages/react/src/hooks/useAtomSelector.ts
@@ -5,7 +5,7 @@ import {
   SelectorCache,
 } from '@zedux/atoms'
 import { MutableRefObject, useMemo, useRef } from 'react'
-import { useSyncExternalStore } from 'use-sync-external-store/shim'
+import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 import { destroyed, External } from '../utils'
 import { useEcosystem } from './useEcosystem'
 import { useReactComponentId } from './useReactComponentId'

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -75,6 +75,17 @@ const tscBuild = async isCjs => {
     )
     process.exit(1)
   }
+
+  const fixJsxPragma = await cmd(
+    `find dist/esm -type f -exec sed -i${
+      platform() === 'darwin' ? " ''" : ''
+    } "s|\\(from \\"react/jsx-runtime\\)\\"|\\1.js\\"|" {} +`
+  )
+
+  if (fixJsxPragma.code) {
+    console.error(`fixing jsx pragma failed. Output: ${fixJsxPragma}`)
+    process.exit(1)
+  }
 }
 
 const run = async () => {


### PR DESCRIPTION
## Description

React's `react/jsx-runtime` auto-added imports are auto-added wrong in esm builds. Make it specify the file extension. Also make the `useSyncExternalStore` shim imports do the same.