### PR TITLE
feat(atoms): improve non-TS `.getInstance()` usage by throwing helpful errors

### DIFF
--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -1,4 +1,4 @@
-import { createStore, is, isPlainObject } from '@zedux/core'
+import { createStore, detailedTypeof, is, isPlainObject } from '@zedux/core'
 import { internalStore } from '../store/index'
 import {
   AnyAtomInstance,
@@ -27,6 +27,7 @@ import { AtomInstanceBase } from './instances/AtomInstanceBase'
 import { Scheduler } from './Scheduler'
 import { SelectorCache, Selectors } from './Selectors'
 import { Mod, ZeduxPlugin } from './ZeduxPlugin'
+import { AtomTemplate } from './templates/AtomTemplate'
 
 const defaultMods = Object.keys(pluginActions).reduce((map, mod) => {
   map[mod as Mod] = 0
@@ -414,6 +415,24 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
     atom: A | AnyAtomInstance,
     params?: AtomParamsType<A>
   ) {
+    if (DEV) {
+      if (!atom || (!is(atom, AtomInstanceBase) && !is(atom, AtomTemplate))) {
+        throw new TypeError(
+          `Zedux: Expected an atom template or atom instance. Received ${detailedTypeof(
+            atom
+          )}`
+        )
+      }
+
+      if (typeof params !== 'undefined' && !Array.isArray(params)) {
+        throw new TypeError(
+          `Zedux: Expected atom params to be an array. Received ${detailedTypeof(
+            params
+          )}`
+        )
+      }
+    }
+
     if (is(atom, AtomInstanceBase)) {
       // if the passed atom instance is Destroyed, get(/create) the
       // non-Destroyed instance

--- a/packages/atoms/src/classes/templates/AtomTemplateBase.ts
+++ b/packages/atoms/src/classes/templates/AtomTemplateBase.ts
@@ -3,9 +3,9 @@ import {
   AtomValueOrFactory,
   AtomGenerics,
 } from '@zedux/atoms/types/index'
+import { prefix } from '@zedux/atoms/utils/index'
 import { Ecosystem } from '../Ecosystem'
 import { AtomInstance } from '../instances/AtomInstance'
-import { prefix } from '@zedux/atoms/utils'
 
 export abstract class AtomTemplateBase<
   G extends AtomGenerics,

--- a/packages/atoms/src/classes/templates/AtomTemplateBase.ts
+++ b/packages/atoms/src/classes/templates/AtomTemplateBase.ts
@@ -5,11 +5,14 @@ import {
 } from '@zedux/atoms/types/index'
 import { Ecosystem } from '../Ecosystem'
 import { AtomInstance } from '../instances/AtomInstance'
+import { prefix } from '@zedux/atoms/utils'
 
 export abstract class AtomTemplateBase<
   G extends AtomGenerics,
   InstanceType extends AtomInstance<G>
 > {
+  public static $$typeof = Symbol.for(`${prefix}/AtomTemplateBase`)
+
   public readonly dehydrate?: AtomConfig<G['State']>['dehydrate']
   public readonly flags?: string[]
   public readonly hydrate?: AtomConfig<G['State']>['hydrate']

--- a/packages/react/test/units/Ecosystem.test.tsx
+++ b/packages/react/test/units/Ecosystem.test.tsx
@@ -112,6 +112,25 @@ describe('Ecosystem', () => {
     expect(ecosystem.findAll()).toEqual(expected)
   })
 
+  test('getInstance() throws an error if bad values are passed', () => {
+    const atom1 = atom('1', (param: string) => param)
+
+    // @ts-expect-error first param must be an atom template or instance
+    expect(() => ecosystem.getInstance({})).toThrowError(
+      /Expected an atom template or atom instance. Received object/i
+    )
+
+    // @ts-expect-error first param must be an atom template or instance
+    expect(() => ecosystem.getInstance()).toThrowError(
+      /Expected an atom template or atom instance. Received undefined/i
+    )
+
+    // @ts-expect-error second param must be an array or undefined
+    expect(() => ecosystem.getInstance(atom1, 'a')).toThrowError(
+      /Expected atom params to be an array. Received string/i
+    )
+  })
+
   test("registerPlugin() ignores the plugin if it's already registered", () => {
     const plugin = new ZeduxPlugin()
 


### PR DESCRIPTION
## Description

When using JS (non-TS), it's much easier to forget to pass something. It's ugly seeing Zedux throw errors from trying to use undefined values, etc. Throw helpful error messages instead in the most common case - when a non-template/instance is passed (directly or indirectly) to `ecosystem.getInstance()`