### PR TITLE
feat(react): upgrade peer and dev deps to React 19

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,11 +13,12 @@
     "@zedux/atoms": "^1.3.0-rc.2"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^14.0.0",
-    "@types/react-dom": "^18.0.11",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "@testing-library/react": "^16.0.1",
+    "@types/react-dom": "^18.3.0",
+    "react": "^19.0.0-rc-ee1a403a-20240916",
+    "react-dom": "^19.0.0-rc-ee1a403a-20240916"
   },
   "exports": {
     ".": {
@@ -55,7 +56,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=18.0.0"
+    "react": ">=19.0.0"
   },
   "repository": {
     "directory": "packages/react",

--- a/packages/react/src/hooks/useReactComponentId.ts
+++ b/packages/react/src/hooks/useReactComponentId.ts
@@ -1,5 +1,35 @@
 import React, { useId } from 'react'
 
+type MaybeComponent =
+  | {
+      displayName?: string
+      name?: string
+    }
+  | undefined
+
+type React19 = {
+  __CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE?: {
+    A?: {
+      getOwner?: () => {
+        type?: MaybeComponent
+      }
+    }
+  }
+
+  __SERVER_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE?: {
+    A?: {
+      getOwner?: () => {
+        type?: MaybeComponent
+      }
+    }
+  }
+}
+
+const react19KeyBase =
+  '_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE' as const
+const clientKey = `__CLIENT${react19KeyBase}` as const
+const serverKey = `__SERVER${react19KeyBase}` as const
+
 /**
  * Get a unique id for a Zedux hook call. This id is predictable - it should be
  * exactly the same every time a given component renders in the same place in
@@ -8,18 +38,14 @@ import React, { useId } from 'react'
  *
  * This uses the forbidden React internals object. We only use it to get a
  * dev-friendly name for the React component's node in the atom graph. It's fine
- * if React changes their internals - we'll fall back to using a generated node
- * name.
+ * if React changes their internals - we'll fall back to the string "rc" ("React
+ * Component"). We have no need to "warn users they cannot upgrade" 'cause they
+ * can at the cost of some DX.
  */
 export const useReactComponentId = () => {
-  const component:
-    | {
-        displayName?: string
-        name?: string
-      }
-    | undefined = (React as any)
-    .__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED?.ReactCurrentOwner
-    ?.current?.type
+  const component: MaybeComponent = (
+    (React as React19)[clientKey] || (React as React19)[serverKey]
+  )?.A?.getOwner?.()?.type
 
   const name = component?.displayName || component?.name || 'rc'
 

--- a/packages/react/test/integrations/ecosystem.test.tsx
+++ b/packages/react/test/integrations/ecosystem.test.tsx
@@ -11,7 +11,7 @@ import {
   getEcosystem,
 } from '@zedux/react'
 import React, { useState } from 'react'
-import { act } from 'react-dom/test-utils'
+import { act } from '@testing-library/react'
 import { ecosystem } from '../utils/ecosystem'
 import { renderInEcosystem } from '../utils/renderInEcosystem'
 import { fireEvent, render } from '@testing-library/react'

--- a/packages/react/test/integrations/react-context.test.tsx
+++ b/packages/react/test/integrations/react-context.test.tsx
@@ -119,7 +119,6 @@ describe('React context', () => {
 
       render() {
         if (this.state.error) {
-          // You can render any custom fallback UI
           return <div data-testid="1">{this.state.error}</div>
         }
 
@@ -136,7 +135,7 @@ describe('React context', () => {
     const div = await findByTestId('1')
 
     expect(div.innerHTML).toMatch(/AtomProvider.*requires.*prop/i)
-    expect(spy).toHaveBeenCalledTimes(3)
+    expect(spy).toHaveBeenCalledTimes(1)
 
     spy.mockReset()
   })
@@ -209,7 +208,6 @@ describe('React context', () => {
 
   test('useAtomContext() throws an error if 2nd param is true and no instance was provided', async () => {
     jest.useFakeTimers()
-    const mock = mockConsole('error')
     const atom1 = atom('1', (id: string) => id)
 
     function Test() {
@@ -222,11 +220,5 @@ describe('React context', () => {
     const pattern = /no atom instance was provided/i
 
     expect(() => renderInEcosystem(<Test />)).toThrowError(pattern)
-    expect(mock).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        message: expect.stringMatching(pattern),
-      })
-    )
   })
 })

--- a/packages/react/test/integrations/suspense.test.tsx
+++ b/packages/react/test/integrations/suspense.test.tsx
@@ -93,12 +93,15 @@ describe('suspense', () => {
     const div2 = await findByTestId('error')
 
     expect(div2.innerHTML).toBe('b')
-    expect(mock).toHaveBeenCalledTimes(3)
-    expect(mock).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        message: expect.stringMatching(/uncaught 'b'/i),
-      })
+    expect(mock).toHaveBeenCalledTimes(1)
+    expect(mock).toHaveBeenCalledWith(
+      expect.any(String),
+      'b',
+      expect.stringContaining(
+        'The above error occurred in the <Child> component'
+      ),
+      expect.any(String),
+      expect.any(String)
     )
   })
 
@@ -132,12 +135,15 @@ describe('suspense', () => {
     const div2 = await findByTestId('error')
 
     expect(div2.innerHTML).toBe('b')
-    expect(mock).toHaveBeenCalledTimes(3)
-    expect(mock).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        message: expect.stringMatching(/uncaught 'b'/i),
-      })
+    expect(mock).toHaveBeenCalledTimes(1)
+    expect(mock).toHaveBeenCalledWith(
+      expect.any(String),
+      'b',
+      expect.stringContaining(
+        'The above error occurred in the <Child> component'
+      ),
+      expect.any(String),
+      expect.any(String)
     )
   })
 

--- a/packages/react/test/units/__snapshots__/useAtomSelector.test.tsx.snap
+++ b/packages/react/test/units/__snapshots__/useAtomSelector.test.tsx.snap
@@ -76,13 +76,7 @@ exports[`useAtomSelector inline selector that returns a different object referen
   "1": {
     "dependencies": Map {},
     "dependents": Map {
-      "@@selector-unnamed-0" => {
-        "callback": undefined,
-        "createdAt": 123456789,
-        "flags": 0,
-        "operation": "get",
-      },
-      "@@selector-unnamed-2" => {
+      "@@selector-unnamed-1" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -90,26 +84,10 @@ exports[`useAtomSelector inline selector that returns a different object referen
       },
     },
     "isSelector": undefined,
-    "refCount": 2,
+    "refCount": 1,
     "weight": 1,
   },
