### PR TITLE
fix(core): allow store-extending classes to have array state types

### DIFF
--- a/packages/core/src/api/createStore.ts
+++ b/packages/core/src/api/createStore.ts
@@ -17,6 +17,7 @@ import {
   SubscriberObject,
   Scheduler,
   Job,
+  KnownHierarchyDescriptor,
 } from '../types'
 import { STORE_IDENTIFIER } from '../utils/general'
 import * as defaultHierarchyConfig from '../utils/hierarchyConfig'
@@ -95,7 +96,9 @@ export class Store<State = any> {
     this._state = initialState as State
     this._scheduler = Store._scheduler || defaultScheduler
 
-    if (initialHierarchy) this.use(initialHierarchy)
+    if (initialHierarchy) {
+      this.use(initialHierarchy as KnownHierarchyDescriptor<State>)
+    }
   }
 
   public actionStream() {
@@ -325,7 +328,7 @@ export class Store<State = any> {
 
     Dispatches the special `prime` action to the store.
   */
-  public use(newHierarchy: HierarchyDescriptor<State>) {
+  public use(newHierarchy: KnownHierarchyDescriptor<State>) {
     const newTree = hierarchyDescriptorToHierarchy(
       newHierarchy,
       (childStorePath: string[], childStore: Store) =>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -115,11 +115,43 @@ export interface HierarchyConfig<T = any> {
   size: (node: T) => number
 }
 
+/**
+ * Describes a store's dependency tree. A store can have any number of reducers
+ * or child stores nested indefinitely.
+ *
+ * ```ts
+ * import { createStore } from '@zedux/core'
+ *
+ * const store = createStore({
+ *   a: {
+ *     b: childStoreB,
+ *     c: childStoreC,
+ *     d: {
+ *       e: reducerE,
+ *     }
+ *   }
+ * })
+ * ```
+ */
 export type HierarchyDescriptor<State = any> =
   | Branch<State>
   | Store<State>
   | Reducer<State>
   | null
+
+/**
+ * After a store is created, TS knows the hierarchy shape and we can be more
+ * intelligent in e.g. the store's `.use()` method
+ */
+export type KnownHierarchyDescriptor<State = any> = State extends Record<
+  any,
+  any
+>
+  ? State extends any[]
+    ? // arrays match the Record type but can't be `Branch`es
+      Store<State> | Reducer<State> | null
+    : Branch<State> | Store<State> | Reducer<State> | null
+  : Store<State> | Reducer<State> | null
 
 export interface Job {
   flags?: number

--- a/packages/core/test/types.test.tsx
+++ b/packages/core/test/types.test.tsx
@@ -1,0 +1,28 @@
+import { Store } from '@zedux/core'
+import { expectTypeOf } from 'expect-type'
+
+type AcceptsStore<S extends Store<any>> = S
+
+describe('core types', () => {
+  test('classes that extend the Store class can have any state shape', () => {
+    class CustomStore<State> extends Store<State> {}
+
+    expectTypeOf<AcceptsStore<CustomStore<string[]>>>().toEqualTypeOf<
+      Store<string[]>
+    >()
+    expectTypeOf<AcceptsStore<CustomStore<number>>>().toEqualTypeOf<
+      Store<number>
+    >()
+    expectTypeOf<
+      AcceptsStore<CustomStore<{ a: string[]; b: { c: number[] } }>>
+    >().toEqualTypeOf<Store<{ a: string[]; b: { c: number[] } }>>()
+
+    expectTypeOf<AcceptsStore<CustomStore<symbol>>>().toEqualTypeOf<
+      Store<symbol>
+    >()
+    expectTypeOf<AcceptsStore<CustomStore<null>>>().toEqualTypeOf<Store<null>>()
+    expectTypeOf<AcceptsStore<CustomStore<[string, string][]>>>().toEqualTypeOf<
+      Store<[string, string][]>
+    >()
+  })
+})

--- a/packages/react/test/types.test.tsx
+++ b/packages/react/test/types.test.tsx
@@ -54,7 +54,7 @@ afterEach(() => {
   ecosystem.reset()
 })
 
-describe('types', () => {
+describe('react types', () => {
   test('atom generic getters', () => {
     const instance = ecosystem.getInstance(exampleAtom, ['a'])
 


### PR DESCRIPTION
## Description

When extending the core `Store` class and instantiating your class with an array type, TS gives a super cryptic error message that basically boils down to: `store.use()` doesn't accept a hierarchy descriptor type where the `State` generic is an array.

## Solution

Make `store.use()` accept a different type that infers the hierarchy descriptor type better since it's know at that point. Prevent the new type's union from containing `Branch` if the state type at a given level is an array. Even though `store.use()` technically allows swapping an array out for more nested objects, there should never be a real use case for that and TS land really doesn't need to know about it.

## The Past and the Future

`store.use()` wasn't designed with TS in mind. It used to be the primary mechanism for code-splitting in Zedux before atoms. Now it's pretty useless with atoms and is only used to swap out destroyed child stores with their new instances. We should maybe consider a better API for that use case in Zedux v2.