### PR TITLE
fix(atoms): let the WeakMap clean up selector ref keys

### DIFF
--- a/packages/atoms/src/classes/Selectors.ts
+++ b/packages/atoms/src/classes/Selectors.ts
@@ -294,7 +294,9 @@ export class Selectors {
     _graph.removeNode(id)
     delete this._items[id]
     cache.isDestroyed = true
-    this._refBaseKeys.delete(cache.selectorRef)
+    // don't delete the ref from this._refBaseKeys; this selector cache isn't
+    // necessarily the only one using it (if the selector takes params). Just
+    // let the WeakMap clean itself up.
 
     if (_mods.statusChanged) {
       modBus.dispatch(

--- a/packages/react/test/integrations/__snapshots__/selection.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/selection.test.tsx.snap
@@ -106,10 +106,10 @@ exports[`selection same-name selectors share the namespace when destroyed and re
 {
   "1": {
     "dependencies": Map {
-      "@@selector-common-name-4" => true,
+      "@@selector-common-name-0" => true,
     },
     "dependents": Map {
-      "no-5" => {
+      "no-4" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 3,
@@ -136,12 +136,12 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "refCount": 1,
     "weight": 3,
   },
-  "@@selector-common-name-2": {
+  "@@selector-common-name-0": {
     "dependencies": Map {
       "root" => true,
     },
     "dependents": Map {
-      "2" => {
+      "1" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -152,12 +152,12 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "refCount": 1,
     "weight": 2,
   },
-  "@@selector-common-name-4": {
+  "@@selector-common-name-2": {
     "dependencies": Map {
       "root" => true,
     },
     "dependents": Map {
-      "1" => {
+      "2" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -177,7 +177,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
         "flags": 0,
         "operation": "get",
       },
-      "@@selector-common-name-4" => {
+      "@@selector-common-name-0" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -195,10 +195,10 @@ exports[`selection same-name selectors share the namespace when destroyed and re
 {
   "1": {
     "dependencies": Map {
-      "@@selector-common-name-4" => true,
+      "@@selector-common-name-0" => true,
     },
     "dependents": Map {
-      "no-5" => {
+      "no-4" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 3,
@@ -209,7 +209,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "refCount": 1,
     "weight": 3,
   },
-  "@@selector-common-name-4": {
+  "@@selector-common-name-0": {
     "dependencies": Map {
       "root" => true,
     },
@@ -228,7 +228,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
   "root": {
     "dependencies": Map {},
     "dependents": Map {
-      "@@selector-common-name-4" => {
+      "@@selector-common-name-0" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,

--- a/packages/react/test/units/Selectors.test.tsx
+++ b/packages/react/test/units/Selectors.test.tsx
@@ -62,8 +62,9 @@ describe('the Selectors class', () => {
     ecosystem.selectors.destroyCache(cache2b) // destroys only selector2
 
     expect(ecosystem.selectors._items).toEqual({
-      // id # is 3 by now 'cause #1 was destroyed with cache2a above
-      '@@selector-selector1-3': expect.any(Object),
+      // id # is still 1 'cause the Selector class's `_refBaseKeys` still holds
+      // the cached key despite `cache2b`'s destruction above
+      '@@selector-selector1-1': expect.any(Object),
     })
 
     cleanup()
@@ -115,8 +116,10 @@ describe('the Selectors class', () => {
     expect(cache1.isDestroyed).toBe(true)
     expect(cache2.isDestroyed).toBe(true)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-selector1-4': 'ab', // id # 4 - selector was recreated
-      '@@selector-selector2-3': 'abc', // id # 3 - selector was recreated
+      // ids 2 & 1 - the refs are still cached in the Selector class's
+      // `_refBaseKeys`
+      '@@selector-selector1-2': 'ab',
+      '@@selector-selector2-1': 'abc',
       '@@selector-selector3-0': 'abcd',
     })
 


### PR DESCRIPTION
## Description

Selectors with params can have multiple selector cache entries reusing the same `_refBaseKeys` entry. When one of these selectors is destroyed, it shouldn't delete the `_refBaseKeys` WeakMap entry - other selector caches could still be using it. Let the WeakMap clean up after itself instead.