### PR TITLE
refactor: micro-optimize store and graph operations

### DIFF
--- a/packages/atoms/src/classes/EvaluationStack.ts
+++ b/packages/atoms/src/classes/EvaluationStack.ts
@@ -103,10 +103,6 @@ export class EvaluationStack {
     }
   }
 
-  public isEvaluating(id: string) {
-    return stack.some(item => item.node.id === id)
-  }
-
   public finish() {
     const item = stack.pop()
     const { _idGenerator, _mods, modBus } = this.ecosystem
@@ -129,11 +125,11 @@ export class EvaluationStack {
     return stack[stack.length - 1]
   }
 
-  public start(item: AnyAtomInstance | SelectorCache<any, any>) {
+  public start(node: AnyAtomInstance | SelectorCache<any, any>) {
     const { _idGenerator, _mods, _scheduler } = this.ecosystem
 
     const newItem: StackItem = {
-      node: item,
+      node,
       start: _mods.evaluationFinished ? _idGenerator.now(true) : undefined,
     }
 

--- a/packages/atoms/src/classes/Selectors.ts
+++ b/packages/atoms/src/classes/Selectors.ts
@@ -131,9 +131,9 @@ export class Selectors {
 
     const node = this.ecosystem._graph.nodes[id]
 
-    if (!force && Object.keys(node.dependents).length) return
-
-    this._destroySelector(id)
+    if (force || !node.refCount) {
+      this._destroySelector(id)
+    }
   }
 
   /**

--- a/packages/atoms/src/classes/instances/AtomInstance.ts
+++ b/packages/atoms/src/classes/instances/AtomInstance.ts
@@ -123,10 +123,7 @@ export class AtomInstance<G extends AtomGenerics> extends AtomInstanceBase<
     if (this.status === 'Destroyed') return
 
     // If we're not force-destroying, don't destroy if there are dependents
-    if (
-      !force &&
-      Object.keys(this.ecosystem._graph.nodes[this.id]?.dependents || {}).length
-    ) {
+    if (!force && this.ecosystem._graph.nodes[this.id]?.refCount) {
       return
     }
 

--- a/packages/atoms/src/injectors/injectStore.ts
+++ b/packages/atoms/src/injectors/injectStore.ts
@@ -12,10 +12,7 @@ export const doSubscribe = <State>(
     // during evaluation. TODO: Create an ecosystem-level flag to turn on
     // warning logging for state-updates-during-evaluation, since this may be
     // considered an anti-pattern.
-    if (
-      instance.ecosystem._evaluationStack.isEvaluating(instance.id) ||
-      action.meta === zeduxTypes.ignore
-    ) {
+    if (instance._isEvaluating || action.meta === zeduxTypes.ignore) {
       return
     }
 

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -199,8 +199,8 @@ export interface EcosystemConfig<
 }
 
 export interface EcosystemGraphNode {
-  dependencies: Record<string, true>
-  dependents: Record<string, DependentEdge>
+  dependencies: Map<string, true>
+  dependents: Map<string, DependentEdge>
   isSelector?: boolean
   refCount: number
   weight: number

--- a/packages/immer/src/injectImmerStore.ts
+++ b/packages/immer/src/injectImmerStore.ts
@@ -20,7 +20,7 @@ const doSubscribe = <State>(
     // during evaluation or that are caused by `zeduxTypes.ignore` actions
     if (
       newState === oldState ||
-      instance.ecosystem._evaluationStack.isEvaluating(instance.id) ||
+      instance._isEvaluating ||
       action?.meta === zeduxTypes.ignore
     ) {
       return

--- a/packages/machines/src/injectMachineStore.ts
+++ b/packages/machines/src/injectMachineStore.ts
@@ -279,7 +279,7 @@ export const injectMachineStore: <
           if (
             !subscribeRef.current ||
             newState === oldState ||
-            instance.ecosystem._evaluationStack.isEvaluating(instance.id) ||
+            instance._isEvaluating ||
             action?.meta === zeduxTypes.ignore
           ) {
             return

--- a/packages/react/src/hooks/useAtomInstance.ts
+++ b/packages/react/src/hooks/useAtomInstance.ts
@@ -83,7 +83,9 @@ export const useAtomInstance: {
     return [
       (onStoreChange: () => void) => {
         // this function must be idempotent
-        if (!ecosystem._graph.nodes[instance.id]?.dependents[dependentKey]) {
+        if (
+          !ecosystem._graph.nodes[instance.id]?.dependents.get(dependentKey)
+        ) {
           // React can unmount other components before calling this subscribe
           // function but after we got the instance above. Re-get the instance
           // if such unmountings destroyed it in the meantime:

--- a/packages/react/src/hooks/useAtomSelector.ts
+++ b/packages/react/src/hooks/useAtomSelector.ts
@@ -42,8 +42,7 @@ const isRefDifferent = (
   const oldSelector = cacheRef.current.selectorRef
   if (newSelector === oldSelector) return false
 
-  const { dependents } = _graph.nodes[cacheRef.current.id]
-  if (Object.keys(dependents).length !== 1) return true
+  if (_graph.nodes[cacheRef.current.id].refCount !== 1) return true
 
   const newIsFunction = typeof newSelector === 'function'
   const oldIsFunction = typeof oldSelector === 'function'
@@ -121,7 +120,7 @@ export const useAtomSelector = <T, Args extends any[]>(
         if (glob.IS_REACT_ACT_ENVIRONMENT) onStoreChange()
 
         // this function must be idempotent
-        if (!_graph.nodes[cache.id]?.dependents[dependentKey]) {
+        if (!_graph.nodes[cache.id]?.dependents.get(dependentKey)) {
           // React can unmount other components before calling this subscribe
           // function but after we got the cache above. Re-get the cache
           // if such unmountings destroyed it in the meantime:

--- a/packages/react/test/integrations/__snapshots__/graph.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/graph.test.tsx.snap
@@ -1,5 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`graph getInstance(atom) returns the instance 1`] = `
+{
+  "atom1": {
+    "dependencies": Map {},
+    "dependents": Map {
+      "ion1" => {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 4,
+        "operation": "getInstance",
+      },
+    },
+    "isSelector": undefined,
+    "refCount": 1,
+    "weight": 1,
+  },
+  "atom2": {
+    "dependencies": Map {},
+    "dependents": Map {
+      "ion1" => {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 4,
+        "operation": "getInstance",
+      },
+    },
+    "isSelector": undefined,
+    "refCount": 1,
+    "weight": 1,
+  },
+  "ion1": {
+    "dependencies": Map {
+      "atom1" => true,
+      "atom2" => true,
+    },
+    "dependents": Map {},
+    "isSelector": undefined,
+    "refCount": 0,
+    "weight": 1,
+  },
+}
+`;
+
 exports[`graph injectAtomGetters 1`] = `
 {
   "atom1": {
@@ -71,6 +114,99 @@ exports[`graph injectAtomGetters 3`] = `
   "atom2": {},
   "atom3": {
     "atom4": {},
+  },
+}
+`;
+
+exports[`graph on reevaluation, get() updates the graph 1`] = `
+{
+  "a": {
+    "dependencies": Map {},
+    "dependents": Map {
+      "d" => {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 0,
+        "operation": "injectAtomValue",
+      },
+    },
+    "isSelector": undefined,
+    "refCount": 1,
+    "weight": 1,
+  },
+  "b-["b"]": {
+    "dependencies": Map {},
+    "dependents": Map {
+      "d" => {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 0,
+        "operation": "get",
+      },
+    },
+    "isSelector": undefined,
+    "refCount": 1,
+    "weight": 1,
+  },
+  "d": {
+    "dependencies": Map {
+      "a" => true,
+      "b-["b"]" => true,
+    },
+    "dependents": Map {},
+    "isSelector": undefined,
+    "refCount": 0,
+    "weight": 3,
+  },
+}
+`;
+
+exports[`graph on reevaluation, get() updates the graph 2`] = `
+{
+  "a": {
+    "dependencies": Map {},
+    "dependents": Map {
+      "d" => {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 0,
+        "operation": "injectAtomValue",
+      },
+    },
+    "isSelector": undefined,
+    "refCount": 1,
+    "weight": 1,
+  },
+  "b-["b"]": {
+    "dependencies": Map {},
+    "dependents": Map {},
+    "isSelector": undefined,
+    "refCount": 0,
+    "weight": 1,
+  },
+  "c": {
+    "dependencies": Map {},
+    "dependents": Map {
+      "d" => {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 0,
+        "operation": "get",
+      },
+    },
+    "isSelector": undefined,
+    "refCount": 1,
+    "weight": 1,
+  },
+  "d": {
+    "dependencies": Map {
+      "a" => true,
+      "c" => true,
+    },
+    "dependents": Map {},
+    "isSelector": undefined,
+    "refCount": 0,
+    "weight": 3,
   },
 }
 `;

--- a/packages/react/test/integrations/__snapshots__/selection.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/selection.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`selection same-name selectors share the namespace when destroyed and recreated at different times 1`] = `
 {
   "1": {
-    "dependencies": {
-      "@@selector-common-name-0": true,
+    "dependencies": Map {
+      "@@selector-common-name-0" => true,
     },
-    "dependents": {
-      "no-1": {
+    "dependents": Map {
+      "no-1" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 3,
@@ -19,11 +19,11 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "weight": 3,
   },
   "@@selector-common-name-0": {
-    "dependencies": {
-      "root": true,
+    "dependencies": Map {
+      "root" => true,
     },
-    "dependents": {
-      "1": {
+    "dependents": Map {
+      "1" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -35,9 +35,9 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "weight": 2,
   },
   "root": {
-    "dependencies": {},
-    "dependents": {
-      "@@selector-common-name-0": {
+    "dependencies": Map {},
+    "dependents": Map {
+      "@@selector-common-name-0" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -54,11 +54,11 @@ exports[`selection same-name selectors share the namespace when destroyed and re
 exports[`selection same-name selectors share the namespace when destroyed and recreated at different times 2`] = `
 {
   "2": {
-    "dependencies": {
-      "@@selector-common-name-2": true,
+    "dependencies": Map {
+      "@@selector-common-name-2" => true,
     },
-    "dependents": {
-      "no-3": {
+    "dependents": Map {
+      "no-3" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 3,
@@ -70,11 +70,11 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "weight": 3,
   },
   "@@selector-common-name-2": {
-    "dependencies": {
-      "root": true,
+    "dependencies": Map {
+      "root" => true,
     },
-    "dependents": {
-      "2": {
+    "dependents": Map {
+      "2" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -86,9 +86,9 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "weight": 2,
   },
   "root": {
-    "dependencies": {},
-    "dependents": {
-      "@@selector-common-name-2": {
+    "dependencies": Map {},
+    "dependents": Map {
+      "@@selector-common-name-2" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -105,11 +105,11 @@ exports[`selection same-name selectors share the namespace when destroyed and re
 exports[`selection same-name selectors share the namespace when destroyed and recreated at different times 3`] = `
 {
   "1": {
-    "dependencies": {
-      "@@selector-common-name-4": true,
+    "dependencies": Map {
+      "@@selector-common-name-4" => true,
     },
-    "dependents": {
-      "no-5": {
+    "dependents": Map {
+      "no-5" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 3,
@@ -121,11 +121,11 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "weight": 3,
   },
   "2": {
-    "dependencies": {
-      "@@selector-common-name-2": true,
+    "dependencies": Map {
+      "@@selector-common-name-2" => true,
     },
-    "dependents": {
-      "no-3": {
+    "dependents": Map {
+      "no-3" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 3,
@@ -137,11 +137,11 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "weight": 3,
   },
   "@@selector-common-name-2": {
-    "dependencies": {
-      "root": true,
+    "dependencies": Map {
+      "root" => true,
     },
-    "dependents": {
-      "2": {
+    "dependents": Map {
+      "2" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -153,11 +153,11 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "weight": 2,
   },
   "@@selector-common-name-4": {
-    "dependencies": {
-      "root": true,
+    "dependencies": Map {
+      "root" => true,
     },
-    "dependents": {
-      "1": {
+    "dependents": Map {
+      "1" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -169,15 +169,15 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "weight": 2,
   },
   "root": {
-    "dependencies": {},
-    "dependents": {
-      "@@selector-common-name-2": {
+    "dependencies": Map {},
+    "dependents": Map {
+      "@@selector-common-name-2" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
       },
-      "@@selector-common-name-4": {
+      "@@selector-common-name-4" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -194,11 +194,11 @@ exports[`selection same-name selectors share the namespace when destroyed and re
 exports[`selection same-name selectors share the namespace when destroyed and recreated at different times 4`] = `
 {
   "1": {
-    "dependencies": {
-      "@@selector-common-name-4": true,
+    "dependencies": Map {
+      "@@selector-common-name-4" => true,
     },
-    "dependents": {
-      "no-5": {
+    "dependents": Map {
+      "no-5" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 3,
@@ -210,11 +210,11 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "weight": 3,
   },
   "@@selector-common-name-4": {
-    "dependencies": {
-      "root": true,
+    "dependencies": Map {
+      "root" => true,
     },
-    "dependents": {
-      "1": {
+    "dependents": Map {
+      "1" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -226,9 +226,9 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "weight": 2,
   },
   "root": {
-    "dependencies": {},
-    "dependents": {
-      "@@selector-common-name-4": {
+    "dependencies": Map {},
+    "dependents": Map {
+      "@@selector-common-name-4" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,

--- a/packages/react/test/integrations/graph.test.tsx
+++ b/packages/react/test/integrations/graph.test.tsx
@@ -16,7 +16,6 @@ import {
   AtomGetters,
   EvaluationReason,
 } from '@zedux/react'
-import { Static } from '@zedux/react/utils'
 import React from 'react'
 import { ecosystem } from '../utils/ecosystem'
 import { renderInEcosystem } from '../utils/renderInEcosystem'
@@ -72,20 +71,20 @@ describe('graph', () => {
       operation: 'get',
     }
 
-    expect(ecosystem._graph.nodes.atom1.dependents).toEqual({
-      atom4: expectedEdges,
-    })
+    expect([...ecosystem._graph.nodes.atom1.dependents.entries()]).toEqual([
+      ['atom4', expectedEdges],
+    ])
 
-    expect(ecosystem._graph.nodes.atom2.dependents).toEqual({
-      atom4: expectedEdges,
-    })
+    expect([...ecosystem._graph.nodes.atom2.dependents.entries()]).toEqual([
+      ['atom4', expectedEdges],
+    ])
 
     expect(ecosystem._graph.nodes.atom3).toBeUndefined()
 
-    expect(ecosystem._graph.nodes.atom4.dependencies).toEqual({
-      atom1: true,
-      atom2: true,
-    })
+    expect([...ecosystem._graph.nodes.atom4.dependencies.entries()]).toEqual([
+      ['atom1', true],
+      ['atom2', true],
+    ])
 
     const button = await findByText('toggle')
 
@@ -96,20 +95,20 @@ describe('graph', () => {
 
     expect(div).toHaveTextContent('4')
 
-    expect(ecosystem._graph.nodes.atom1.dependents).toEqual({
-      atom4: expectedEdges,
-    })
+    expect([...ecosystem._graph.nodes.atom1.dependents.entries()]).toEqual([
+      ['atom4', expectedEdges],
+    ])
 
-    expect(ecosystem._graph.nodes.atom2.dependents).toEqual({})
+    expect([...ecosystem._graph.nodes.atom2.dependents.entries()]).toEqual([])
 
-    expect(ecosystem._graph.nodes.atom3.dependents).toEqual({
-      atom4: expectedEdges,
-    })
+    expect([...ecosystem._graph.nodes.atom3.dependents.entries()]).toEqual([
+      ['atom4', expectedEdges],
+    ])
 
-    expect(ecosystem._graph.nodes.atom4.dependencies).toEqual({
-      atom1: true,
-      atom3: true,
-    })
+    expect([...ecosystem._graph.nodes.atom4.dependencies.entries()]).toEqual([
+      ['atom1', true],
+      ['atom3', true],
+    ])
 
     expect(ecosystem.viewGraph()).toMatchSnapshot()
     expect(ecosystem.viewGraph('bottom-up')).toMatchSnapshot()
@@ -140,43 +139,7 @@ describe('graph', () => {
       ion1: expect.any(Object),
     })
 
-    expect(ecosystem._graph.nodes).toEqual({
-      atom1: {
-        dependencies: {},
-        dependents: {
-          ion1: {
-            callback: undefined,
-            createdAt: expect.any(Number),
-            flags: Static,
-            operation: 'getInstance',
-          },
-        },
-        isSelector: undefined,
-        refCount: 1,
-        weight: 1,
-      },
-      atom2: {
-        dependencies: {},
-        dependents: {
-          ion1: {
-            callback: undefined,
-            createdAt: expect.any(Number),
-            flags: Static,
-            operation: 'getInstance',
-          },
-        },
-        isSelector: undefined,
-        refCount: 1,
-        weight: 1,
-      },
-      ion1: {
-        dependencies: { atom1: true, atom2: true },
-        dependents: {},
-        isSelector: undefined,
-        refCount: 0,
-        weight: 1, // static dependencies don't affect the weight
-      },
-    })
+    expect(ecosystem._graph.nodes).toMatchSnapshot()
 
     expect(evaluations).toEqual([1])
 
@@ -202,98 +165,13 @@ describe('graph', () => {
 
     const instance = ecosystem.getInstance(atomD)
 
-    expect(ecosystem._graph.nodes).toEqual({
-      a: {
-        dependencies: {},
-        dependents: {
-          d: {
-            callback: undefined,
-            createdAt: expect.any(Number),
-            flags: 0,
-            operation: 'injectAtomValue',
-          },
-        },
-        isSelector: undefined,
-        refCount: 1,
-        weight: 1,
-      },
-      'b-["b"]': {
-        dependencies: {},
-        dependents: {
-          d: {
-            callback: undefined,
-            createdAt: expect.any(Number),
-            flags: 0,
-            operation: 'get',
-          },
-        },
-        isSelector: undefined,
-        refCount: 1,
-        weight: 1,
-      },
-      d: {
-        dependencies: {
-          a: true,
-          'b-["b"]': true,
-        },
-        dependents: {},
-        isSelector: undefined,
-        refCount: 0,
-        weight: 3,
-      },
-    })
+    expect(ecosystem._graph.nodes).toMatchSnapshot()
 
     useB = false
     instance.invalidate()
     jest.runAllTimers()
 
-    expect(ecosystem._graph.nodes).toEqual({
-      a: {
-        dependencies: {},
-        dependents: {
-          d: {
-            callback: undefined,
-            createdAt: expect.any(Number),
-            flags: 0,
-            operation: 'injectAtomValue',
-          },
-        },
-        isSelector: undefined,
-        refCount: 1,
-        weight: 1,
-      },
-      'b-["b"]': {
-        dependencies: {},
-        dependents: {},
-        isSelector: undefined,
-        refCount: 0,
-        weight: 1,
-      },
-      c: {
-        dependencies: {},
-        dependents: {
-          d: {
-            callback: undefined,
-            createdAt: expect.any(Number),
-            flags: 0,
-            operation: 'get',
-          },
-        },
-        isSelector: undefined,
-        refCount: 1,
-        weight: 1,
-      },
-      d: {
-        dependencies: {
-          a: true,
-          c: true,
-        },
-        dependents: {},
-        isSelector: undefined,
-        refCount: 0,
-        weight: 3,
-      },
-    })
+    expect(ecosystem._graph.nodes).toMatchSnapshot()
   })
 
   test('atom instances can be passed as atom params', () => {


### PR DESCRIPTION
## Description

Use maps instead of objects for tracking graph dependencies and dependents. These are much faster to iterate over according to [this benchmark](https://jsbench.me/49lhtusot1/1). Some local testing shows that these changes increase speed by up to 4x in some cases.

Also set the `store._isSolo` property instead of deriving it for a tiny speed gain. Also set the `instance._isEvaluating` property instead of deriving it from the evaluation stack for even more tiny speed gains.

Also improve bundle size a little bit.

## Affects

atoms, core, immer, machines, react