### PR TITLE
fix(atoms): make query atoms retain data

### DIFF
--- a/packages/atoms/src/classes/instances/AtomInstance.ts
+++ b/packages/atoms/src/classes/instances/AtomInstance.ts
@@ -511,7 +511,8 @@ export class AtomInstance<G extends AtomGenerics> extends AtomInstanceBase<
   }
 
   private _setPromise(promise: Promise<any>, isStateUpdater?: boolean) {
-    if (promise === this.promise) return this.store.getState()
+    const currentState = this.store?.getState()
+    if (promise === this.promise) return currentState
 
     this.promise = promise as G['Promise']
 
@@ -541,7 +542,7 @@ export class AtomInstance<G extends AtomGenerics> extends AtomInstanceBase<
         )
       })
 
-    const state: PromiseState<any> = getInitialPromiseState()
+    const state: PromiseState<any> = getInitialPromiseState(currentState?.data)
     this._promiseStatus = state.status
 
     this.ecosystem._graph.scheduleDependents(


### PR DESCRIPTION
## Description

#65 made `injectPromise` retain the `.data` property during refetch. Query atoms apparently still don't have this functionality. Change that.