### PR TITLE
feat(react): get component name via forbidden react internals

### DIFF
--- a/packages/atoms/src/classes/IdGenerator.ts
+++ b/packages/atoms/src/classes/IdGenerator.ts
@@ -40,37 +40,15 @@ export class IdGenerator {
   /**
    * Generate a graph node key for a React component
    */
-  public generateReactComponentId() {
+  public generateReactComponentId(component: {
+    displayName?: string
+    name?: string
+  }) {
     if (!DEV) return this.generateId('rc')
 
-    const { stack } = new Error()
-
-    if (!stack) return ''
-
-    const lines = stack
-      .split('\n')
-      .slice(2)
-      .map(line =>
-        line
-          .trim()
-          // V8/JavaScriptCore:
-          .replace('at ', '')
-          .replace(/ \(.*\)/, '')
-          // SpiderMonkey:
-          .replace(/@.*/, '')
-      )
-
-    const componentName = lines
-      .find(line => {
-        if (!/\w/.test(line[0])) return false
-
-        const identifiers = line.split('.')
-        const fn = identifiers[identifiers.length - 1]
-        return fn[0]?.toUpperCase() === fn[0]
-      })
-      ?.split(' ')[0]
-
-    return this.generateId(componentName || 'UnknownComponent')
+    return this.generateId(
+      component.displayName || component.name || 'UnknownComponent'
+    )
   }
 
   /**

--- a/packages/react/src/hooks/useReactComponentId.ts
+++ b/packages/react/src/hooks/useReactComponentId.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import React, { useMemo } from 'react'
 import { useEcosystem } from './useEcosystem'
 
 /**
@@ -10,10 +10,17 @@ export const useReactComponentId = () => {
   const ecosystem = useEcosystem()
 
   // would be nice if React provided some way to know that multiple hooks are
-  // from the same component. For now, every Zedux hook usage creates a new
-  // graph node
+  // from the same component instance. For now, every Zedux hook usage creates a
+  // new graph node
   return useMemo(
-    () => ecosystem._idGenerator.generateReactComponentId(),
+    () =>
+      ecosystem._idGenerator.generateReactComponentId(
+        // Yes. Fire me. Seriously though, why doesn't React expose the current
+        // component in a way that won't get me fired. Surely Recoil and Zedux
+        // aren't the only ones to run into this.
+        (React as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+          .ReactCurrentOwner.current.type
+      ),
     [ecosystem]
   )
 }


### PR DESCRIPTION
## Description

Every couple weeks, I get the strongest urge to make this change. I know it's mega bad practice and I don't think I can bring myself to actually merge this. But I'm gonna leave this here. Just so I can stop thinking of implementing it.

This uses the forbidden React secret internals object to access the currently-rendering component so we can get its displayName for the atom graph without using incredibly slow, hacky, brittle stack trace parsing.