### PR TITLE
fix(atoms): make data retention consistent across `injectPromise` and `api(promise)`

### DIFF
--- a/packages/atoms/src/injectors/injectPromise.ts
+++ b/packages/atoms/src/injectors/injectPromise.ts
@@ -1,4 +1,4 @@
-import { detailedTypeof, Store } from '@zedux/core'
+import { detailedTypeof, RecursivePartial, Store } from '@zedux/core'
 import { api } from '../factories/api'
 import {
   getErrorPromiseState,
@@ -119,7 +119,12 @@ export const injectPromise: {
 
     if (!dataOnly) {
       // preserve previous data and error using setStateDeep:
-      store.setStateDeep(getInitialPromiseState())
+      store.setStateDeep(
+        state =>
+          getInitialPromiseState(
+            (state as PromiseState<T>).data
+          ) as RecursivePartial<PromiseState<T>>
+      )
     }
 
     promise

--- a/packages/react/test/integrations/promises.test.tsx
+++ b/packages/react/test/integrations/promises.test.tsx
@@ -1,0 +1,67 @@
+import { atom, injectAtomValue, injectPromise } from '@zedux/react'
+import { ecosystem } from '../utils/ecosystem'
+
+const reloadAtom = atom('reload', 0)
+
+const promiseAtom = atom('promise', () => {
+  const reloadCounter = injectAtomValue(reloadAtom)
+
+  const atomApi = injectPromise(
+    () =>
+      new Promise(resolve => {
+        setTimeout(() => resolve(reloadCounter), 1)
+      }),
+    [reloadCounter]
+  )
+
+  return atomApi
+})
+
+describe('promises', () => {
+  test('injectPromise retains data during reload', async () => {
+    jest.useFakeTimers()
+
+    const promiseInstance = ecosystem.getInstance(promiseAtom)
+    const reloadInstance = ecosystem.getInstance(reloadAtom)
+
+    expect(promiseInstance.getState()).toEqual({
+      data: undefined,
+      isError: false,
+      isLoading: true,
+      isSuccess: false,
+      status: 'loading',
+    })
+
+    jest.runAllTimers()
+    await Promise.resolve() // wait for injectPromise's .then to run
+
+    expect(promiseInstance.getState()).toEqual({
+      data: 0,
+      isError: false,
+      isLoading: false,
+      isSuccess: true,
+      status: 'success',
+    })
+
+    reloadInstance.setState(1)
+
+    expect(promiseInstance.getState()).toEqual({
+      data: 0,
+      isError: false,
+      isLoading: true,
+      isSuccess: false,
+      status: 'loading',
+    })
+
+    jest.runAllTimers()
+    await Promise.resolve() // wait for injectPromise's .then to run
+
+    expect(promiseInstance.getState()).toEqual({
+      data: 1,
+      isError: false,
+      isLoading: false,
+      isSuccess: true,
+      status: 'success',
+    })
+  })
+})


### PR DESCRIPTION
## Description

`injectPromise()` currently clears the previous `.data` when the promise factory reruns. This is inconsistent with how query atoms work and isn't useful.

Make `.data` persist across reruns.