### PR TITLE
fix(react): make `useAtomSelector` wait for idle time to do failsafe cleanup

### DIFF
--- a/packages/atoms/src/classes/Selectors.ts
+++ b/packages/atoms/src/classes/Selectors.ts
@@ -56,6 +56,7 @@ export class Selectors {
     {
       cache?: SelectorCache
       ignorePhase?: number
+      timeoutId?: ReturnType<typeof requestIdleCallback | typeof setTimeout>
     }
   > = {}
 

--- a/packages/react/test/units/useAtomSelector.test.tsx
+++ b/packages/react/test/units/useAtomSelector.test.tsx
@@ -440,6 +440,8 @@ describe('useAtomSelector', () => {
     const button = await findByTestId('button')
     const div = await findByTestId('text')
 
+    jest.runAllTimers()
+
     expect(ecosystem.selectors.findAll()).toMatchInlineSnapshot(`
       {
         "@@selector-unnamed-1": SelectorCache {
@@ -530,6 +532,8 @@ describe('useAtomSelector', () => {
     })
 
     const div = await findByTestId('text')
+
+    jest.runAllTimers()
 
     expect(div.innerHTML).toBe('1')
     expect(renders).toBe(2) // 2 rerenders + 2 for strict mode


### PR DESCRIPTION
## Description

`useAtomSelector`'s failsafe `queueMicrotask` is a little too aggressive and can (very rarely) lead to race conditions with React's own queued microtasks. #106 and Zedux v1.3.x already fix this for React 19, but React 18 is still the current version and still needs a better (temporary) fix.

Use `requestIdleCallback` (falling back to `setTimeout` in node) instead of `queueMicrotask`. This means (in StrictMode in React 18) that some leaked selector nodes will be visible for a short time before Zedux circles back and cleans them up, but it's better than being too aggressive and cleaning up graph edges that shouldn't be.