### PR TITLE
fix(core): always notify effects subscribers when a hydration has metadata

### DIFF
--- a/packages/core/src/api/createStore.ts
+++ b/packages/core/src/api/createStore.ts
@@ -441,8 +441,9 @@ export class Store<State = any> {
             (this.constructor as typeof Store).hierarchyConfig
           )[0]
 
-    if (newState === this._state) {
-      // Nothing to do. TODO: Should this inform effects subscribers?
+    // short-circuit if there's no change and no metadata that needs to reach
+    // this (or a parent/child) store's effects subscribers
+    if (newState === this._state && !meta) {
       return this._state
     }
 


### PR DESCRIPTION
## Description

We've had a TODO to maybe inform effects subscribers when `Store#setState` or `Store#setStateDeep` are called but don't change state. We've finally figured out the behavior that's needed in this situation.

Short-circuiting is fine when state hasn't changed _unless_ metadata is passed (e.g. `setState(newState, metadataHere)`. When metadata is passed, the action should always proceed to all parent/child stores and notify all effects subscribers of the pseudo-action with its `meta` property.