### PR TITLE
fix: prevent injectors from consuming hydrations

### DIFF
--- a/packages/atoms/src/classes/instances/AtomInstance.ts
+++ b/packages/atoms/src/classes/instances/AtomInstance.ts
@@ -230,11 +230,11 @@ export class AtomInstance<G extends AtomGenerics> extends AtomInstanceBase<
     this.ecosystem._graph.flushUpdates()
 
     // hydrate if possible
-    if (this.template.manualHydration) return
-
     const hydration = this.ecosystem._consumeHydration(this)
 
-    if (typeof hydration === 'undefined') return
+    if (this.template.manualHydration || typeof hydration === 'undefined') {
+      return
+    }
 
     this.store.setState(hydration)
   }

--- a/packages/atoms/src/injectors/injectStore.ts
+++ b/packages/atoms/src/injectors/injectStore.ts
@@ -118,12 +118,10 @@ export const injectStore: {
       typeof storeFactory === 'function'
         ? (storeFactory as () => Store<State>)
         : (hydration?: State) =>
-            createStore<State>(null, hydration || storeFactory)
+            createStore<State>(null, hydration ?? storeFactory)
 
     const store = getStore(
-      config?.hydrate
-        ? instance.ecosystem._consumeHydration(instance)
-        : undefined
+      config?.hydrate ? instance.ecosystem.hydration?.[instance.id] : undefined
     )
 
     const subscription = subscribe && doSubscribe(instance, store)

--- a/packages/immer/src/injectImmerStore.ts
+++ b/packages/immer/src/injectImmerStore.ts
@@ -62,7 +62,7 @@ export const injectImmerStore: {
 
   const store = injectMemo(() => {
     const hydration = config?.hydrate
-      ? instance.ecosystem._consumeHydration(instance)
+      ? instance.ecosystem.hydration?.[instance.id]
       : undefined
 
     return createImmerStore<State>(hydration ?? state)

--- a/packages/machines/src/injectMachineStore.ts
+++ b/packages/machines/src/injectMachineStore.ts
@@ -237,7 +237,7 @@ export const injectMachineStore: <
 
     const [initialState] = statesFactory(createState)
     const hydration =
-      config?.hydrate && instance.ecosystem._consumeHydration(instance)
+      config?.hydrate && instance.ecosystem.hydration?.[instance.id]
 
     const store = new MachineStore<StateNames, EventNames, Context>(
       hydration?.value ?? (initialState.stateName as StateNames),

--- a/packages/react/test/integrations/ssr.test.tsx
+++ b/packages/react/test/integrations/ssr.test.tsx
@@ -1,4 +1,4 @@
-import { atom, ion } from '@zedux/react'
+import { atom, createStore, injectStore, ion } from '@zedux/react'
 import { ecosystem } from '../utils/ecosystem'
 
 describe('ssr', () => {
@@ -252,5 +252,29 @@ describe('ssr', () => {
         includeFlags: ['include-me'],
       })
     ).toEqual({})
+  })
+
+  test('all injectors receive the hydration', () => {
+    const atom1 = atom(
+      '1',
+      () => {
+        const a = injectStore('a', { hydrate: true })
+        const b = injectStore('b', { hydrate: true })
+
+        const store = injectStore(() => createStore({ a, b }))
+        store.use({ a, b })
+
+        return store
+      },
+      { manualHydration: true }
+    )
+
+    ecosystem.hydrate({ 1: 'ab' })
+    const instance = ecosystem.getInstance(atom1)
+
+    expect(instance.getState()).toEqual({
+      a: 'ab',
+      b: 'ab',
+    })
   })
 })


### PR DESCRIPTION
## Description

`injectStore` and similar store-injecting injectors shouldn't call `ecosystem._consumeHydration()` when their `hydrate` option is true since that breaks injector composability. Instead, always call `ecosystem._consumeHydration()` once, after evaluation is over. This allows all injectors that want it to receive the hydration.

@affects atoms, immer, machines