### PR TITLE
fix(react): restore `useAtomSelector` mounted state when swapping inline refs

### DIFF
--- a/packages/react/src/hooks/useAtomSelector.ts
+++ b/packages/react/src/hooks/useAtomSelector.ts
@@ -68,7 +68,7 @@ export const useAtomSelector = <T, Args extends any[]>(
       selectorOrConfig as AtomSelectorOrConfig<any, any[]>,
       resolvedArgs
     )
-    ;(render as any).mounted = false
+    ;(render as any).mounted = true
   }
 
   const cache = isSwappingRefs


### PR DESCRIPTION
## Description

The new `useAtomSelector` implementation had a copy-paste error - when setting `mounted` to false temporarily while swapping out inline refs, the code never actually set it back to true, instead setting it to false again. This meant inline selectors would lose their subscription after the 2nd update (it would go: First render, first update, second render, swap ref and destroy subscription). No test cases and my simple testing never checked beyond the second render.

Add a regression test for this that makes sure inline selectors stay subscribed across four renders.