### PR TITLE
feat(atoms): add `runOnInvalidate` option to `injectPromise`

### DIFF
--- a/docs/docs/api/injectors/injectPromise.mdx
+++ b/docs/docs/api/injectors/injectPromise.mdx
@@ -73,17 +73,19 @@ It also gives you access to the promise and store so you can compose them with o
   <T>(
     promiseFactory: (controller?: AbortController) => Promise<T>,
     deps: InjectorDeps,
-    config: { initialState?: T; dataOnly: true } & InjectStoreConfig
+    config: Omit<InjectPromiseConfig, 'dataOnly'> & {
+      dataOnly: true
+    } & InjectStoreConfig
   ): AtomApi<{
     Exports: Record<string, any>
     Promise: Promise<T>
     State: T
     Store: Store<T>
-  }>\n
+  }>
   <T>(
     promiseFactory: (controller?: AbortController) => Promise<T>,
     deps?: InjectorDeps,
-    config?: { initialState?: T; dataOnly?: boolean } & InjectStoreConfig
+    config?: InjectPromiseConfig<T> & InjectStoreConfig
   ): AtomApi<{
     Exports: Record<string, any>
     Promise: Promise<T>
@@ -143,7 +145,7 @@ store.getState() // <the data>
   </Item>
   <Item name="config">
     <p>Optional. An object with the following optional properties:</p>
-    <Ts>{`{ dataOnly, initialState, ...storeConfig }`}</Ts>
+    <Ts>{`{ dataOnly, initialState, runOnInvalidate, ...storeConfig }`}</Ts>
     <Legend>
       <Item name="dataOnly">
         <p>
@@ -170,6 +172,26 @@ store.getState() // <the data>
           Without this specified, the store's <code>data</code> will be{' '}
           <code>undefined</code> until the promise resolves
         </p>
+      </Item>
+      <Item name="runOnInvalidate">
+        <p>
+          Optional. Boolean. Default <code>false.</code>
+        </p>
+        <p>
+          If true, the promise factory will rerun when the current atom instance
+          reevaluates due to an{' '}
+          <Link to="../classes/AtomInstance#invalidate">
+            <code>invalidate</code>
+          </Link>{' '}
+          call.
+        </p>
+        <p>Essentially a shorthand for doing this yourself:</p>
+        <Ts>{`const reasons = injectWhy()
+const counterRef = injectRef(0)\n
+if (reasons.some(reason => reason.type === 'cache invalidated')) {
+  counterRef.current++
+}\n
+const promiseApi = injectPromise(myPromiseFactory, [counterRef.current])`}</Ts>
       </Item>
       <Item name="storeConfig">
         <p>Optional. Configuration properties for the created store.</p>

--- a/packages/atoms/src/injectors/injectPromise.ts
+++ b/packages/atoms/src/injectors/injectPromise.ts
@@ -66,10 +66,8 @@ export const injectPromise: {
   <T>(
     promiseFactory: (controller?: AbortController) => Promise<T>,
     deps: InjectorDeps,
-    config: {
+    config: Omit<InjectPromiseConfig, 'dataOnly'> & {
       dataOnly: true
-      initialState?: T
-      runOnInvalidate?: boolean
     } & InjectStoreConfig
   ): AtomApi<{
     Exports: Record<string, any>

--- a/packages/atoms/src/injectors/injectPromise.ts
+++ b/packages/atoms/src/injectors/injectPromise.ts
@@ -5,12 +5,18 @@ import {
   getInitialPromiseState,
   getSuccessPromiseState,
 } from '../utils/promiseUtils'
-import { InjectorDeps, InjectStoreConfig, PromiseState } from '../types/index'
+import {
+  InjectorDeps,
+  InjectPromiseConfig,
+  InjectStoreConfig,
+  PromiseState,
+} from '../types/index'
 import { injectEffect } from './injectEffect'
 import { injectMemo } from './injectMemo'
 import { injectStore } from './injectStore'
 import { injectRef } from './injectRef'
 import { AtomApi } from '../classes/AtomApi'
+import { injectWhy } from './injectWhy'
 
 /**
  * Create a memoized promise reference. Kicks off the promise immediately
@@ -60,7 +66,11 @@ export const injectPromise: {
   <T>(
     promiseFactory: (controller?: AbortController) => Promise<T>,
     deps: InjectorDeps,
-    config: { initialState?: T; dataOnly: true } & InjectStoreConfig
+    config: {
+      dataOnly: true
+      initialState?: T
+      runOnInvalidate?: boolean
+    } & InjectStoreConfig
   ): AtomApi<{
     Exports: Record<string, any>
     Promise: Promise<T>
@@ -71,7 +81,7 @@ export const injectPromise: {
   <T>(
     promiseFactory: (controller?: AbortController) => Promise<T>,
     deps?: InjectorDeps,
-    config?: { initialState?: T; dataOnly?: boolean } & InjectStoreConfig
+    config?: InjectPromiseConfig<T> & InjectStoreConfig
   ): AtomApi<{
     Exports: Record<string, any>
     Promise: Promise<T>
@@ -84,17 +94,28 @@ export const injectPromise: {
   {
     dataOnly,
     initialState,
+    runOnInvalidate,
     ...storeConfig
-  }: { dataOnly?: boolean; initialState?: T } & InjectStoreConfig = {}
+  }: InjectPromiseConfig<T> & InjectStoreConfig = {}
 ) => {
-  const refs = injectRef(
-    {} as { controller?: AbortController; promise: Promise<T> }
-  )
+  const refs = injectRef({ counter: 0 } as {
+    controller?: AbortController
+    counter: number
+    promise: Promise<T>
+  })
 
   const store = injectStore(
     dataOnly ? initialState : getInitialPromiseState<T>(initialState),
     storeConfig
   )
+
+  if (
+    runOnInvalidate &&
+    // injectWhy is an unrestricted injector - using it conditionally is fine:
+    injectWhy().some(reason => reason.type === 'cache invalidated')
+  ) {
+    refs.current.counter++
+  }
 
   // setting a ref during evaluation is perfectly fine in Zedux
   refs.current.promise = injectMemo(() => {
@@ -141,7 +162,7 @@ export const injectPromise: {
       })
 
     return promise
-  }, deps)
+  }, deps && [...deps, refs.current.counter])
 
   injectEffect(
     () => () => {

--- a/packages/atoms/src/injectors/injectWhy.ts
+++ b/packages/atoms/src/injectors/injectWhy.ts
@@ -1,8 +1,8 @@
 import { readInstance } from '../classes/EvaluationStack'
 
 /**
- * A fake injector (can actually be used in loops and if statements). An alias
- * for:
+ * An "unrestricted" injector (can actually be used in loops and if statements).
+ * An alias for:
  *
  * ```ts
  * const { ecosystem } = injectAtomGetters()

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -265,6 +265,12 @@ export type InjectOrUseSelector<State, Params extends any[]> = Params extends []
   ? <D = any>(selector: (state: State) => D) => D
   : <D = any>(params: Params, selector: (state: State) => D) => D
 
+export interface InjectPromiseConfig<T = any> {
+  dataOnly?: boolean
+  initialState?: T
+  runOnInvalidate?: boolean
+}
+
 export interface InjectStoreConfig {
   hydrate?: boolean
   subscribe?: boolean


### PR DESCRIPTION
## Description

With query atoms, calling `instance.invalidate()` reevaluates the atom, thus recreating the promise. When migrating from a query atom to using `injectPromise` (a common task when more power is needed), `instance.invalidate()` is no longer sufficient to make the promise rerun.

There are many workarounds, but all are pretty inconvenient. This PR adds a `runOnInvalidate` config option to `injectPromise` itself to get the query atom behavior back.

```ts
const myPromiseAtom = atom(
  'myPromise',
  () => injectPromise(myPromiseFactory, [], { runOnInvalidate })
)

const myPromiseInstance = myEcosystem.getInstance(myPromiseAtom)

// now this will cause `myPromiseFactory` to rerun, updating the store's loading status:
myPromiseInstance.invalidate()
```