### PR TITLE
feat: remove uSES usages and support strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pnpm add @zedux/react # pnpm
 
 The React package (`@zedux/react`) contains everything you need to use Zedux in a React app - the [core store model](https://www.npmjs.com/package/@zedux/core), the [core atomic model](https://www.npmjs.com/package/@zedux/atoms), and the React-specific APIs.
 
-`@zedux/react` has a peer dependency on React. It's heavily tested on React 18+ and makes use of the [`useSyncExternalStore()` shim](https://www.npmjs.com/package/use-sync-external-store) to support React versions 16.3.0 and up.
+`@zedux/react` has a peer dependency on React. It supports React version 18 and up.
 
 ## Intro
 

--- a/packages/atoms/src/classes/IdGenerator.ts
+++ b/packages/atoms/src/classes/IdGenerator.ts
@@ -38,42 +38,6 @@ export class IdGenerator {
   }
 
   /**
-   * Generate a graph node key for a React component
-   */
-  public generateReactComponentId() {
-    if (!DEV) return this.generateId('rc')
-
-    const { stack } = new Error()
-
-    if (!stack) return ''
-
-    const lines = stack
-      .split('\n')
-      .slice(2)
-      .map(line =>
-        line
-          .trim()
-          // V8/JavaScriptCore:
-          .replace('at ', '')
-          .replace(/ \(.*\)/, '')
-          // SpiderMonkey:
-          .replace(/@.*/, '')
-      )
-
-    const componentName = lines
-      .find(line => {
-        if (!/\w/.test(line[0])) return false
-
-        const identifiers = line.split('.')
-        const fn = identifiers[identifiers.length - 1]
-        return fn[0]?.toUpperCase() === fn[0]
-      })
-      ?.split(' ')[0]
-
-    return this.generateId(componentName || 'UnknownComponent')
-  }
-
-  /**
    * Turn an array of anything into a predictable string. If any item is an atom
    * instance, it will be serialized as the instance's id. If
    * acceptComplexParams is true, map class instances and functions to a

--- a/packages/atoms/src/classes/Selectors.ts
+++ b/packages/atoms/src/classes/Selectors.ts
@@ -397,9 +397,7 @@ export class Selectors {
 
     if (existingId || weak) return existingId
 
-    const selectorName =
-      this._getIdealCacheId(selectorOrConfig) ||
-      (DEV ? 'unknownSelector' : 'as')
+    const selectorName = this._getIdealCacheId(selectorOrConfig) || 'unnamed'
 
     const key = this.ecosystem._idGenerator.generateId(
       `@@selector-${selectorName}`

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,14 +10,12 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/atoms": "^1.1.1",
-    "use-sync-external-store": "^1.2.0"
+    "@zedux/atoms": "^1.1.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@types/react-dom": "^18.0.11",
-    "@types/use-sync-external-store": "^0.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -57,7 +55,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=16.3.0"
+    "react": ">=18.0.0"
   },
   "repository": {
     "directory": "packages/react",

--- a/packages/react/src/components/EcosystemProvider.tsx
+++ b/packages/react/src/components/EcosystemProvider.tsx
@@ -1,6 +1,5 @@
 import { createEcosystem, Ecosystem, EcosystemConfig } from '@zedux/atoms'
-import React, { ReactNode, useMemo } from 'react'
-import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
+import React, { ReactNode, useEffect, useMemo } from 'react'
 import { ecosystemContext } from '../utils'
 
 /**
@@ -35,25 +34,21 @@ export const EcosystemProvider = ({
       children?: ReactNode
       ecosystem?: undefined
     })) => {
-  const [subscribe, getSnapshot] = useMemo(() => {
-    const resolvedEcosystem =
+  const ecosystem = useMemo(
+    () =>
       passedEcosystem ||
       createEcosystem({
         destroyOnUnmount: true,
         ...ecosystemConfig,
-      })
+      }),
+    [ecosystemConfig.id, passedEcosystem]
+  ) // don't pass other vals; just get snapshot when these change
 
-    return [
-      () => {
-        resolvedEcosystem._incrementRefCount()
+  useEffect(() => {
+    ecosystem._incrementRefCount()
 
-        return () => resolvedEcosystem._decrementRefCount()
-      },
-      () => resolvedEcosystem,
-    ]
-  }, [ecosystemConfig.id, passedEcosystem]) // don't pass other vals; just get snapshot when these change
-
-  const ecosystem = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+    return () => ecosystem._decrementRefCount()
+  }, [ecosystem])
 
   return (
     <ecosystemContext.Provider value={ecosystem.id}>

--- a/packages/react/src/hooks/useAtomSelector.ts
+++ b/packages/react/src/hooks/useAtomSelector.ts
@@ -1,61 +1,14 @@
 import {
+  AtomSelectorConfig,
   AtomSelectorOrConfig,
-  Ecosystem,
   haveDepsChanged,
-  SelectorCache,
 } from '@zedux/atoms'
-import { MutableRefObject, useMemo, useRef } from 'react'
-import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
-import { destroyed, External } from '../utils'
+import { useEffect, useRef, useState } from 'react'
+import { External } from '../utils'
 import { useEcosystem } from './useEcosystem'
 import { useReactComponentId } from './useReactComponentId'
 
-const glob = ((typeof globalThis !== 'undefined' && globalThis) || {}) as any
 const OPERATION = 'useAtomSelector'
-
-/**
- * If we detect an inline selector using these not-exactly-cheap checks, we can
- * prevent the graph from changing by swapping out its reference and
- * invalidating the cache. It's unfortunately probably not a good trade-off
- * performance-wise, but it's necessary to prevent React's render-loop-of-death
- * in `useSyncExternalStore` when both the subscribe reference and the selector
- * result change every render. Simple reproduction:
- *
- * ```tsx
- * // subscribe ref and getSnapshot result ref change every render = death
- * useSyncExternalStore(() => () => {}, () => ({}))
- * ```
- *
- * It's also better dev-X when the graph doesn't change unnecessarily.
- *
- * An inline selector's graph node must have exactly one dependent - the React
- * component that called `useAtomSelector(inlineSelector)`. It will also have
- * the exact same ideal cache id, which we derive from the name of the selector
- * function if possible.
- */
-const isRefDifferent = (
-  _graph: Ecosystem['_graph'],
-  selectors: Ecosystem['selectors'],
-  newSelector: AtomSelectorOrConfig<any, any>,
-  cacheRef: MutableRefObject<SelectorCache<any, any>>
-) => {
-  const oldSelector = cacheRef.current.selectorRef
-  if (newSelector === oldSelector) return false
-
-  if (_graph.nodes[cacheRef.current.id].refCount !== 1) return true
-
-  const newIsFunction = typeof newSelector === 'function'
-  const oldIsFunction = typeof oldSelector === 'function'
-
-  if (newIsFunction !== oldIsFunction) return true
-
-  const newKey = selectors._getIdealCacheId(newSelector)
-  const oldKey = selectors._getIdealCacheId(oldSelector)
-
-  // if this last check is false, we're confident enough that it's an inline
-  // selector. It isn't a big deal if it isn't; it's just for _ideal_ Dev X
-  return newKey !== oldKey
-}
 
 /**
  * Get the result of running an AtomSelector in the current ecosystem.
@@ -71,111 +24,54 @@ export const useAtomSelector = <T, Args extends any[]>(
   selectorOrConfig: AtomSelectorOrConfig<T, Args>,
   ...args: Args
 ): T => {
-  const { _graph, selectors } = useEcosystem()
+  const ecosystem = useEcosystem()
+  const { _graph, selectors } = ecosystem
   const dependentKey = useReactComponentId()
-  const cacheRef = useRef<SelectorCache<T, Args>>()
-  const skipState = useRef<T>(destroyed as any)
-  const isConfig = typeof selectorOrConfig !== 'function'
+  const cacheRef = useRef<{ args: Args }>()
+  const [, render] = useState<undefined | object>()
+
+  const existingCache =
+    cacheRef.current || selectors.find(selectorOrConfig, args)
 
   const argsChanged =
-    isConfig && selectorOrConfig.argsComparator && cacheRef.current?.args
-      ? !selectorOrConfig.argsComparator(args, cacheRef.current.args)
-      : haveDepsChanged(cacheRef.current?.args, args)
+    !existingCache ||
+    ((selectorOrConfig as AtomSelectorConfig<T, Args>).argsComparator
+      ? !(
+          (selectorOrConfig as AtomSelectorConfig<T, Args>).argsComparator as (
+            newArgs: Args,
+            oldArgs: Args
+          ) => boolean
+        )(args, existingCache.args || ([] as unknown as Args))
+      : haveDepsChanged(existingCache.args, args))
 
-  const resolvedArgs = argsChanged
-    ? args
-    : // if args haven't changed, cacheRef has to exist. This cast is fine:
-      (cacheRef.current as SelectorCache<T, Args>).args
+  const resolvedArgs = argsChanged ? args : (existingCache.args as Args)
+  const renderedResult = ecosystem.select(selectorOrConfig, ...resolvedArgs)
 
-  const hasRefChanged = selectorOrConfig !== cacheRef.current?.selectorRef
-  const isDifferent =
-    argsChanged ||
-    isRefDifferent(
-      _graph,
-      selectors,
-      selectorOrConfig,
-      // the argsChanged check guarantees `cacheRef.current` is defined here:
-      cacheRef as MutableRefObject<SelectorCache<any, any>>
+  useEffect(() => {
+    // Don't cache the selector until this effect runs. Sadly, this means that
+    // all selectors that are first invoked from React will be double-invoked.
+    // There's really nothing (performant and good) that we can do about this.
+    // React is really just missing lots of features for external stores.
+    const cache = selectors.getCache(selectorOrConfig, resolvedArgs)
+
+    if (_graph.nodes[cache.id]?.dependents.get(dependentKey)) return
+
+    _graph.addEdge(dependentKey, cache.id, OPERATION, External, () =>
+      render({})
     )
 
-  if (isDifferent) {
-    // yes, this mutation is fine
-    cacheRef.current = selectors.getCache(
-      selectorOrConfig,
-      resolvedArgs as Args
-    )
-  }
+    // an unmounting component's effect cleanup can force-destroy the selector
+    // or update its dependencies before this component is mounted. If that
+    // happened, trigger a rerender to recache the selector and/or get its new
+    // result
+    if (cache.result !== renderedResult) render({})
 
-  const cache = cacheRef.current as SelectorCache<T, Args>
+    // use the referentially stable render function as a ref :O
+    // ;(render as any).mounted = true
+    cacheRef.current = { args: resolvedArgs }
 
-  const [subscribe, getSnapshot] = useMemo(() => {
-    let isInvalidated = false
+    return () => _graph.removeEdge(dependentKey, cache.id)
+  }, [selectorOrConfig, resolvedArgs])
 
-    return [
-      (onStoreChange: () => void) => {
-        // we have to fire an extra update on subscribe in test envs because
-        // there's a bug in React (but only in test environments) where
-        // useEffects in child components run before useSyncExternalStore
-        // subscribe is called in the parent component.
-        if (glob.IS_REACT_ACT_ENVIRONMENT) onStoreChange()
-
-        // this function must be idempotent
-        if (!_graph.nodes[cache.id]?.dependents.get(dependentKey)) {
-          // React can unmount other components before calling this subscribe
-          // function but after we got the cache above. Re-get the cache
-          // if such unmountings destroyed it in the meantime:
-          if (cache.isDestroyed) {
-            ;(cacheRef.current as any) = destroyed
-            isInvalidated = true
-
-            onStoreChange()
-
-            return () => {} // let the next render register the graph edge
-          }
-
-          _graph.addEdge(
-            dependentKey,
-            cache.id,
-            OPERATION,
-            External,
-            (signal, newState) => {
-              if (newState === skipState.current) {
-                ;(skipState.current as any) = destroyed
-                return
-              }
-
-              if (signal === 'Destroyed') {
-                // see comment in useAtomInstance about why returning
-                // a nonsense value from `getSnapshot` works
-                ;(cacheRef.current as any) = destroyed
-                isInvalidated = true
-              }
-
-              onStoreChange()
-            }
-          )
-        }
-
-        return () => {
-          // I don't think we need to unset any of the cache refs here
-          _graph.removeEdge(dependentKey, cache.id)
-        }
-      },
-      () => (isInvalidated ? destroyed : cache.result),
-    ]
-  }, [_graph, cache])
-
-  // if ref changed but is likely the "same" selector, swap out the ref and
-  // invalidate the cache
-  if (hasRefChanged && !isDifferent) {
-    selectors._swapRefs(
-      cache.selectorRef as AtomSelectorOrConfig<any, any[]>,
-      selectorOrConfig as AtomSelectorOrConfig<any, any[]>,
-      resolvedArgs as Args
-    )
-    // prevent state update loop if new selector ref just returned a new result:
-    skipState.current = cache.result as T
-  }
-
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot) as T
+  return renderedResult
 }

--- a/packages/react/src/hooks/useReactComponentId.ts
+++ b/packages/react/src/hooks/useReactComponentId.ts
@@ -1,19 +1,27 @@
-import { useMemo } from 'react'
-import { useEcosystem } from './useEcosystem'
+import React, { useId } from 'react'
 
 /**
- * Get a unique id for a Zedux hook call. The exact string doesn't really
- * matter, but in dev try to use an error stack to grab the React component's
- * actual name for a better debugging experience
+ * Get a unique id for a Zedux hook call. This id is predictable - it should be
+ * exactly the same every time a given component renders in the same place in
+ * the component tree. This means it persists across component
+ * destruction/recreation which happens a lot e.g. during suspense.
+ *
+ * This uses the forbidden React internals object. We only use it to get a
+ * dev-friendly name for the React component's node in the atom graph. It's fine
+ * if React changes their internals - we'll fall back to using a generated node
+ * name.
  */
 export const useReactComponentId = () => {
-  const ecosystem = useEcosystem()
+  const component:
+    | {
+        displayName?: string
+        name?: string
+      }
+    | undefined = (React as any)
+    .__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED?.ReactCurrentOwner
+    ?.current?.type
 
-  // would be nice if React provided some way to know that multiple hooks are
-  // from the same component. For now, every Zedux hook usage creates a new
-  // graph node
-  return useMemo(
-    () => ecosystem._idGenerator.generateReactComponentId(),
-    [ecosystem]
-  )
+  const name = component?.displayName || component?.name || 'rc'
+
+  return `${name}-${useId()}`
 }

--- a/packages/react/test/integrations/__snapshots__/ecosystem.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/ecosystem.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`ecosystem big graph 1`] = `
         "operation": "injectAtomValue",
       },
       {
-        "key": "Child-4",
+        "key": "Child-:r4:",
         "operation": "useAtomValue",
       },
     ],
@@ -45,7 +45,7 @@ exports[`ecosystem big graph 1`] = `
         "operation": "injectAtomValue",
       },
       {
-        "key": "Child-3",
+        "key": "Child-:r3:",
         "operation": "useAtomValue",
       },
     ],
