### PR TITLE
fix(react): fix multiple renderers cross-window React warning

### DIFF
--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -19,12 +19,19 @@ export const getReactContext = (
   ecosystem: Ecosystem,
   atom: AnyAtomTemplate
 ) => {
-  const reactStorage: Record<
-    string,
-    React.Context<any>
-  > = (ecosystem._storage.react ||= {})
+  const reactStorage: {
+    contexts: WeakMap<typeof createContext, Record<string, React.Context<any>>>
+  } = (ecosystem._storage.react ||= {})
 
-  return (reactStorage[atom.key] ||= createContext(
+  const contexts = (reactStorage.contexts ||= new WeakMap())
+  const windowContexts =
+    contexts.get(createContext) ||
+    (contexts.set(createContext, {}).get(createContext) as Record<
+      string,
+      React.Context<any>
+    >)
+
+  return (windowContexts[atom.key] ||= createContext(
     undefined
   ) as React.Context<any>)
 }


### PR DESCRIPTION
## Description

React complains about the same React context object being used by multiple "renderers" (react-dom instances in this case) when Zedux shares context objects across windows in multi-window setups. Instead, create a different context object for each instance of React that Zedux runs in. Use the React instance's `createContext` function to key a WeakMap mapped to the record of cached context objects.