### PR TITLE
fix: optimize `useAtomSelector` for React 19

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "yarn",
+      "args": ["jest", "--runInBand"],
+      "console": "integratedTerminal",
+      "cwd": "${workspaceRoot}",
+      "internalConsoleOptions": "neverOpen"
+    },
+  ]
+}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,36 @@
 import '@testing-library/jest-dom/extend-expect'
+
+let callstacks: Record<string, string> = {}
+let id = 0
+
+afterEach(() => {
+  callstacks = {}
+  id = 0
+})
+
+const generateId = () => {
+  const stack =
+    (new Error().stack || '')
+      .split('\n')
+      .find(line => /\.test\.tsx:/.test(line)) || ''
+
+  return (callstacks[stack] ||= `:r${id++}:`)
+}
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useId: generateId,
+}))
+
+// React's `useId` gives new ids in the same callstack when a component tree is
+// destroyed/unmounted. Call this to manually force ids to be recreated in tests
+// to mimic React's behavior.
+;(globalThis as any).clearUseIdEntry = (idNum: number) => {
+  const key = Object.keys(callstacks).find(
+    key => callstacks[key] === `:r${idNum}:`
+  )
+
+  if (key) {
+    delete callstacks[key]
+  }
+}

--- a/packages/atoms/src/classes/Selectors.ts
+++ b/packages/atoms/src/classes/Selectors.ts
@@ -48,17 +48,6 @@ export class Selectors {
    */
   public _refBaseKeys = new WeakMap<AtomSelectorOrConfig<any, any>, string>()
 
-  /**
-   * Used to work around React double-renders and double-effects.
-   */
-  public _storage: Record<
-    string,
-    {
-      cache?: SelectorCache
-      ignorePhase?: number
-    }
-  > = {}
-
   constructor(private readonly ecosystem: Ecosystem) {}
 
   public addDependent(
@@ -181,9 +170,8 @@ export class Selectors {
       args as Args,
       true
     )
-    if (!id) return
 
-    return this._items[id]
+    return id && this._items[id]
   }
 
   /**
@@ -304,6 +292,7 @@ export class Selectors {
     _graph.removeDependencies(id)
     _graph.removeNode(id)
     delete this._items[id]
+    this._refBaseKeys.delete(cache.selectorRef)
     cache.isDestroyed = true
     // don't delete the ref from this._refBaseKeys; this selector cache isn't
     // necessarily the only one using it (if the selector takes params). Just
@@ -368,20 +357,19 @@ export class Selectors {
   /**
    * Should only be used internally
    */
-  public _swapRefs(
-    oldRef: AtomSelectorOrConfig<any, any[]>,
-    newRef: AtomSelectorOrConfig<any, any[]>,
+  public _swapRefs<T, Args extends any[]>(
+    oldCache: SelectorCache<T, Args>,
+    newRef: AtomSelectorOrConfig<T, Args>,
     args: any[] = []
   ) {
-    const existingCache = this.find(oldRef, args)
-    const baseKey = this._refBaseKeys.get(oldRef)
+    const baseKey = this._refBaseKeys.get(oldCache.selectorRef)
 
-    if (!existingCache || !baseKey) return
+    if (!baseKey) return
 
     this._refBaseKeys.set(newRef, baseKey)
-    this._refBaseKeys.delete(oldRef)
-    existingCache.selectorRef = newRef
-    this.runSelector(existingCache.id, args)
+    this._refBaseKeys.delete(oldCache.selectorRef)
+    oldCache.selectorRef = newRef
+    this.runSelector(oldCache.id, args, false, true)
   }
 
   /**
@@ -394,7 +382,6 @@ export class Selectors {
     })
 
     this._refBaseKeys = new WeakMap()
-    this._storage = {}
   }
 
   /**
@@ -428,7 +415,8 @@ export class Selectors {
   private runSelector<T = any, Args extends any[] = []>(
     id: string,
     args: Args,
-    isInitializing?: boolean
+    isInitializing?: boolean,
+    skipNotifyingDependents?: boolean
   ) {
     const { _evaluationStack, _graph, _mods, modBus } = this.ecosystem
     _graph.bufferUpdates(id)
@@ -450,7 +438,9 @@ export class Selectors {
       const result = selector(_evaluationStack.atomGetters, ...args)
 
       if (!isInitializing && !resultsComparator(result, cache.result as T)) {
-        _graph.scheduleDependents(id, cache.nextReasons, result, cache.result)
+        if (!skipNotifyingDependents) {
+          _graph.scheduleDependents(id, cache.nextReasons, result, cache.result)
+        }
 
         if (_mods.stateChanged) {
           modBus.dispatch(

--- a/packages/machines/test/integrations/state-machines.test.tsx
+++ b/packages/machines/test/integrations/state-machines.test.tsx
@@ -3,7 +3,7 @@ import {
   InjectMachineStoreParams,
   MachineState,
 } from '@zedux/machines'
-import { api, atom } from '@zedux/react'
+import { api, atom } from '@zedux/atoms'
 import { ecosystem } from '../../../react/test/utils/ecosystem'
 
 const injectMachine = <

--- a/packages/machines/test/snippets/api.tsx
+++ b/packages/machines/test/snippets/api.tsx
@@ -5,7 +5,7 @@ import {
   ion,
   useAtomSelector,
   useAtomValue,
-} from '@zedux/react'
+} from '../../../react/src'
 import { injectMachineStore } from '@zedux/machines'
 import React, { Suspense, useState } from 'react'
 

--- a/packages/react/src/hooks/useAtomInstance.ts
+++ b/packages/react/src/hooks/useAtomInstance.ts
@@ -117,8 +117,12 @@ export const useAtomInstance: {
     }
 
     return () => {
-      // no need to set the "ref"'s `.mounted` property to false here
+      // remove the edge immediately - no need for a delay here. When StrictMode
+      // double-invokes (invokes, then cleans up, then re-invokes) this effect,
+      // it's expected that any `ttl: 0` atoms get destroyed and recreated -
+      // that's part of what StrictMode is ensuring
       ecosystem._graph.removeEdge(dependentKey, instance.id)
+      // no need to set `render.mounted` to false here
     }
   }, [instance.id])
 

--- a/packages/react/src/hooks/useAtomSelector.ts
+++ b/packages/react/src/hooks/useAtomSelector.ts
@@ -29,10 +29,10 @@ export const useAtomSelector = <T, Args extends any[]>(
   const { _graph, selectors } = ecosystem
   const dependentKey = useReactComponentId()
   const [, render] = useState<undefined | object>()
-  const storage =
-    (render as any).storage || (selectors._storage[dependentKey] ||= {})
 
-  const existingCache = storage.cache as SelectorCache<T, Args> | undefined
+  const existingCache = (render as any).cache as
+    | SelectorCache<T, Args>
+    | undefined
 
   const argsChanged =
     !existingCache ||
@@ -46,90 +46,74 @@ export const useAtomSelector = <T, Args extends any[]>(
       : haveDepsChanged(existingCache.args, args))
 
   const resolvedArgs = argsChanged ? args : (existingCache.args as Args)
-  const cache = selectors.getCache(selectorOrConfig, resolvedArgs)
-  const renderedResult = cache.result
 
-  if (cache !== existingCache) {
-    if (existingCache) {
-      // yes, remove this during render
-      _graph.removeEdge(dependentKey, existingCache.id)
+  // if the refs/args don't match, existingCache has refCount: 1, there is no
+  // cache yet for the new ref, and the new ref has the same name, assume it's
+  // an inline selector
+  const isSwappingRefs =
+    existingCache &&
+    existingCache.selectorRef !== selectorOrConfig &&
+    !argsChanged
+      ? _graph.nodes[existingCache.id]?.refCount === 1 &&
+        !selectors._refBaseKeys.has(selectorOrConfig) &&
+        selectors._getIdealCacheId(existingCache.selectorRef) ===
+          selectors._getIdealCacheId(selectorOrConfig)
+      : false
+
+  if (isSwappingRefs) {
+    // switch `mounted` to false temporarily to prevent circular rerenders
+    ;(render as any).mounted = false
+    selectors._swapRefs(
+      existingCache as SelectorCache<any, any[]>,
+      selectorOrConfig as AtomSelectorOrConfig<any, any[]>,
+      resolvedArgs
+    )
+    ;(render as any).mounted = false
+  }
+
+  const cache = isSwappingRefs
+    ? (existingCache as SelectorCache<T, Args>)
+    : selectors.getCache(selectorOrConfig, resolvedArgs)
+
+  const addEdge = () => {
+    if (!_graph.nodes[cache.id]?.dependents.get(dependentKey)) {
+      _graph.addEdge(dependentKey, cache.id, OPERATION, External, () => {
+        if ((render as any).mounted) render({})
+      })
     }
-
-    storage.cache = cache as SelectorCache<any, any[]>
   }
 
-  // When an inline selector returns a referentially unstable result every run,
-  // we have to ignore the subsequent update. Do that using a "state machine"
-  // that goes from 0 -> 1 -> 2. This machine ensures that the ignored update
-  // occurs after the component rerenders and the effect reruns after that
-  // render. This works with strict mode on or off. Use the stable `render`
-  // function as a "ref" :O
-  if (storage.ignorePhase === 1) {
-    storage.ignorePhase = 2
-  }
+  // Yes, subscribe during render. This operation is idempotent.
+  addEdge()
 
-  let cancelCleanup = false
+  const renderedResult = cache.result
+  ;(render as any).cache = cache as SelectorCache<any, any[]>
 
   useEffect(() => {
-    cancelCleanup = true
-    delete selectors._storage[dependentKey]
-    ;(render as any).storage = storage
+    // Try adding the edge again (will be a no-op unless React's StrictMode ran
+    // this effect's cleanup unnecessarily)
+    addEdge()
 
-    // re-get the cache in case an unmounting component's effect cleanup
-    // destroyed it before we could add this dependent
-    const newCache = selectors.getCache(selectorOrConfig, resolvedArgs)
-
-    const cleanup = () => {
-      if (cancelCleanup) {
-        cancelCleanup = false
-
-        return
-      }
-
-      if (storage.ignorePhase !== 1) {
-        delete selectors._storage[dependentKey]
-
-        queueMicrotask(() => {
-          _graph.removeEdge(dependentKey, newCache.id)
-        })
-      }
-    }
-
-    // Make this function idempotent to guard against React's double-invocation
-    if (_graph.nodes[newCache.id]?.dependents.get(dependentKey)) {
-      return cleanup
-    }
-
-    _graph.addEdge(dependentKey, newCache.id, OPERATION, External, () =>
-      render({})
-    )
+    // use the referentially stable render function as a ref :O
+    ;(render as any).mounted = true
 
     // an unmounting component's effect cleanup can force-destroy the selector
-    // or update its dependencies before this component is mounted. If that
-    // happened, trigger a rerender to recache the selector and/or get its new
-    // result. On the rerender, ignore changes
-    if (newCache.result !== renderedResult && !storage.ignorePhase) {
-      storage.ignorePhase = 1
+    // or update the state of its dependencies (causing it to rerun) before we
+    // set `render.mounted`. If that happened, trigger a rerender to recreate
+    // the selector and/or get its new state
+    if (cache.isDestroyed || cache.result !== renderedResult) {
       render({})
     }
 
-    if (storage.ignorePhase === 2) {
-      storage.ignorePhase = 0
+    return () => {
+      // remove the edge immediately - no need for a delay here. When StrictMode
+      // double-invokes (invokes, then cleans up, then re-invokes) this effect,
+      // it's expected that selectors and `ttl: 0` atoms with no other
+      // dependents get destroyed and recreated - that's part of what StrictMode
+      // is ensuring
+      _graph.removeEdge(dependentKey, cache.id)
+      // no need to set `render.mounted` to false here
     }
-
-    // React StrictMode's double renders can wreak havoc on the selector cache.
-    // Clean up havoc
-    queueMicrotask(() => {
-      cancelCleanup = false
-
-      Object.values(selectors._storage).forEach(storageItem => {
-        if (storageItem.cache?.id) {
-          selectors._destroySelector(storageItem.cache.id)
-        }
-      })
-    })
-
-    return cleanup
   }, [cache])
 
   return renderedResult as T

--- a/packages/react/test/integrations/__snapshots__/selection.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/selection.test.tsx.snap
@@ -106,10 +106,10 @@ exports[`selection same-name selectors share the namespace when destroyed and re
 {
   "1": {
     "dependencies": Map {
-      "@@selector-common-name-0" => true,
+      "@@selector-common-name-4" => true,
     },
     "dependents": Map {
-      "no-4" => {
+      "no-5" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 3,
@@ -136,12 +136,12 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "refCount": 1,
     "weight": 3,
   },
-  "@@selector-common-name-0": {
+  "@@selector-common-name-2": {
     "dependencies": Map {
       "root" => true,
     },
     "dependents": Map {
-      "1" => {
+      "2" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -152,12 +152,12 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "refCount": 1,
     "weight": 2,
   },
-  "@@selector-common-name-2": {
+  "@@selector-common-name-4": {
     "dependencies": Map {
       "root" => true,
     },
     "dependents": Map {
-      "2" => {
+      "1" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -177,7 +177,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
         "flags": 0,
         "operation": "get",
       },
-      "@@selector-common-name-0" => {
+      "@@selector-common-name-4" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -195,10 +195,10 @@ exports[`selection same-name selectors share the namespace when destroyed and re
 {
   "1": {
     "dependencies": Map {
-      "@@selector-common-name-0" => true,
+      "@@selector-common-name-4" => true,
     },
     "dependents": Map {
-      "no-4" => {
+      "no-5" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 3,
@@ -209,7 +209,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "refCount": 1,
     "weight": 3,
   },
-  "@@selector-common-name-0": {
+  "@@selector-common-name-4": {
     "dependencies": Map {
       "root" => true,
     },
@@ -228,7 +228,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
   "root": {
     "dependencies": Map {},
     "dependents": Map {
-      "@@selector-common-name-0" => {
+      "@@selector-common-name-4" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,

--- a/packages/react/test/integrations/selection.test.tsx
+++ b/packages/react/test/integrations/selection.test.tsx
@@ -150,6 +150,11 @@ describe('selection', () => {
     expect(selector3).toHaveBeenCalledTimes(1)
     expect((await findByTestId('text')).innerHTML).toBe('c1')
 
+    // reset the 3 useId calls in ResurrectingComponent's useAtomSelectors
+    ;(globalThis as any).clearUseIdEntry(1)
+    ;(globalThis as any).clearUseIdEntry(2)
+    ;(globalThis as any).clearUseIdEntry(3)
+
     act(() => {
       fireEvent.click(button)
       jest.runAllTimers()

--- a/packages/react/test/units/Selectors.test.tsx
+++ b/packages/react/test/units/Selectors.test.tsx
@@ -62,9 +62,8 @@ describe('the Selectors class', () => {
     ecosystem.selectors.destroyCache(cache2b) // destroys only selector2
 
     expect(ecosystem.selectors._items).toEqual({
-      // id # is still 1 'cause the Selector class's `_refBaseKeys` still holds
-      // the cached key despite `cache2b`'s destruction above
-      '@@selector-selector1-1': expect.any(Object),
+      // id 3 'cause cache1b is the 4th id'd item created
+      '@@selector-selector1-3': expect.any(Object),
     })
 
     cleanup()
@@ -116,10 +115,9 @@ describe('the Selectors class', () => {
     expect(cache1.isDestroyed).toBe(true)
     expect(cache2.isDestroyed).toBe(true)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      // ids 2 & 1 - the refs are still cached in the Selector class's
-      // `_refBaseKeys`
-      '@@selector-selector1-2': 'ab',
-      '@@selector-selector2-1': 'abc',
+      // 5 ids have been created at this point
+      '@@selector-selector1-4': 'ab',
+      '@@selector-selector2-3': 'abc',
       '@@selector-selector3-0': 'abcd',
     })
 

--- a/packages/react/test/units/__snapshots__/useAtomSelector.test.tsx.snap
+++ b/packages/react/test/units/__snapshots__/useAtomSelector.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`useAtomSelector inline selector that returns a different object referen
       "1" => true,
     },
     "dependents": Map {
-      "Test-:rb:" => {
+      "Test-:r0:" => {
         "callback": [Function],
         "createdAt": 123456789,
         "flags": 2,
@@ -40,7 +40,7 @@ exports[`useAtomSelector inline selector that returns a different object referen
   "1": {
     "dependencies": Map {},
     "dependents": Map {
-      "@@selector-unnamed-1" => {
+      "@@selector-unnamed-0" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -51,16 +51,17 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "refCount": 1,
     "weight": 1,
   },
-  "@@selector-unnamed-1": {
+  "@@selector-unnamed-0": {
     "dependencies": Map {
       "1" => true,
     },
     "dependents": Map {
-      "Test-:rb:" => {
+      "Test-:r0:" => {
         "callback": [Function],
         "createdAt": 123456789,
         "flags": 2,
         "operation": "useAtomSelector",
+        "task": undefined,
       },
     },
     "isSelector": true,
@@ -75,7 +76,13 @@ exports[`useAtomSelector inline selector that returns a different object referen
   "1": {
     "dependencies": Map {},
     "dependents": Map {
-      "@@selector-unnamed-1" => {
+      "@@selector-unnamed-0" => {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 0,
+        "operation": "get",
+      },
+      "@@selector-unnamed-2" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -83,15 +90,31 @@ exports[`useAtomSelector inline selector that returns a different object referen
       },
     },
     "isSelector": undefined,
-    "refCount": 1,
+    "refCount": 2,
     "weight": 1,
   },
-  "@@selector-unnamed-1": {
+  "@@selector-unnamed-0": {
     "dependencies": Map {
       "1" => true,
     },
     "dependents": Map {
-      "Test-:rd:" => {
+      "Test-:r0:" => {
+        "callback": [Function],
+        "createdAt": 123456789,
+        "flags": 2,
+        "operation": "useAtomSelector",
+      },
+    },
+    "isSelector": true,
+    "refCount": 1,
+    "weight": 2,
+  },
+  "@@selector-unnamed-2": {
+    "dependencies": Map {
+      "1" => true,
+    },
+    "dependents": Map {
+      "Test-:r0:" => {
         "callback": [Function],
         "createdAt": 123456789,
         "flags": 2,
@@ -110,7 +133,13 @@ exports[`useAtomSelector inline selector that returns a different object referen
   "1": {
     "dependencies": Map {},
     "dependents": Map {
-      "@@selector-unnamed-3" => {
+      "@@selector-unnamed-0" => {
+        "callback": undefined,
+        "createdAt": 123456789,
+        "flags": 0,
+        "operation": "get",
+      },
+      "@@selector-unnamed-2" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -118,19 +147,37 @@ exports[`useAtomSelector inline selector that returns a different object referen
       },
     },
     "isSelector": undefined,
-    "refCount": 1,
+    "refCount": 2,
     "weight": 1,
   },
-  "@@selector-unnamed-3": {
+  "@@selector-unnamed-0": {
     "dependencies": Map {
       "1" => true,
     },
     "dependents": Map {
-      "Test-:rd:" => {
+      "Test-:r0:" => {
         "callback": [Function],
         "createdAt": 123456789,
         "flags": 2,
         "operation": "useAtomSelector",
+        "task": undefined,
+      },
+    },
+    "isSelector": true,
+    "refCount": 1,
+    "weight": 2,
+  },
+  "@@selector-unnamed-2": {
+    "dependencies": Map {
+      "1" => true,
+    },
+    "dependents": Map {
+      "Test-:r0:" => {
+        "callback": [Function],
+        "createdAt": 123456789,
+        "flags": 2,
+        "operation": "useAtomSelector",
+        "task": undefined,
       },
     },
     "isSelector": true,

--- a/packages/react/test/units/useAtomSelector.test.tsx
+++ b/packages/react/test/units/useAtomSelector.test.tsx
@@ -168,7 +168,7 @@ describe('useAtomSelector', () => {
     })
   })
 
-  test('useAtomSelector creates/uses a different cache when selector goes from object form to function form', async () => {
+  test('useAtomSelector reuses the same cache when selector goes from object form to function form', async () => {
     jest.useFakeTimers()
     const selector1 = jest.fn(() => 1)
 
@@ -208,7 +208,7 @@ describe('useAtomSelector', () => {
     expect(div.innerHTML).toBe('1')
     expect(selector1).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-1': 1,
+      '@@selector-mockConstructor-0': 1,
     })
   })
 
@@ -305,7 +305,7 @@ describe('useAtomSelector', () => {
     expect(div.innerHTML).toBe('0')
     expect(selector1).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-1-[0]': 0,
+      '@@selector-mockConstructor-0-[0]': 0,
     })
   })
 
@@ -356,7 +356,7 @@ describe('useAtomSelector', () => {
     expect(div.innerHTML).toBe('1')
     expect(selector1).toHaveBeenCalledTimes(2)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      '@@selector-mockConstructor-2': 1,
+      '@@selector-mockConstructor-0': 1,
     })
     expect(renders).toBe(2)
   })
@@ -440,11 +440,22 @@ describe('useAtomSelector', () => {
     const button = await findByTestId('button')
     const div = await findByTestId('text')
 
+    // TODO: These snapshots are temporarily wrong in StrictMode pre React 19
+    // (React 18 StrictMode causes a memory leak). Upgrading to React 19 will
+    // fix them.
     expect(ecosystem.selectors.findAll()).toMatchInlineSnapshot(`
       {
-        "@@selector-unnamed-1": SelectorCache {
+        "@@selector-unnamed-0": SelectorCache {
           "args": [],
-          "id": "@@selector-unnamed-1",
+          "id": "@@selector-unnamed-0",
+          "nextReasons": [],
+          "prevReasons": [],
+          "result": 1,
+          "selectorRef": [Function],
+        },
+        "@@selector-unnamed-2": SelectorCache {
+          "args": [],
+          "id": "@@selector-unnamed-2",
           "nextReasons": [],
           "prevReasons": [],
           "result": 1,
@@ -463,9 +474,17 @@ describe('useAtomSelector', () => {
 
     expect(ecosystem.selectors.findAll()).toMatchInlineSnapshot(`
       {
-        "@@selector-unnamed-3": SelectorCache {
+        "@@selector-unnamed-0": SelectorCache {
           "args": [],
-          "id": "@@selector-unnamed-3",
+          "id": "@@selector-unnamed-0",
+          "nextReasons": [],
+          "prevReasons": [],
+          "result": 1,
+          "selectorRef": [Function],
+        },
+        "@@selector-unnamed-2": SelectorCache {
+          "args": [],
+          "id": "@@selector-unnamed-2",
           "nextReasons": [],
           "prevReasons": [],
           "result": 1,
@@ -532,7 +551,11 @@ describe('useAtomSelector', () => {
     const div = await findByTestId('text')
 
     expect(div.innerHTML).toBe('1')
-    expect(renders).toBe(2) // 2 rerenders + 2 for strict mode
+    expect(renders).toBe(4) // 2 rerenders + 2 for strict mode
+
+    // TODO: These snapshots are temporarily wrong in StrictMode pre React 19
+    // (React 18 StrictMode causes a memory leak). Upgrading to React 19 will
+    // fix them.
     expect(ecosystem._graph.nodes).toMatchSnapshot()
 
     act(() => {
@@ -541,7 +564,7 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('2')
-    expect(renders).toBe(4) // 4 rerenders + 4 for strict mode
+    expect(renders).toBe(6) // 3 rerenders + 3 for strict mode
     expect(ecosystem._graph.nodes).toMatchSnapshot()
   })
 })

--- a/packages/react/test/utils/ecosystem.ts
+++ b/packages/react/test/utils/ecosystem.ts
@@ -1,5 +1,5 @@
 import { act } from '@testing-library/react'
-import { createEcosystem } from '@zedux/react'
+import { createEcosystem } from '@zedux/atoms'
 
 export const ecosystem = createEcosystem({ id: 'test' })
 


### PR DESCRIPTION
## Description

`useAtomSelector` has had to jump through so many hoops to support React 18. Some of these hoops have caused such ugly code that edge cases are possible. We've seen one that we can't reproduce consistently, but it comes down to React scheduling `useEffect` microtasks for a newly mounted component tree at different points in time that interweave with `useAtomSelector`'s `queueMicrotask` calls inside its `useEffect`s in that same component tree.

`useAtomSelector` has to support React StrictMode (and concurrent mode and everything StrictMode prepares for) while handling inline selectors, selectors that return referentially unstable results, and of course the old problematic React behavior of unmounting a component tree after the new tree has rendered, but before its effects have run.

This is fairly difficult. But two underlying React issues in StrictMode (and only StrictMode - concurrent mode is fine) made it just ridiculous:

- React's `useRef` (and `useState()[1]` function) references are unstable due to StrictMode unnecessarily destroying those resources after initial render.
-  React's `useId` returns a different id after initial render.

These made tracking down selector cache entries created for inline selectors on that initial render an impossible task to do perfectly. We had to put some hacky workarounds together to prevent memory leaks. These hacky workarounds included the problematic `queueMicrotask` in a `useEffect` that reads data off the Zedux ecosystem (something that does persist between renders) to try to clean up leaked selector caches from inline selectors whose references changed on the second render. Anyway, it was a nightmare. But:

This nightmare is no more! React 19 fixes both these underlying issues - refs are stable even in StrictMode and `useId` returns a consistent id even on initial render.

So clean up `useAtomSelector` a ton. Get rid of the `ignorePhase` state machine, the `queueMicrotask`s, `ecosystem.selectors._storage`, and the deferring graph edge creation until the `useEffect` runs. Go back to the good old ref swapping for inline selectors to prevent unnecessary graph updates. Update tests and double check all of them.

## What This Means for You

We're releasing this change under Zedux `v1.3.0-rc.x`. This change is compatible with React 18 **non-StrictMode only**.

- If you're not using StrictMode, you can upgrade to the new Zedux version when this PR merges via `npm i @zedux/react@canary`.
- If you're using StrictMode, upgrading to Zedux v1.3 can lead to memory leaks in React 18 if you pass inline selectors (functions declared in the function body of the component, including in a `useMemo`) to `useAtomSelector`. Either ensure you never do that or (recommended) upgrade to React 19 (which should be released soon) before upgrading to Zedux v1.3.