### PR TITLE
fix: remove package.json production exports

### DIFF
--- a/packages/atoms/package.json
+++ b/packages/atoms/package.json
@@ -14,11 +14,6 @@
   },
   "exports": {
     ".": {
-      "production": {
-        "import": "./dist/zedux-atoms.es.min.js",
-        "require": "./dist/zedux-atoms.umd.min.js",
-        "default": "./dist/zedux-atoms.umd.min.js"
-      },
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "default": "./dist/cjs/index.js"

--- a/packages/atoms/package.json
+++ b/packages/atoms/package.json
@@ -14,13 +14,13 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
       "production": {
         "import": "./dist/zedux-atoms.es.min.js",
         "require": "./dist/zedux-atoms.umd.min.js",
         "default": "./dist/zedux-atoms.umd.min.js"
       },
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
       "default": "./dist/cjs/index.js"
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,11 +11,6 @@
   },
   "exports": {
     ".": {
-      "production": {
-        "import": "./dist/zedux.es.min.js",
-        "require": "./dist/zedux.umd.min.js",
-        "default": "./dist/zedux.umd.min.js"
-      },
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "default": "./dist/cjs/index.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,13 +11,13 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
       "production": {
         "import": "./dist/zedux.es.min.js",
         "require": "./dist/zedux.umd.min.js",
         "default": "./dist/zedux.umd.min.js"
       },
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
       "default": "./dist/cjs/index.js"
     }
   },

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -15,13 +15,13 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
       "production": {
         "import": "./dist/zedux-immer.es.min.js",
         "require": "./dist/zedux-immer.umd.min.js",
         "default": "./dist/zedux-immer.umd.min.js"
       },
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
       "default": "./dist/cjs/index.js"
     }
   },

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -15,11 +15,6 @@
   },
   "exports": {
     ".": {
-      "production": {
-        "import": "./dist/zedux-immer.es.min.js",
-        "require": "./dist/zedux-immer.umd.min.js",
-        "default": "./dist/zedux-immer.umd.min.js"
-      },
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "default": "./dist/cjs/index.js"

--- a/packages/machines/package.json
+++ b/packages/machines/package.json
@@ -14,13 +14,13 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
       "production": {
         "import": "./dist/zedux-machines.es.min.js",
         "require": "./dist/zedux-machines.umd.min.js",
         "default": "./dist/zedux-machines.umd.min.js"
       },
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
       "default": "./dist/cjs/index.js"
     }
   },

--- a/packages/machines/package.json
+++ b/packages/machines/package.json
@@ -14,11 +14,6 @@
   },
   "exports": {
     ".": {
-      "production": {
-        "import": "./dist/zedux-machines.es.min.js",
-        "require": "./dist/zedux-machines.umd.min.js",
-        "default": "./dist/zedux-machines.umd.min.js"
-      },
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "default": "./dist/cjs/index.js"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,11 +23,6 @@
   },
   "exports": {
     ".": {
-      "production": {
-        "import": "./dist/zedux-react.es.min.js",
-        "require": "./dist/zedux-react.umd.min.js",
-        "default": "./dist/zedux-react.umd.min.js"
-      },
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "default": "./dist/cjs/index.js"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,13 +23,13 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
       "production": {
         "import": "./dist/zedux-react.es.min.js",
         "require": "./dist/zedux-react.umd.min.js",
         "default": "./dist/zedux-react.umd.min.js"
       },
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
       "default": "./dist/cjs/index.js"
     }
   },


### PR DESCRIPTION
@affects atoms, core, immer, machines, react

## Description

The node resolver chooses the first package.json export that matches. Since the "production" export was not listed first, it has effectively not been in use (at least when using the node resolver and any tooling that adheres to that resolving strategy). Much more of a write-up and how I ran into this in https://github.com/nitrojs/nitro/issues/2923

I've adjusted the exports to move "production" to the first position. 

That said - is there a reason to ship the minified files at all? Why not remove the complexity here and allow downstream consumers to consume as is (node) or minify w their existing build pipeline (vite, swc, etc)? Better stack traces / debugging is a major benefit to downstream consumers importing a non-minified version of zedux.