### PR TITLE
feat(atoms): deprecate `injectInvalidate` (prefer `injectSelf`)

### DIFF
--- a/docs/docs/api/injectors/injectInvalidate.mdx
+++ b/docs/docs/api/injectors/injectInvalidate.mdx
@@ -5,6 +5,18 @@ title: injectInvalidate
 
 import { Legend, Item, Link, Tabs, Ts, tab1, tab2 } from '@site/src/all'
 
+:::warning
+This injector is deprecated and will be removed in the next major release. Use the following pattern instead:
+
+```ts
+const self = injectSelf()
+// then in a callback or effect:
+self.invalidate()
+```
+
+See [`injectSelf()`](injectSelf)
+:::
+
 ```ts
 import { injectInvalidate } from '@zedux/react'
 ```

--- a/packages/atoms/src/injectors/injectInvalidate.ts
+++ b/packages/atoms/src/injectors/injectInvalidate.ts
@@ -1,5 +1,18 @@
 import { readInstance } from '../classes/EvaluationStack'
 
+/**
+ * Returns a function that can be called to invalidate the current atom
+ * instance.
+ *
+ * @deprecated This injector will be removed in the next major release. Use the
+ * following pattern instead:
+ *
+ * ```ts
+ * const self = injectSelf()
+ * // then in a callback or effect:
+ * self.invalidate()
+ * ```
+ */
 export const injectInvalidate = () => {
   const instance = readInstance()
 


### PR DESCRIPTION
## Description

Since we introduced `injectSelf`, `injectInvalidate` isn't necessary. Deprecate it. We'll plan to remove it in Zedux v2.

Use the following pattern instead:

```ts
const self = injectSelf()
// then in a callback or effect:
self.invalidate()
```