### PR TITLE
fix(react): only rerun `useAtomSelector` effect on cache id change

### DIFF
--- a/packages/atoms/src/classes/Selectors.ts
+++ b/packages/atoms/src/classes/Selectors.ts
@@ -292,7 +292,6 @@ export class Selectors {
     _graph.removeDependencies(id)
     _graph.removeNode(id)
     delete this._items[id]
-    this._refBaseKeys.delete(cache.selectorRef)
     cache.isDestroyed = true
     // don't delete the ref from this._refBaseKeys; this selector cache isn't
     // necessarily the only one using it (if the selector takes params). Just

--- a/packages/react/src/hooks/useAtomSelector.ts
+++ b/packages/react/src/hooks/useAtomSelector.ts
@@ -114,7 +114,7 @@ export const useAtomSelector = <T, Args extends any[]>(
       _graph.removeEdge(dependentKey, cache.id)
       // no need to set `render.mounted` to false here
     }
-  }, [cache])
+  }, [cache.id])
 
   return renderedResult as T
 }

--- a/packages/react/test/integrations/__snapshots__/selection.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/selection.test.tsx.snap
@@ -106,10 +106,10 @@ exports[`selection same-name selectors share the namespace when destroyed and re
 {
   "1": {
     "dependencies": Map {
-      "@@selector-common-name-4" => true,
+      "@@selector-common-name-0" => true,
     },
     "dependents": Map {
-      "no-5" => {
+      "no-4" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 3,
@@ -136,12 +136,12 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "refCount": 1,
     "weight": 3,
   },
-  "@@selector-common-name-2": {
+  "@@selector-common-name-0": {
     "dependencies": Map {
       "root" => true,
     },
     "dependents": Map {
-      "2" => {
+      "1" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -152,12 +152,12 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "refCount": 1,
     "weight": 2,
   },
-  "@@selector-common-name-4": {
+  "@@selector-common-name-2": {
     "dependencies": Map {
       "root" => true,
     },
     "dependents": Map {
-      "1" => {
+      "2" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -177,7 +177,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
         "flags": 0,
         "operation": "get",
       },
-      "@@selector-common-name-4" => {
+      "@@selector-common-name-0" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -195,10 +195,10 @@ exports[`selection same-name selectors share the namespace when destroyed and re
 {
   "1": {
     "dependencies": Map {
-      "@@selector-common-name-4" => true,
+      "@@selector-common-name-0" => true,
     },
     "dependents": Map {
-      "no-5" => {
+      "no-4" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 3,
@@ -209,7 +209,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "refCount": 1,
     "weight": 3,
   },
-  "@@selector-common-name-4": {
+  "@@selector-common-name-0": {
     "dependencies": Map {
       "root" => true,
     },
@@ -228,7 +228,7 @@ exports[`selection same-name selectors share the namespace when destroyed and re
   "root": {
     "dependencies": Map {},
     "dependents": Map {
-      "@@selector-common-name-4" => {
+      "@@selector-common-name-0" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,

--- a/packages/react/test/units/Selectors.test.tsx
+++ b/packages/react/test/units/Selectors.test.tsx
@@ -62,8 +62,9 @@ describe('the Selectors class', () => {
     ecosystem.selectors.destroyCache(cache2b) // destroys only selector2
 
     expect(ecosystem.selectors._items).toEqual({
-      // id 3 'cause cache1b is the 4th id'd item created
-      '@@selector-selector1-3': expect.any(Object),
+      // id # is still 1 'cause the Selector class's `_refBaseKeys` still holds
+      // the cached key despite `cache2b`'s destruction above
+      '@@selector-selector1-1': expect.any(Object),
     })
 
     cleanup()
@@ -115,9 +116,10 @@ describe('the Selectors class', () => {
     expect(cache1.isDestroyed).toBe(true)
     expect(cache2.isDestroyed).toBe(true)
     expect(ecosystem.selectors.dehydrate()).toEqual({
-      // 5 ids have been created at this point
-      '@@selector-selector1-4': 'ab',
-      '@@selector-selector2-3': 'abc',
+      // ids 2 & 1 - the refs are still cached in the Selector class's
+      // `_refBaseKeys`
+      '@@selector-selector1-2': 'ab',
+      '@@selector-selector2-1': 'abc',
       '@@selector-selector3-0': 'abcd',
     })
 


### PR DESCRIPTION
## Description

With the new changes to `useAtomSelector`, we can optimize the `useEffect` to only rerun when the cache id changes, not the cache object reference. This makes `useAtomSelector` even more closely mimic `useAtomInstance` which has been a beautifully stable piece of code for a long time now.

This actually fixes an rerender loop bug that I originally attempted to address by going back to deleting the ref from the Selector class's weak map on selector destroy. But that approach doesn't work because it deletes the ref that may still be in use by other caches of the same selector ref that have different params. Add a test case for this so we never regress again.