### PR TITLE
fix: fix package.json export order

### DIFF
--- a/packages/atoms/package.json
+++ b/packages/atoms/package.json
@@ -16,12 +16,12 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "default": "./dist/cjs/index.js",
       "production": {
         "import": "./dist/zedux-atoms.es.min.js",
         "require": "./dist/zedux-atoms.umd.min.js",
         "default": "./dist/zedux-atoms.umd.min.js"
-      }
+      },
+      "default": "./dist/cjs/index.js"
     }
   },
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,12 +13,12 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "default": "./dist/cjs/index.js",
       "production": {
         "import": "./dist/zedux.es.min.js",
         "require": "./dist/zedux.umd.min.js",
         "default": "./dist/zedux.umd.min.js"
-      }
+      },
+      "default": "./dist/cjs/index.js"
     }
   },
   "files": [

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -17,12 +17,12 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "default": "./dist/cjs/index.js",
       "production": {
         "import": "./dist/zedux-immer.es.min.js",
         "require": "./dist/zedux-immer.umd.min.js",
         "default": "./dist/zedux-immer.umd.min.js"
-      }
+      },
+      "default": "./dist/cjs/index.js"
     }
   },
   "files": [

--- a/packages/machines/package.json
+++ b/packages/machines/package.json
@@ -16,12 +16,12 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "default": "./dist/cjs/index.js",
       "production": {
         "import": "./dist/zedux-machines.es.min.js",
         "require": "./dist/zedux-machines.umd.min.js",
         "default": "./dist/zedux-machines.umd.min.js"
-      }
+      },
+      "default": "./dist/cjs/index.js"
     }
   },
   "files": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,12 +25,12 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "default": "./dist/cjs/index.js",
       "production": {
         "import": "./dist/zedux-react.es.min.js",
         "require": "./dist/zedux-react.umd.min.js",
         "default": "./dist/zedux-react.umd.min.js"
-      }
+      },
+      "default": "./dist/cjs/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Description

The `default` field in the `package.json` files of all packages should be the last one declared - including after the nested `production` key. Fix that for all packages.

## Affects

atoms, core, immer, machines, react