@@ -68,7 +68,7 @@ exports[`ecosystem big graph 1`] = `
         "operation": "injectAtomValue",
       },
       {
-        "key": "Child-2",
+        "key": "Child-:r2:",
         "operation": "useAtomValue",
       },
     ],
@@ -91,7 +91,7 @@ exports[`ecosystem big graph 1`] = `
         "operation": "injectAtomValue",
       },
       {
-        "key": "Child-1",
+        "key": "Child-:r1:",
         "operation": "useAtomState",
       },
     ],
@@ -114,7 +114,7 @@ exports[`ecosystem big graph 1`] = `
     ],
     "dependents": [
       {
-        "key": "Child-0",
+        "key": "Child-:r0:",
         "operation": "useAtomValue",
       },
     ],

--- a/packages/react/test/integrations/__snapshots__/graph.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/graph.test.tsx.snap
@@ -83,11 +83,11 @@ exports[`graph injectAtomGetters 1`] = `
     ],
     "dependents": [
       {
-        "key": "Test-0",
+        "key": "Test-:r0:",
         "operation": "useAtomValue",
       },
       {
-        "key": "Test-1",
+        "key": "Test-:r1:",
         "operation": "useAtomInstance",
       },
     ],

--- a/packages/react/test/integrations/selection.test.tsx
+++ b/packages/react/test/integrations/selection.test.tsx
@@ -42,8 +42,8 @@ describe('selection', () => {
 
     const button = await findByTestId('button')
 
-    expect(selector1).toHaveBeenCalledTimes(1)
-    expect(selector2).toHaveBeenCalledTimes(1)
+    expect(selector1).toHaveBeenCalledTimes(2)
+    expect(selector2).toHaveBeenCalledTimes(2)
     expect((await findByTestId('text')).innerHTML).toBe('a')
 
     act(() => {
@@ -51,20 +51,20 @@ describe('selection', () => {
       jest.runAllTimers()
     })
 
-    expect(selector1).toHaveBeenCalledTimes(1)
-    expect(selector2).toHaveBeenCalledTimes(1)
+    expect(selector1).toHaveBeenCalledTimes(2)
+    expect(selector2).toHaveBeenCalledTimes(2)
 
     act(() => {
       ecosystem.find(testAtom, ['a'])?.setState('b')
       jest.runAllTimers()
     })
 
-    expect(selector1).toHaveBeenCalledTimes(2)
-    expect(selector2).toHaveBeenCalledTimes(2)
+    expect(selector1).toHaveBeenCalledTimes(3)
+    expect(selector2).toHaveBeenCalledTimes(3)
     expect((await findByTestId('text')).innerHTML).toBe('b')
   })
 
-  test('selector is recreated if an unmounted component destroys it after a newly-rendered component reads from the cache but before the new component can create the dependency', async () => {
+  test("a state change from an unmounting component's effect cleanup triggers rerenders in newly-created components that use the updated atom or its dependents", async () => {
     jest.useFakeTimers()
     const selector = jest.fn(({ get }: AtomGetters) => get(testAtom, ['a']))
 
@@ -102,7 +102,7 @@ describe('selection', () => {
 
     const button = await findByTestId('button')
 
-    expect(selector).toHaveBeenCalledTimes(1)
+    expect(selector).toHaveBeenCalledTimes(2)
     expect((await findByTestId('text')).innerHTML).toBe('a')
 
     act(() => {
@@ -110,7 +110,7 @@ describe('selection', () => {
       jest.runAllTimers()
     })
 
-    expect(selector).toHaveBeenCalledTimes(2)
+    expect(selector).toHaveBeenCalledTimes(3)
     expect((await findByTestId('text')).innerHTML).toBe('b')
   })
 
@@ -123,10 +123,10 @@ describe('selection', () => {
 
     function ResurrectingComponent({ view }: { view: number }) {
       useAtomSelector(selector1)
-      const { b } = useAtomSelector(selector2)
-      useAtomSelector(selector3, view)
+      useAtomSelector(selector2)
+      const val = useAtomSelector(selector3, view)
 
-      return <div data-testid="text">{b}</div>
+      return <div data-testid="text">{val}</div>
     }
 
     function Test() {
@@ -145,20 +145,20 @@ describe('selection', () => {
 
     const button = await findByTestId('button')
 
-    expect(selector1).toHaveBeenCalledTimes(1)
-    expect(selector2).toHaveBeenCalledTimes(1)
-    expect(selector3).toHaveBeenCalledTimes(1)
-    expect((await findByTestId('text')).innerHTML).toBe('2')
+    expect(selector1).toHaveBeenCalledTimes(3)
+    expect(selector2).toHaveBeenCalledTimes(2)
+    expect(selector3).toHaveBeenCalledTimes(2)
+    expect((await findByTestId('text')).innerHTML).toBe('c1')
 
     act(() => {
       fireEvent.click(button)
       jest.runAllTimers()
     })
 
-    expect(selector1).toHaveBeenCalledTimes(1)
-    expect(selector2).toHaveBeenCalledTimes(2)
-    expect(selector3).toHaveBeenCalledTimes(2)
-    expect((await findByTestId('text')).innerHTML).toBe('3')
+    expect(selector1).toHaveBeenCalledTimes(3)
+    expect(selector2).toHaveBeenCalledTimes(3)
+    expect(selector3).toHaveBeenCalledTimes(4)
+    expect((await findByTestId('text')).innerHTML).toBe('c2')
   })
 
   test('inline selectors are swapped out and evaluated every time the ref changes', async () => {
@@ -184,7 +184,7 @@ describe('selection', () => {
 
     const button = await findByTestId('button')
 
-    expect(selector).toHaveBeenCalledTimes(1)
+    expect(selector).toHaveBeenCalledTimes(2)
     expect(selector).toHaveBeenLastCalledWith(expect.any(Object), 1)
     expect((await findByTestId('text')).innerHTML).toBe('2')
 
@@ -193,7 +193,7 @@ describe('selection', () => {
       jest.runAllTimers()
     })
 
-    expect(selector).toHaveBeenCalledTimes(2)
+    expect(selector).toHaveBeenCalledTimes(4)
     expect(selector).toHaveBeenLastCalledWith(expect.any(Object), 2)
     expect((await findByTestId('text')).innerHTML).toBe('4')
   })

--- a/packages/react/test/units/useAtomSelector.test.tsx
+++ b/packages/react/test/units/useAtomSelector.test.tsx
@@ -61,7 +61,7 @@ describe('useAtomSelector', () => {
     const div = await findByTestId('text')
 
     expect(div.innerHTML).toBe('a')
-    expect(selector1).toHaveBeenCalledTimes(1)
+    expect(selector1).toHaveBeenCalledTimes(2)
 
     act(() => {
       fireEvent.click(button)
@@ -69,7 +69,7 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('a')
-    expect(selector1).toHaveBeenCalledTimes(2)
+    expect(selector1).toHaveBeenCalledTimes(4)
   })
 
   test('useAtomSelector creates/uses a different cache when args change', async () => {
@@ -100,9 +100,9 @@ describe('useAtomSelector', () => {
     const div = await findByTestId('text')
 
     expect(div.innerHTML).toBe('0')
-    expect(selector1).toHaveBeenCalledTimes(1)
+    expect(selector1).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-1-[0]': 0,
+      '@@selector-mockConstructor-0-[0]': 0,
     })
 
     act(() => {
@@ -111,9 +111,9 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('1')
-    expect(selector1).toHaveBeenCalledTimes(2)
+    expect(selector1).toHaveBeenCalledTimes(4)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-1-[1]': 1,
+      '@@selector-mockConstructor-0-[1]': 1,
     })
   })
 
@@ -150,9 +150,9 @@ describe('useAtomSelector', () => {
 
     expect(div.innerHTML).toBe('2')
     expect(selector1).not.toHaveBeenCalled()
-    expect(selector2).toHaveBeenCalledTimes(1)
+    expect(selector2).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-1': 2,
+      '@@selector-mockConstructor-0': 2,
     })
 
     act(() => {
@@ -161,10 +161,10 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('1')
-    expect(selector1).toHaveBeenCalledTimes(1)
-    expect(selector2).toHaveBeenCalledTimes(1)
+    expect(selector1).toHaveBeenCalledTimes(2)
+    expect(selector2).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-2-[1]': 1,
+      '@@selector-mockConstructor-1-[1]': 1,
     })
   })
 
@@ -195,9 +195,9 @@ describe('useAtomSelector', () => {
     const div = await findByTestId('text')
 
     expect(div.innerHTML).toBe('1')
-    expect(selector1).toHaveBeenCalledTimes(1)
+    expect(selector1).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-1': 1,
+      '@@selector-mockConstructor-0': 1,
     })
 
     act(() => {
@@ -206,9 +206,9 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('1')
-    expect(selector1).toHaveBeenCalledTimes(2)
+    expect(selector1).toHaveBeenCalledTimes(4)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-2': 1,
+      '@@selector-mockConstructor-1': 1,
     })
   })
 
@@ -241,9 +241,9 @@ describe('useAtomSelector', () => {
     const div = await findByTestId('text')
 
     expect(div.innerHTML).toBe('0')
-    expect(selector1.selector).toHaveBeenCalledTimes(1)
+    expect(selector1.selector).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-1-[0]': 0,
+      '@@selector-mockConstructor-0-[0]': 0,
     })
 
     act(() => {
@@ -252,13 +252,13 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('0')
-    expect(selector1.selector).toHaveBeenCalledTimes(1)
+    expect(selector1.selector).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-1-[0]': 0,
+      '@@selector-mockConstructor-0-[0]': 0,
     })
   })
 
-  test('argsComparator does not prevent an inline selector from running when refs are swapped', async () => {
+  test('argsComparator does not prevent an inline selector from (re)-running, but the previous args are reused', async () => {
     jest.useFakeTimers()
     const atom1 = atom('1', (id: number) => id)
     const selector1 = jest.fn(({ get }: AtomGetters, id: number) =>
@@ -292,9 +292,9 @@ describe('useAtomSelector', () => {
     const div = await findByTestId('text')
 
     expect(div.innerHTML).toBe('0')
-    expect(selector1).toHaveBeenCalledTimes(1)
+    expect(selector1).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-1-[0]': 0,
+      '@@selector-mockConstructor-0-[0]': 0,
     })
 
     act(() => {
@@ -303,7 +303,7 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('0')
-    expect(selector1).toHaveBeenCalledTimes(2)
+    expect(selector1).toHaveBeenCalledTimes(4)
     expect(ecosystem.selectors.dehydrate()).toEqual({
       '@@selector-mockConstructor-1-[0]': 0,
     })
@@ -341,9 +341,9 @@ describe('useAtomSelector', () => {
     const div = await findByTestId('text')
 
     expect(div.innerHTML).toBe('1')
-    expect(selector1).toHaveBeenCalledTimes(1)
+    expect(selector1).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-1': 1,
+      '@@selector-mockConstructor-0': 1,
     })
     expect(renders).toBe(1)
 
@@ -354,9 +354,9 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('1')
-    expect(selector1).toHaveBeenCalledTimes(2)
+    expect(selector1).toHaveBeenCalledTimes(4)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-1': 1,
+      '@@selector-mockConstructor-2': 1,
     })
     expect(renders).toBe(2)
   })
@@ -402,12 +402,76 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('1')
-    expect(selector1).toHaveBeenCalledTimes(1)
+    expect(selector1).toHaveBeenCalledTimes(2)
     expect(selector2).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
       '@@selector-mockConstructor-0': 2,
-      // id # 3 'cause Test component and `addDependent` generate ids 1 & 2:
-      '@@selector-mockConstructor-3': 1,
+      // id # 2 'cause `addDependent` generate id 1:
+      '@@selector-mockConstructor-2': 1,
     })
+  })
+
+  test('inline selectors are swapped out in strict mode double-renders', async () => {
+    const atom1 = atom('1', () => ({ val: 1 }))
+
+    function Test() {
+      const [state, setState] = useState(0)
+      const val = useAtomSelector(({ get }) => get(atom1).val)
+
+      return (
+        <>
+          <button
+            data-testid="button"
+            onClick={() => setState(state => state + 1)}
+          />
+          <div data-testid="text">
+            {val}
+            {state}
+          </div>
+        </>
+      )
+    }
+
+    const { findByTestId } = renderInEcosystem(<Test />, {
+      useStrictMode: true,
+    })
+
+    const button = await findByTestId('button')
+    const div = await findByTestId('text')
+
+    expect(ecosystem.selectors.findAll()).toMatchInlineSnapshot(`
+      {
+        "@@selector-unnamed-0": SelectorCache {
+          "args": [],
+          "id": "@@selector-unnamed-0",
+          "nextReasons": [],
+          "prevReasons": [],
+          "result": 1,
+          "selectorRef": [Function],
+        },
+      }
+    `)
+    expect(div.innerHTML).toBe('10')
+
+    act(() => {
+      fireEvent.click(button)
+    })
+
+    await Promise.resolve()
+
+    expect(div.innerHTML).toBe('11')
+
+    expect(ecosystem.selectors.findAll()).toMatchInlineSnapshot(`
+      {
+        "@@selector-unnamed-1": SelectorCache {
+          "args": [],
+          "id": "@@selector-unnamed-1",
+          "nextReasons": [],
+          "prevReasons": [],
+          "result": 1,
+          "selectorRef": [Function],
+        },
+      }
+    `)
   })
 })

--- a/packages/react/test/utils/renderInEcosystem.tsx
+++ b/packages/react/test/utils/renderInEcosystem.tsx
@@ -1,12 +1,21 @@
 import { render } from '@testing-library/react'
 import { Ecosystem, EcosystemProvider } from '@zedux/react'
-import React from 'react'
-import { ecosystem } from './ecosystem'
+import React, { StrictMode } from 'react'
+import { ecosystem as defaultEcosystem } from './ecosystem'
 
 export const renderInEcosystem = (
   children: JSX.Element,
-  theEcosystem: Ecosystem = ecosystem
-) =>
-  render(
-    <EcosystemProvider ecosystem={theEcosystem}>{children}</EcosystemProvider>
+  {
+    ecosystem = defaultEcosystem,
+    useStrictMode,
+  }: {
+    ecosystem?: Ecosystem
+    useStrictMode?: boolean
+  } = {}
+) => {
+  const provider = (
+    <EcosystemProvider ecosystem={ecosystem}>{children}</EcosystemProvider>
   )
+
+  return render(useStrictMode ? <StrictMode>{provider}</StrictMode> : provider)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1440,11 +1440,6 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
   integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
 
-"@types/use-sync-external-store@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
-  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
-
 "@types/yargs-parser@*":
   version "20.2.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.0.tgz#dd3e6699ba3237f0348cd085e4698780204842f9"
@@ -5784,11 +5779,6 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-use-sync-external-store@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
-  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 util-deprecate@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
## Description

React 18 broke `useAtomSelector` in strict mode. This is because of lots of quirks with `useSyncExternalStore` that I coded circles around in React 17.

Stop fighting with `useSyncExternalStore`. It still has many quirks, doesn't solve any of the problems we wanted it to solve, and most importantly looks to be poorly supported by the React team - for example, transitions will likely never be supported.

Remove `useSyncExternalStore` usages. Instead,

- add graph edges during render in `useAtomInstance`, handling strict mode double-renders and double-effect-invocations specifically. The impure operations are completely idempotent  since generated ids are consistent for a given component thanks to `useId`
- add a simple `useEffect` in `EcosystemProvider`
- run selectors statically during render in `useAtomSelector` and then cache and destroy them in a very simple `useEffect` call

These changes make use of the new `useId` hook, which I believe was released in React 18, so we'd need a shim (or manual handling) to support React 17 again, though I don't think that's a very high priority - most people should be off React 17 by now.

@affects atoms, react

## Issues

Resolves #83 - `useAtomSelector` is completely rewritten, cleaner, and should have no problems in strict mode in React 18

Closes #73 - this PR incorporates those changes, using the forbidden React internals only for improving Dev X and falling back to generating names if React does change their internals.
