### PR TITLE
fix: useAtomSelector - subscribe to the new selector before destroying the old

### DIFF
--- a/packages/atoms/src/classes/Graph.ts
+++ b/packages/atoms/src/classes/Graph.ts
@@ -224,7 +224,14 @@ export class Graph {
     const dependentEdge = dependency.dependents.get(dependentKey)
 
     // happens in React 18+ (see this method's jsdoc above)
-    if (!dependentEdge) return
+    if (!dependentEdge) {
+      // useAtomSelector can delete edges that were never drawn 'cause React
+      // StrictMode double-renders can create an entirely new SelectorCache
+      // before the old one received dependents. Delete the old one in this case
+      if (dependency.isSelector) scheduleNodeDestruction(this, dependencyKey)
+
+      return
+    }
 
     dependency.dependents.delete(dependentKey)
     dependency.refCount--

--- a/packages/atoms/src/classes/Selectors.ts
+++ b/packages/atoms/src/classes/Selectors.ts
@@ -48,6 +48,17 @@ export class Selectors {
    */
   public _refBaseKeys = new WeakMap<AtomSelectorOrConfig<any, any>, string>()
 
+  /**
+   * Used to work around React double-renders and double-effects.
+   */
+  public _storage: Record<
+    string,
+    {
+      cache?: SelectorCache
+      ignorePhase?: number
+    }
+  > = {}
+
   constructor(private readonly ecosystem: Ecosystem) {}
 
   public addDependent(
@@ -383,6 +394,7 @@ export class Selectors {
     })
 
     this._refBaseKeys = new WeakMap()
+    this._storage = {}
   }
 
   /**

--- a/packages/react/test/integrations/selection.test.tsx
+++ b/packages/react/test/integrations/selection.test.tsx
@@ -42,8 +42,8 @@ describe('selection', () => {
 
     const button = await findByTestId('button')
 
-    expect(selector1).toHaveBeenCalledTimes(2)
-    expect(selector2).toHaveBeenCalledTimes(2)
+    expect(selector1).toHaveBeenCalledTimes(1)
+    expect(selector2).toHaveBeenCalledTimes(1)
     expect((await findByTestId('text')).innerHTML).toBe('a')
 
     act(() => {
@@ -51,16 +51,16 @@ describe('selection', () => {
       jest.runAllTimers()
     })
 
-    expect(selector1).toHaveBeenCalledTimes(2)
-    expect(selector2).toHaveBeenCalledTimes(2)
+    expect(selector1).toHaveBeenCalledTimes(1)
+    expect(selector2).toHaveBeenCalledTimes(1)
 
     act(() => {
       ecosystem.find(testAtom, ['a'])?.setState('b')
       jest.runAllTimers()
     })
 
-    expect(selector1).toHaveBeenCalledTimes(3)
-    expect(selector2).toHaveBeenCalledTimes(3)
+    expect(selector1).toHaveBeenCalledTimes(2)
+    expect(selector2).toHaveBeenCalledTimes(2)
     expect((await findByTestId('text')).innerHTML).toBe('b')
   })
 
@@ -102,7 +102,7 @@ describe('selection', () => {
 
     const button = await findByTestId('button')
 
-    expect(selector).toHaveBeenCalledTimes(2)
+    expect(selector).toHaveBeenCalledTimes(1)
     expect((await findByTestId('text')).innerHTML).toBe('a')
 
     act(() => {
@@ -110,7 +110,7 @@ describe('selection', () => {
       jest.runAllTimers()
     })
 
-    expect(selector).toHaveBeenCalledTimes(3)
+    expect(selector).toHaveBeenCalledTimes(2)
     expect((await findByTestId('text')).innerHTML).toBe('b')
   })
 
@@ -145,9 +145,9 @@ describe('selection', () => {
 
     const button = await findByTestId('button')
 
-    expect(selector1).toHaveBeenCalledTimes(3)
-    expect(selector2).toHaveBeenCalledTimes(2)
-    expect(selector3).toHaveBeenCalledTimes(2)
+    expect(selector1).toHaveBeenCalledTimes(1)
+    expect(selector2).toHaveBeenCalledTimes(1)
+    expect(selector3).toHaveBeenCalledTimes(1)
     expect((await findByTestId('text')).innerHTML).toBe('c1')
 
     act(() => {
@@ -155,9 +155,9 @@ describe('selection', () => {
       jest.runAllTimers()
     })
 
-    expect(selector1).toHaveBeenCalledTimes(3)
-    expect(selector2).toHaveBeenCalledTimes(3)
-    expect(selector3).toHaveBeenCalledTimes(4)
+    expect(selector1).toHaveBeenCalledTimes(1)
+    expect(selector2).toHaveBeenCalledTimes(1)
+    expect(selector3).toHaveBeenCalledTimes(2)
     expect((await findByTestId('text')).innerHTML).toBe('c2')
   })
 
@@ -184,7 +184,7 @@ describe('selection', () => {
 
     const button = await findByTestId('button')
 
-    expect(selector).toHaveBeenCalledTimes(2)
+    expect(selector).toHaveBeenCalledTimes(1)
     expect(selector).toHaveBeenLastCalledWith(expect.any(Object), 1)
     expect((await findByTestId('text')).innerHTML).toBe('2')
 
@@ -193,7 +193,7 @@ describe('selection', () => {
       jest.runAllTimers()
     })
 
-    expect(selector).toHaveBeenCalledTimes(4)
+    expect(selector).toHaveBeenCalledTimes(2)
     expect(selector).toHaveBeenLastCalledWith(expect.any(Object), 2)
     expect((await findByTestId('text')).innerHTML).toBe('4')
   })

--- a/packages/react/test/units/__snapshots__/useAtomSelector.test.tsx.snap
+++ b/packages/react/test/units/__snapshots__/useAtomSelector.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`useAtomSelector inline selector that returns a different object referen
   "1": {
     "dependencies": Map {},
     "dependents": Map {
-      "@@selector-unnamed-1" => {
+      "@@selector-unnamed-0" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -16,7 +16,7 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "refCount": 1,
     "weight": 1,
   },
-  "@@selector-unnamed-1": {
+  "@@selector-unnamed-0": {
     "dependencies": Map {
       "1" => true,
     },
@@ -40,7 +40,7 @@ exports[`useAtomSelector inline selector that returns a different object referen
   "1": {
     "dependencies": Map {},
     "dependents": Map {
-      "@@selector-unnamed-3" => {
+      "@@selector-unnamed-1" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -51,7 +51,7 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "refCount": 1,
     "weight": 1,
   },
-  "@@selector-unnamed-3": {
+  "@@selector-unnamed-1": {
     "dependencies": Map {
       "1" => true,
     },

--- a/packages/react/test/units/useAtomSelector.test.tsx
+++ b/packages/react/test/units/useAtomSelector.test.tsx
@@ -61,7 +61,7 @@ describe('useAtomSelector', () => {
     const div = await findByTestId('text')
 
     expect(div.innerHTML).toBe('a')
-    expect(selector1).toHaveBeenCalledTimes(2)
+    expect(selector1).toHaveBeenCalledTimes(1)
 
     act(() => {
       fireEvent.click(button)
@@ -69,7 +69,7 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('a')
-    expect(selector1).toHaveBeenCalledTimes(4)
+    expect(selector1).toHaveBeenCalledTimes(2)
   })
 
   test('useAtomSelector creates/uses a different cache when args change', async () => {
@@ -100,7 +100,7 @@ describe('useAtomSelector', () => {
     const div = await findByTestId('text')
 
     expect(div.innerHTML).toBe('0')
-    expect(selector1).toHaveBeenCalledTimes(2)
+    expect(selector1).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
       '@@selector-mockConstructor-0-[0]': 0,
     })
@@ -111,7 +111,7 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('1')
-    expect(selector1).toHaveBeenCalledTimes(4)
+    expect(selector1).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
       '@@selector-mockConstructor-0-[1]': 1,
     })
@@ -150,7 +150,7 @@ describe('useAtomSelector', () => {
 
     expect(div.innerHTML).toBe('2')
     expect(selector1).not.toHaveBeenCalled()
-    expect(selector2).toHaveBeenCalledTimes(2)
+    expect(selector2).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
       '@@selector-mockConstructor-0': 2,
     })
@@ -161,8 +161,8 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('1')
-    expect(selector1).toHaveBeenCalledTimes(2)
-    expect(selector2).toHaveBeenCalledTimes(2)
+    expect(selector1).toHaveBeenCalledTimes(1)
+    expect(selector2).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
       '@@selector-mockConstructor-1-[1]': 1,
     })
@@ -195,7 +195,7 @@ describe('useAtomSelector', () => {
     const div = await findByTestId('text')
 
     expect(div.innerHTML).toBe('1')
-    expect(selector1).toHaveBeenCalledTimes(2)
+    expect(selector1).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
       '@@selector-mockConstructor-0': 1,
     })
@@ -206,7 +206,7 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('1')
-    expect(selector1).toHaveBeenCalledTimes(4)
+    expect(selector1).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
       '@@selector-mockConstructor-1': 1,
     })
@@ -241,7 +241,7 @@ describe('useAtomSelector', () => {
     const div = await findByTestId('text')
 
     expect(div.innerHTML).toBe('0')
-    expect(selector1.selector).toHaveBeenCalledTimes(2)
+    expect(selector1.selector).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
       '@@selector-mockConstructor-0-[0]': 0,
     })
@@ -252,7 +252,7 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('0')
-    expect(selector1.selector).toHaveBeenCalledTimes(2)
+    expect(selector1.selector).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
       '@@selector-mockConstructor-0-[0]': 0,
     })
@@ -292,7 +292,7 @@ describe('useAtomSelector', () => {
     const div = await findByTestId('text')
 
     expect(div.innerHTML).toBe('0')
-    expect(selector1).toHaveBeenCalledTimes(2)
+    expect(selector1).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
       '@@selector-mockConstructor-0-[0]': 0,
     })
@@ -303,7 +303,7 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('0')
-    expect(selector1).toHaveBeenCalledTimes(4)
+    expect(selector1).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
       '@@selector-mockConstructor-1-[0]': 0,
     })
@@ -341,7 +341,7 @@ describe('useAtomSelector', () => {
     const div = await findByTestId('text')
 
     expect(div.innerHTML).toBe('1')
-    expect(selector1).toHaveBeenCalledTimes(2)
+    expect(selector1).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
       '@@selector-mockConstructor-0': 1,
     })
@@ -354,7 +354,7 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('1')
-    expect(selector1).toHaveBeenCalledTimes(4)
+    expect(selector1).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
       '@@selector-mockConstructor-2': 1,
     })
@@ -402,7 +402,7 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('1')
-    expect(selector1).toHaveBeenCalledTimes(2)
+    expect(selector1).toHaveBeenCalledTimes(1)
     expect(selector2).toHaveBeenCalledTimes(1)
     expect(ecosystem.selectors.dehydrate()).toEqual({
       '@@selector-mockConstructor-0': 2,
@@ -412,6 +412,7 @@ describe('useAtomSelector', () => {
   })
 
   test('inline selectors are swapped out in strict mode double-renders', async () => {
+    jest.useFakeTimers()
     const atom1 = atom('1', () => ({ val: 1 }))
 
     function Test() {
@@ -441,9 +442,9 @@ describe('useAtomSelector', () => {
 
     expect(ecosystem.selectors.findAll()).toMatchInlineSnapshot(`
       {
-        "@@selector-unnamed-0": SelectorCache {
+        "@@selector-unnamed-1": SelectorCache {
           "args": [],
-          "id": "@@selector-unnamed-0",
+          "id": "@@selector-unnamed-1",
           "nextReasons": [],
           "prevReasons": [],
           "result": 1,
@@ -455,17 +456,16 @@ describe('useAtomSelector', () => {
 
     act(() => {
       fireEvent.click(button)
+      jest.runAllTimers()
     })
-
-    await Promise.resolve()
 
     expect(div.innerHTML).toBe('11')
 
     expect(ecosystem.selectors.findAll()).toMatchInlineSnapshot(`
       {
-        "@@selector-unnamed-1": SelectorCache {
+        "@@selector-unnamed-3": SelectorCache {
           "args": [],
-          "id": "@@selector-unnamed-1",
+          "id": "@@selector-unnamed-3",
           "nextReasons": [],
           "prevReasons": [],
           "result": 1,
@@ -476,6 +476,7 @@ describe('useAtomSelector', () => {
   })
 
   test('inline selector that returns a different object reference every time only triggers one extra rerender (strict mode off)', async () => {
+    jest.useFakeTimers()
     const atom1 = atom('1', () => ({ val: 1 }))
     let renders = 0
 
@@ -495,21 +496,21 @@ describe('useAtomSelector', () => {
     const div = await findByTestId('text')
 
     expect(div.innerHTML).toBe('1')
-    expect(renders).toBe(2)
+    expect(renders).toBe(1)
     expect(ecosystem._graph.nodes).toMatchSnapshot()
 
     act(() => {
       ecosystem.getInstance(atom1).setState({ val: 2 })
+      jest.runAllTimers()
     })
 
-    await Promise.resolve()
-
     expect(div.innerHTML).toBe('2')
-    expect(renders).toBe(4)
+    expect(renders).toBe(2)
     expect(ecosystem._graph.nodes).toMatchSnapshot()
   })
 
   test('inline selector that returns a different object reference every time only triggers one extra rerender (strict mode on)', async () => {
+    jest.useFakeTimers()
     const atom1 = atom('1', () => ({ val: 1 }))
     let renders = 0
 
@@ -531,17 +532,16 @@ describe('useAtomSelector', () => {
     const div = await findByTestId('text')
 
     expect(div.innerHTML).toBe('1')
-    expect(renders).toBe(4) // 2 rerenders + 2 for strict mode
+    expect(renders).toBe(2) // 2 rerenders + 2 for strict mode
     expect(ecosystem._graph.nodes).toMatchSnapshot()
 
     act(() => {
       ecosystem.getInstance(atom1).setState({ val: 2 })
+      jest.runAllTimers()
     })
 
-    await Promise.resolve()
-
     expect(div.innerHTML).toBe('2')
-    expect(renders).toBe(8) // 4 rerenders + 4 for strict mode
+    expect(renders).toBe(4) // 4 rerenders + 4 for strict mode
     expect(ecosystem._graph.nodes).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
## Description

When `useAtomSelector`'s `useEffect`'s cleanup function runs, it can destroy any `ttl: 0` atoms before the `useEffect` body generates the new cached selector that should be keeping those atoms around.

While this extra destruction/recreation shouldn't usually cause problems, it can lead to a bug when such an atom is created outside React, given updated state, and then subscribed to by only the selector that is then destroyed. The best practice is to not give `ttl` (especially not `ttl: 0`) to atoms you intend to pre-cache or manage outside React. But still, Zedux can at least not make things worse in this case.

Use `queueMicrotask` very strategically to work around React's timing here. Defer cleanup of the old selector cache until the new effect run has subscribed to the new selector cache.

Also fix the annoying double renders and double selector invocations we added with the recent selector changes. It was very complex to work around those, so I've been putting it off. But I finally got it using:

- a couple state machines stored in a couple places (locally in the component body, on a `useState()[1]` "ref", and in the Selectors class's new `_storage` property).
- another `queueMicrotask` that cleans up all the mess this causes

These work around React StrictMode's behavior of completely destroying the first-rendered component before any effects can run.

Also clean up `Selectors#_storage` on ecosystem wipe and update tests.