### PR TITLE
release: v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## v1.0.2 (May 19, 2023)
+
+Zedux got a big speed boost! In practice it won't matter much, but Zedux should now perform even better on stress tests and benchmarks. Enjoy!
+
+### New Features:
+
+- `atoms`: allow setting promise to undefined in AtomApi (#58)
+- `atoms`: improve graph perf by removing unnecessary `Object.keys()` calls (#52)
+- `atoms`: improve non-TS `.getInstance()` usage by throwing helpful errors (#59)
+- `atoms`, `react`: make atoms package fully framework agnostic (#51)
+
+### Fixes:
+
+- `atoms`: improve atom searching (#57)
+- `atoms`: make it easier for TS to infer AtomApi types from chained methods (#49)
+- `react`: make React imports specify file extensions in esm builds (#53)
+- `react`: update React peer dep to a minimum of v16.3.0 (#54)
+- `atoms`, `react`: improve overloads of atom-template-accepting functions for paramless atoms (#50)
+- `atoms`, `core`, `immer`, `machines`, `react`: fix package.json export order (#56)
+
 ## v1.0.1 (Apr 28, 2023)
 
 ### Fixes:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zedux",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Molecular State Engine for React",
   "type": "module",
   "author": "Joshua Claunch (bowheart <bowheart31@gmail.com>)",

--- a/packages/atoms/package.json
+++ b/packages/atoms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/atoms",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/core": "^1.0.1"
+    "@zedux/core": "^1.0.2"
   },
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A high-level, declarative, composable form of Redux",
   "main": "./dist/zedux.umd.js",
   "module": "./dist/esm/index.js",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/immer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Official Immer integration for Zedux's store and atomic APIs",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "devDependencies": {
-    "@zedux/atoms": "^1.0.1",
+    "@zedux/atoms": "^1.0.2",
     "immer": "^9.0.21"
   },
   "exports": {
@@ -41,7 +41,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/atoms": "^1.0.1",
+    "@zedux/atoms": "^1.0.2",
     "immer": ">=9.0.19"
   },
   "repository": {

--- a/packages/machines/package.json
+++ b/packages/machines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/machines",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Simple native state machine implementation for Zedux atoms",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "devDependencies": {
-    "@zedux/atoms": "^1.0.1"
+    "@zedux/atoms": "^1.0.2"
   },
   "exports": {
     ".": {
@@ -41,7 +41,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/atoms": "^1.0.1"
+    "@zedux/atoms": "^1.0.2"
   },
   "repository": {
     "directory": "packages/machines",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/react",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/atoms": "^1.0.1",
+    "@zedux/atoms": "^1.0.2",
     "use-sync-external-store": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Increment monorepo package versions and update the CHANGELOG for version 1.0.2.

This PR was generated by the release script at https://github.com/Omnistac/zedux/tree/master/scripts/release.js

The packages will be published to npm and a GitHub release will be created after this PR merges.