### PR TITLE
feat(atoms): allow setting promise to undefined in AtomApi

### DIFF
--- a/packages/atoms/src/classes/AtomApi.ts
+++ b/packages/atoms/src/classes/AtomApi.ts
@@ -62,12 +62,18 @@ export class AtomApi<G extends AtomApiGenerics> {
     > // for chaining
   }
 
-  public setPromise<T>(
-    promise: Promise<T>
-  ): AtomApi<Prettify<Omit<G, 'Promise'> & { Promise: Promise<T> }>> {
+  public setPromise(): AtomApi<Omit<G, 'Promise'> & { Promise: undefined }>
+
+  public setPromise<P extends Promise<any> | undefined>(
+    promise: P
+  ): AtomApi<Omit<G, 'Promise'> & { Promise: P }>
+
+  public setPromise<P extends Promise<any> | undefined>(
+    promise?: P
+  ): AtomApi<Prettify<Omit<G, 'Promise'> & { Promise: P }>> {
     this.promise = promise as unknown as G['Promise']
 
-    return this as AtomApi<Omit<G, 'Promise'> & { Promise: Promise<T> }> // for chaining
+    return this as unknown as AtomApi<Omit<G, 'Promise'> & { Promise: P }> // for chaining
   }
 
   public setTtl(ttl: AtomInstanceTtl | (() => AtomInstanceTtl)) {

--- a/packages/react/test/types.test.tsx
+++ b/packages/react/test/types.test.tsx
@@ -740,4 +740,16 @@ describe('types', () => {
       Store<string>
     >()
   })
+
+  test('promises', () => {
+    const atom1 = atom('1', () => api().setPromise())
+    const atom2 = atom('1', () => api().setPromise(undefined))
+    const atom3 = atom('1', () =>
+      api().setPromise().setPromise(Promise.resolve(2))
+    )
+
+    expectTypeOf<AtomPromiseType<typeof atom1>>().toBeUndefined()
+    expectTypeOf<AtomPromiseType<typeof atom2>>().toBeUndefined()
+    expectTypeOf<AtomPromiseType<typeof atom3>>().resolves.toBeNumber()
+  })
 })


### PR DESCRIPTION
## Description

The `.setPromise()` method currently only accepts a promise. This can be a little annoying to work with e.g. when using inline expressions to conditionally set the promise. Allow such expressions to resolve to `undefined` and make the types correctly reflect that an atom with such a returned api has a `Promise: undefined` type.