### PR TITLE
release: v2.0.0-alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v2.0.0-alpha.0 (Oct 11, 2024)
+
+### New Features:
+
+- **Breaking Change** `core`: remove hierarchy config (#94)
+- **Breaking Change** `atoms`, `immer`, `machines`, `react`: implement ExternalNode class and make nodes the keys of edge maps (#120)
+- **Breaking Change** `atoms`, `core`, `immer`, `machines`, `react`: make instances valid graph nodes and jobs (#114)
+
 ## v1.3.0-rc.2 (Jul 31, 2024)
 
 ### Fixes:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zedux",
-  "version": "1.3.0-rc.2",
+  "version": "2.0.0-alpha.0",
   "description": "A Molecular State Engine for React",
   "type": "module",
   "author": "Joshua Claunch (bowheart <bowheart31@gmail.com>)",

--- a/packages/atoms/package.json
+++ b/packages/atoms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/atoms",
-  "version": "1.3.0-rc.2",
+  "version": "2.0.0-alpha.0",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/core": "^1.3.0-rc.2"
+    "@zedux/core": "^2.0.0-alpha.0"
   },
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/core",
-  "version": "1.3.0-rc.2",
+  "version": "2.0.0-alpha.0",
   "description": "A high-level, declarative, composable form of Redux",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/immer",
-  "version": "1.3.0-rc.2",
+  "version": "2.0.0-alpha.0",
   "description": "Official Immer integration for Zedux's store and atomic APIs",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "devDependencies": {
-    "@zedux/atoms": "^1.3.0-rc.2",
+    "@zedux/atoms": "^2.0.0-alpha.0",
     "immer": "^9.0.21"
   },
   "exports": {
@@ -40,7 +40,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/atoms": "^1.3.0-rc.2",
+    "@zedux/atoms": "^2.0.0-alpha.0",
     "immer": ">=9.0.19"
   },
   "repository": {

--- a/packages/machines/package.json
+++ b/packages/machines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/machines",
-  "version": "1.3.0-rc.2",
+  "version": "2.0.0-alpha.0",
   "description": "Simple native state machine implementation for Zedux atoms",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "devDependencies": {
-    "@zedux/atoms": "^1.3.0-rc.2"
+    "@zedux/atoms": "^2.0.0-alpha.0"
   },
   "exports": {
     ".": {
@@ -40,7 +40,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/atoms": "^1.3.0-rc.2"
+    "@zedux/atoms": "^2.0.0-alpha.0"
   },
   "repository": {
     "directory": "packages/machines",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/react",
-  "version": "1.3.0-rc.2",
+  "version": "2.0.0-alpha.0",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/atoms": "^1.3.0-rc.2"
+    "@zedux/atoms": "^2.0.0-alpha.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",


### PR DESCRIPTION
## Description

Increment monorepo package versions and update the CHANGELOG for version 2.0.0-alpha.0.

This PR was generated by the release script at https://github.com/Omnistac/zedux/tree/master/scripts/release.js

The packages will be published to npm and a GitHub release will be created after this PR merges.