### PR TITLE
fix(atoms): improve atom searching

### DIFF
--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -314,9 +314,12 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
       return this._instances[id]
     }
 
-    return Object.values(this.findAll(template))[0] as
-      | AtomInstanceType<A>
-      | undefined
+    const matches = this.findAll(template)
+
+    return (
+      matches[template] ||
+      (Object.values(matches)[0] as AtomInstanceType<A> | undefined)
+    )
   }
 
   /**
@@ -327,9 +330,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
    */
   public findAll(template?: AnyAtomTemplate | string) {
     const isAtom = (template as AnyAtomTemplate)?.key
-    const filterKey = isAtom
-      ? (template as AnyAtomTemplate).key
-      : (template as string)
+    const filterKey = isAtom || (template as string)?.toLowerCase()
     const hash: Record<string, AnyAtomInstance> = {}
 
     Object.values(this._instances)
@@ -338,7 +339,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
         if (
           filterKey &&
           (isAtom
-            ? instance.template.key !== filterKey
+            ? instance.template.key !== (template as AnyAtomTemplate).key
             : !instance.id.toLowerCase().includes(filterKey))
         ) {
           return

--- a/packages/react/test/units/Ecosystem.test.tsx
+++ b/packages/react/test/units/Ecosystem.test.tsx
@@ -73,6 +73,32 @@ describe('Ecosystem', () => {
     expect(cleanup).toHaveBeenCalledTimes(2)
   })
 
+  test('find() with string returns the exact match if possible', () => {
+    const atom1 = atom('1', (id?: string) => id)
+    const atom2 = atom('someLongKey1', 1)
+    const atom3 = atom('someLongKey11', 1)
+    const atom4 = atom('someLongKey111', 1)
+
+    ecosystem.getInstance(atom1, ['a'])
+    ecosystem.getInstance(atom1)
+    ecosystem.getInstance(atom1, ['b'])
+    ecosystem.getInstance(atom2)
+    ecosystem.getInstance(atom3)
+    ecosystem.getInstance(atom4)
+
+    expect(ecosystem.find('1')).toBe(ecosystem.getInstance(atom1))
+    expect(ecosystem.find('someLongKey11')).toBe(ecosystem.getInstance(atom3))
+
+    // some more checks for fun
+    expect(ecosystem.find(atom4)).toBe(ecosystem.getInstance(atom4))
+    expect(ecosystem.find(atom1, ['a'])).toBe(
+      ecosystem.getInstance(atom1, ['a'])
+    )
+    expect(ecosystem.find(atom1, ['b'])).toBe(
+      ecosystem.getInstance(atom1, ['b'])
+    )
+  })
+
   test('findAll() with no params returns all atom instances', () => {
     const atom1 = atom('1', (id: number) => id)
 


### PR DESCRIPTION
## Description

`ecosystem.findAll()` currently has a bug where it doesn't find a match if a string key with uppercase letters is passed. The simple workaround has been to `.toLowerCase()` the string before passing, but it's time we fixed it for real.

Also improve string searching in `ecosystem.find()` by returning the exact match if there is one, rather than the first match.