### PR TITLE
fix(core): point core package's  field to the correct file

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@zedux/core",
   "version": "1.0.3",
   "description": "A high-level, declarative, composable form of Redux",
-  "main": "./dist/zedux.umd.js",
+  "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
   "author": "Joshua Claunch",


### PR DESCRIPTION
## Description

As discussed in #74, the core package's `main` package.json field is pointing to an old file that doesn't exist anymore. Most bundlers should be resolving the `exports.require` or `exports.default` field instead, but Metro isn't. This should be updated anyway, so do it.