-  "@@selector-unnamed-0": {
-    "dependencies": Map {
-      "1" => true,
-    },
-    "dependents": Map {
-      "Test-:r0:" => {
-        "callback": [Function],
-        "createdAt": 123456789,
-        "flags": 2,
-        "operation": "useAtomSelector",
-      },
-    },
-    "isSelector": true,
-    "refCount": 1,
-    "weight": 2,
-  },
-  "@@selector-unnamed-2": {
+  "@@selector-unnamed-1": {
     "dependencies": Map {
       "1" => true,
     },
@@ -133,13 +111,7 @@ exports[`useAtomSelector inline selector that returns a different object referen
   "1": {
     "dependencies": Map {},
     "dependents": Map {
-      "@@selector-unnamed-0" => {
-        "callback": undefined,
-        "createdAt": 123456789,
-        "flags": 0,
-        "operation": "get",
-      },
-      "@@selector-unnamed-2" => {
+      "@@selector-unnamed-1" => {
         "callback": undefined,
         "createdAt": 123456789,
         "flags": 0,
@@ -147,27 +119,10 @@ exports[`useAtomSelector inline selector that returns a different object referen
       },
     },
     "isSelector": undefined,
-    "refCount": 2,
+    "refCount": 1,
     "weight": 1,
   },
