### PR TITLE
fix(react): update React peer dep to a minimum of v16.3.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -57,7 +57,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=18.0.0"
+    "react": ">=16.3.0"
   },
   "repository": {
     "directory": "packages/react",

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -4,7 +4,11 @@ import { configureVite } from '../vite-base-config'
 
 export default configureVite({
   getConfig: () => ({
-    plugins: [react()],
+    plugins: [
+      react({
+        jsxRuntime: 'classic',
+      }),
+    ],
     resolve: {
       alias: {
         '@zedux/react': resolve(__dirname, 'src'),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
     "lib": ["ESNext"],
     "module": "ESNext",
     "moduleResolution": "node",


### PR DESCRIPTION
## Description

I plugged in the `useSyncExternalStore` shim but forgot to update the `react` package's React peer dep. Zedux should now be compatible with React v16.3.0 and up (the version that introduced the new context API)