### PR TITLE
feat(atoms): give atom instances access to their real template type

### DIFF
--- a/packages/atoms/src/classes/instances/AtomInstance.ts
+++ b/packages/atoms/src/classes/instances/AtomInstance.ts
@@ -68,10 +68,13 @@ const getStateStore = <
   return [stateType, stateStore] as const
 }
 
-export class AtomInstance<G extends AtomGenerics> extends AtomInstanceBase<
-  G['State'],
-  AtomTemplateBase<G, AtomInstance<G>>
-> {
+export class AtomInstance<
+  G extends AtomGenerics,
+  AtomTemplateType extends AtomTemplateBase<
+    G,
+    AtomInstance<G, AtomTemplateType>
+  > = AtomTemplateBase<G, AtomInstance<G, any>>
+> extends AtomInstanceBase<G['State'], AtomTemplateType> {
   public status: LifecycleStatus = 'Initializing'
   public api?: AtomApi<AtomGenericsToAtomApiGenerics<G>>
   public exports: G['Exports']
@@ -98,7 +101,7 @@ export class AtomInstance<G extends AtomGenerics> extends AtomInstanceBase<
 
   constructor(
     public readonly ecosystem: Ecosystem,
-    public readonly template: AtomTemplateBase<G, AtomInstance<G>>,
+    public readonly template: AtomTemplateType,
     public readonly id: string,
     public readonly params: G['Params']
   ) {

--- a/packages/atoms/src/classes/templates/AtomTemplate.ts
+++ b/packages/atoms/src/classes/templates/AtomTemplate.ts
@@ -4,10 +4,10 @@ import { AtomInstance } from '../instances/AtomInstance'
 import { Ecosystem } from '../Ecosystem'
 import { AtomTemplateBase } from './AtomTemplateBase'
 
-export class AtomTemplate<G extends AtomGenerics> extends AtomTemplateBase<
-  G,
-  AtomInstance<G>
-> {
+export class AtomTemplate<
+  G extends AtomGenerics,
+  AtomInstanceType extends AtomInstance<G> = AtomInstance<G>
+> extends AtomTemplateBase<G, AtomInstanceType> {
   /**
    * This method should be overridden when creating custom atom classes that
    * create a custom atom instance class. Return a new instance of your atom
@@ -17,8 +17,8 @@ export class AtomTemplate<G extends AtomGenerics> extends AtomTemplateBase<
     ecosystem: Ecosystem,
     id: string,
     params: G['Params']
-  ): AtomInstance<G> {
-    return new AtomInstance<G>(ecosystem, this, id, params)
+  ): AtomInstanceType {
+    return new AtomInstance<G>(ecosystem, this, id, params) as AtomInstanceType
   }
 
   public getInstanceId(ecosystem: Ecosystem, params?: G['Params']) {

--- a/packages/react/test/types.test.tsx
+++ b/packages/react/test/types.test.tsx
@@ -102,7 +102,16 @@ describe('types', () => {
           Store: AtomStore
           Promise: AtomPromise
         },
-        TAtomInstance
+        AtomInstance<
+          {
+            State: AtomState
+            Params: AtomParams
+            Exports: AtomExports
+            Store: AtomStore
+            Promise: AtomPromise
+          },
+          any
+        >
       >
     >()
 
@@ -180,7 +189,16 @@ describe('types', () => {
           Store: StoreAtomStore
           Promise: StoreAtomPromise
         },
-        TStoreAtomInstance
+        AtomInstance<
+          {
+            State: StoreAtomState
+            Params: StoreAtomParams
+            Exports: StoreAtomExports
+            Store: StoreAtomStore
+            Promise: StoreAtomPromise
+          },
+          any
+        >
       >
     >()
     expectTypeOf<TValueAtomInstance>().toEqualTypeOf<typeof storeInstance>()
@@ -193,7 +211,16 @@ describe('types', () => {
           Store: ValueAtomStore
           Promise: ValueAtomPromise
         },
-        TValueAtomInstance
+        AtomInstance<
+          {
+            State: ValueAtomState
+            Params: ValueAtomParams
+            Exports: ValueAtomExports
+            Store: ValueAtomStore
+            Promise: ValueAtomPromise
+          },
+          any
+        >
       >
     >()
   })
@@ -375,7 +402,16 @@ describe('types', () => {
           Store: StoreIonStore
           Promise: StoreIonPromise
         },
-        TStoreIonInstance
+        AtomInstance<
+          {
+            State: StoreIonState
+            Params: StoreIonParams
+            Exports: StoreIonExports
+            Store: StoreIonStore
+            Promise: StoreIonPromise
+          },
+          any
+        >
       >
     >()
     expectTypeOf<TValueIonInstance>().toEqualTypeOf<typeof storeInstance>()
@@ -388,7 +424,16 @@ describe('types', () => {
           Store: ValueIonStore
           Promise: ValueIonPromise
         },
-        TValueIonInstance
+        AtomInstance<
+          {
+            State: ValueIonState
+            Params: ValueIonParams
+            Exports: ValueIonExports
+            Store: ValueIonStore
+            Promise: ValueIonPromise
+          },
+          any
+        >
       >
     >()
   })


### PR DESCRIPTION
## Description

For TypeScript users, an atom instance's template type (e.g. when using `instance.template`) is inferred to be an instance of the Zedux built-in `AtomTemplate` class. But if the instance was created from a custom class that extends `AtomTemplate`, the type information of that child class would be lost. For example:

```ts
class MyTemplate extends AtomTemplate {
  public customMethod() {
    // ... implemention ...
  }
}

const myCustomTemplateAtom = new MyTemplate('myCustomTemplate', () => 'example state')

const instance = ecosystem.getInstance(myCustomTemplateAtom)
instance.template.customMethod() // actually works! But TS used to complain
```

Now TS doesn't complain; the type information of the instance's actual atom template is retained