-  "@@selector-unnamed-0": {
-    "dependencies": Map {
-      "1" => true,
-    },
-    "dependents": Map {
-      "Test-:r0:" => {
-        "callback": [Function],
-        "createdAt": 123456789,
-        "flags": 2,
-        "operation": "useAtomSelector",
-        "task": undefined,
-      },
-    },
-    "isSelector": true,
-    "refCount": 1,
-    "weight": 2,
-  },
-  "@@selector-unnamed-2": {
+  "@@selector-unnamed-1": {
     "dependencies": Map {
       "1" => true,
     },

--- a/packages/react/test/units/useAtomSelector.test.tsx
+++ b/packages/react/test/units/useAtomSelector.test.tsx
@@ -440,22 +440,11 @@ describe('useAtomSelector', () => {
     const button = await findByTestId('button')
     const div = await findByTestId('text')
 
-    // TODO: These snapshots are temporarily wrong in StrictMode pre React 19
-    // (React 18 StrictMode causes a memory leak). Upgrading to React 19 will
-    // fix them.
     expect(ecosystem.selectors.findAll()).toMatchInlineSnapshot(`
       {
-        "@@selector-unnamed-0": SelectorCache {
+        "@@selector-unnamed-1": SelectorCache {
           "args": [],
-          "id": "@@selector-unnamed-0",
-          "nextReasons": [],
-          "prevReasons": [],
-          "result": 1,
-          "selectorRef": [Function],
-        },
-        "@@selector-unnamed-2": SelectorCache {
-          "args": [],
-          "id": "@@selector-unnamed-2",
+          "id": "@@selector-unnamed-1",
           "nextReasons": [],
           "prevReasons": [],
           "result": 1,
@@ -474,17 +463,9 @@ describe('useAtomSelector', () => {
 
     expect(ecosystem.selectors.findAll()).toMatchInlineSnapshot(`
       {
-        "@@selector-unnamed-0": SelectorCache {
+        "@@selector-unnamed-1": SelectorCache {
           "args": [],
-          "id": "@@selector-unnamed-0",
-          "nextReasons": [],
-          "prevReasons": [],
-          "result": 1,
-          "selectorRef": [Function],
-        },
-        "@@selector-unnamed-2": SelectorCache {
-          "args": [],
-          "id": "@@selector-unnamed-2",
+          "id": "@@selector-unnamed-1",
           "nextReasons": [],
           "prevReasons": [],
           "result": 1,
@@ -552,10 +533,6 @@ describe('useAtomSelector', () => {
 
     expect(div.innerHTML).toBe('1')
     expect(renders).toBe(4) // 2 rerenders + 2 for strict mode
-
-    // TODO: These snapshots are temporarily wrong in StrictMode pre React 19
-    // (React 18 StrictMode causes a memory leak). Upgrading to React 19 will
-    // fix them.
     expect(ecosystem._graph.nodes).toMatchSnapshot()
 
     act(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,11 +23,12 @@
     "@babel/highlight" "^7.18.6"
 
 "@babel/code-frame@^7.10.4":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
-  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
+  version "7.24.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.24.7.tgz#882fd9e09e8ee324e496bd040401c6f046ef4465"
+  integrity sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==
   dependencies:
-    "@babel/highlight" "^7.16.7"
+    "@babel/highlight" "^7.24.7"
+    picocolors "^1.0.0"
 
 "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0":
   version "7.16.0"
@@ -268,15 +269,15 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
   integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
 
-"@babel/helper-validator-identifier@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
-  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
-
 "@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1":
   version "7.19.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
   integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
+
+"@babel/helper-validator-identifier@^7.24.7":
+  version "7.24.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz#75b889cfaf9e35c2aaf42cf0d72c8e91719251db"
+  integrity sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==
 
 "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
@@ -315,15 +316,6 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/highlight@^7.16.7":
-  version "7.17.9"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.17.9.tgz#61b2ee7f32ea0454612def4fccdae0de232b73e3"
-  integrity sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
-
 "@babel/highlight@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
@@ -332,6 +324,16 @@
     "@babel/helper-validator-identifier" "^7.18.6"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
+
+"@babel/highlight@^7.24.7":
+  version "7.24.7"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.24.7.tgz#a05ab1df134b286558aae0ed41e6c5f731bf409d"
+  integrity sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.24.7"
+    chalk "^2.4.2"
+    js-tokens "^4.0.0"
+    picocolors "^1.0.0"
 
 "@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.16.0", "@babel/parser@^7.16.5":
   version "7.16.6"
@@ -1193,15 +1195,15 @@
   dependencies:
     "@sinonjs/commons" "^2.0.0"
 
-"@testing-library/dom@^9.0.0":
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.2.0.tgz#0e1f45e956f2a16f471559c06edd8827c4832f04"
-  integrity sha512-xTEnpUKiV/bMyEsE5bT4oYA0x0Z/colMtxzUY8bKyPXBNLn/e0V4ZjBZkEhms0xE4pv9QsPfSRu9AWS4y5wGvA==
+"@testing-library/dom@^10.4.0":
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.0.tgz#82a9d9462f11d240ecadbf406607c6ceeeff43a8"
+  integrity sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
     "@types/aria-query" "^5.0.1"
-    aria-query "^5.0.0"
+    aria-query "5.3.0"
     chalk "^4.1.0"
     dom-accessibility-api "^0.5.9"
     lz-string "^1.5.0"
@@ -1222,14 +1224,12 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-14.0.0.tgz#59030392a6792450b9ab8e67aea5f3cc18d6347c"
-  integrity sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==
+"@testing-library/react@^16.0.1":
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-16.0.1.tgz#29c0ee878d672703f5e7579f239005e4e0faa875"
+  integrity sha512-dSmwJVtJXmku+iocRhWOUFbrERC76TX2Mnf0ATODz8brzAZrMBbzLwQixlBSanZxR6LddK3eiwpSFZgDET1URg==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@testing-library/dom" "^9.0.0"
-    "@types/react-dom" "^18.0.0"
 
 "@tootallnate/once@2":
   version "2.0.0"
@@ -1272,9 +1272,9 @@
   integrity sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==
 
 "@types/aria-query@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.1.tgz#3286741fb8f1e1580ac28784add4c7a1d49bdfbc"
-  integrity sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
+  integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
 "@types/babel__core@^7.1.14":
   version "7.1.17"
@@ -1389,13 +1389,6 @@
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
-
-"@types/react-dom@^18.0.0":
-  version "18.0.1"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.1.tgz#cb3cc10ea91141b12c71001fede1017acfbce4db"
-  integrity sha512-jCwTXvHtRLiyVvKm9aEdHXs8rflVOGd5Sl913JZrPshfXjn8NYsTNZOz70bCsA31IR0TOqwi3ad+X4tSCBoMTw==
-  dependencies:
-    "@types/react" "*"
 
 "@types/react-dom@^18.0.11":
   version "18.0.11"
@@ -1715,6 +1708,13 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+aria-query@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
+  dependencies:
+    dequal "^2.0.3"
+
 aria-query@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
@@ -2014,7 +2014,7 @@ chalk@4.1.0, chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^2.0.0:
+chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -2344,6 +2344,11 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
@@ -2385,10 +2390,15 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.5.6, dom-accessibility-api@^0.5.9:
+dom-accessibility-api@^0.5.6:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz#102ee5f25eacce09bdf1cfa5a298f86da473be4b"
   integrity sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
 domexception@^4.0.0:
   version "4.0.0"
@@ -4274,7 +4284,7 @@ log-symbols@^5.1.0:
     chalk "^5.0.0"
     is-unicode-supported "^1.1.0"
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -4973,13 +4983,12 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.2.tgz#abf64491e6ecf0f38a6502403d4cda04f372dfd3"
   integrity sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==
 
-react-dom@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
-  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
+react-dom@^19.0.0-rc-ee1a403a-20240916:
+  version "19.0.0-rc-fb9a90fa48-20240614"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.0.0-rc-fb9a90fa48-20240614.tgz#8dce9ed0650096d65437e4bce790628e483831a2"
+  integrity sha512-PoEsPe32F7KPLYOBvZfjylEI1B67N44PwY3lyvpmBkhlluLnLz0jH8q2Wg9YidAi6z0k3iUnNRm5x10wurzt9Q==
   dependencies:
-    loose-envify "^1.1.0"
-    scheduler "^0.23.0"
+    scheduler "0.25.0-rc-fb9a90fa48-20240614"
 
 react-is@^16.13.1:
   version "16.13.1"
@@ -5001,12 +5010,10 @@ react-refresh@^0.14.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
 
-react@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
-  dependencies:
-    loose-envify "^1.1.0"
+react@^19.0.0-rc-ee1a403a-20240916:
+  version "19.0.0-rc-fb9a90fa48-20240614"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.0.0-rc-fb9a90fa48-20240614.tgz#90eb43a0b005e8cc3cbf0d801c14816d01df1b08"
+  integrity sha512-nvE3Gy+IOIfH/DXhkyxFVQSrITarFcQz4+shzC/McxQXEUSonpw2oDy/Wi9hdDtV3hlP12VYuDL95iiBREedNQ==
 
 readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.2"
@@ -5204,12 +5211,10 @@ saxes@^6.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
-  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
-  dependencies:
-    loose-envify "^1.1.0"
+scheduler@0.25.0-rc-fb9a90fa48-20240614:
+  version "0.25.0-rc-fb9a90fa48-20240614"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.25.0-rc-fb9a90fa48-20240614.tgz#9ee11063b7c0f47aef3fea53d9f1be3f13794dce"
+  integrity sha512-HHqQ/SqbeiDfXXVKgNxTpbQTD4n7IUb4hZATvHjp03jr3TF7igehCyHdOjeYTrzIseLO93cTTfSb5f4qWcirMQ==
 
 semver@7.3.4:
   version "7.3.4"


### PR DESCRIPTION
## Description

Since React 19 resolves the big issue that has made Zedux's `useAtomSelector` hook so complex in the past, Zedux v1.3.0 and v2.0.0 (and all future versions) will _technically_ drop support for React versions prior to 19.

Using Zedux in older versions will technically work, so we aren't labeling this as a breaking change or waiting till Zedux v2. However, it will be susceptible to a memory "leak" when using `useAtomSelector`. This isn't a real leak since Zedux gives you full control over the cache. This means you can set up e.g. an interval that regularly destroys cached selectors that have no dependents. For example:

```ts
const runCleanup = () => requestIdleCallback(() => {
  const graph = myEcosytem.viewGraph()

  Object.entries(myEcosystem.selectors.findAll()).forEach(([id, cache]) => {
    if (!Object.keys(graph[id].dependents).length) {
      myEcosystem.selectors.destroyCache(cache, undefined, true)
    }
  })

  // run cleanup every 10 seconds
  setTimeout(runCleanup, 10000)
})

runCleanup()
```

You're also free to not use selectors - they're optional in Zedux. Use ions instead until you can upgrade to React 19.

In older React versions, Zedux will also now be unable to determine a user-friendly name for graph pseudo-nodes created for React components. This doesn't break anything, it's just slightly worse DX. This is because React changed the name of their "internals" object in React 19. Since it isn't a big deal, we'd rather not lose perf by checking for the existence of all possible internals keys or build size by including both big strings.

While circumventing the "leak" is possible, it's still recommended to wait to upgrade Zedux until you upgrade to React 19.