### PR TITLE
chore(react): relax React peer dep for now - use `>=18`

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -55,7 +55,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=19.0.0"
+    "react": ">=18.0.0"
   },
   "repository": {
     "directory": "packages/react",


### PR DESCRIPTION
## Description

Zedux doesn't actually require React v19, it just has a memory leak vulnerability in `useAtomSelector` in older versions when unstable function references are passed.

Since there are valid workarounds for React 18, we shouldn't require v19 in our peer dep. For now anyway.

See [this discussion](https://github.com/Omnistac/zedux/discussions/123#discussioncomment-10930354)