### PR TITLE
fix(atoms): disable `ecosystem.find()` fuzzy search if params are passed

### DIFF
--- a/packages/react/test/units/Ecosystem.test.tsx
+++ b/packages/react/test/units/Ecosystem.test.tsx
@@ -102,6 +102,25 @@ describe('Ecosystem', () => {
     )
   })
 
+  test('find() with params only returns exact matches', () => {
+    const atom1 = atom('1', (id?: string) => id)
+    const atom2 = atom('someLongKey1', 1)
+    const atom3 = atom('someLongKey11', 1)
+    const atom4 = atom('someLongKey111', 1)
+
+    ecosystem.getInstance(atom1, ['a'])
+    ecosystem.getInstance(atom1)
+    ecosystem.getInstance(atom1, ['b'])
+    ecosystem.getInstance(atom2)
+    ecosystem.getInstance(atom3)
+    ecosystem.getInstance(atom4)
+
+    expect(ecosystem.find('someLongKey', [])).toBeUndefined()
+    expect(ecosystem.find(atom1, ['b'])?.getState()).toBe('b')
+    expect(ecosystem.find(atom1, ['c'])).toBeUndefined()
+    expect(ecosystem.find(atom3, [])?.getState()).toBe(1)
+  })
+
   test('findAll() with no params returns all atom instances', () => {
     const atom1 = atom('1', (id: number) => id)
 


### PR DESCRIPTION
## Description

The recent change to add fuzzy search to `ecosystem.find()` (#79) made the search too fuzzy. Specifically, when atom params are passed to `ecosystem.find() , it's never expected that anything but an exact match is returned. Disable fuzzy search when params are passed.

I'm categorizing this as a bug fix, since the overtly-fuzzy search wasn't expected behavior. But it's also a new feature - e.g. now when passing a search string as the first param, you can pass an empty array as the second param to only return an exact match (or undefined if no match).