### PR TITLE
fix(react): fallback to React 18 internals for getting component names

### DIFF
--- a/packages/react/src/hooks/useReactComponentId.ts
+++ b/packages/react/src/hooks/useReactComponentId.ts
@@ -43,9 +43,12 @@ const serverKey = `__SERVER${react19KeyBase}` as const
  * can at the cost of some DX.
  */
 export const useReactComponentId = () => {
-  const component: MaybeComponent = (
-    (React as React19)[clientKey] || (React as React19)[serverKey]
-  )?.A?.getOwner?.()?.type
+  const component: MaybeComponent =
+    (
+      (React as React19)[clientKey] || (React as React19)[serverKey]
+    )?.A?.getOwner?.()?.type ||
+    (React as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+      ?.ReactCurrentOwner?.current?.type
 
   const name = component?.displayName || component?.name || 'rc'
 


### PR DESCRIPTION
## Description

In reviewing the current state of the `v1.x` branch preparatory to publishing a new v1 minor version, I determined that the `useReactComponentId` hook is too optimistically assuming it'll be used in React 19. While this doesn't break anything when used with React 18, it does mean poorer dev X since components will add generic ids to the atom graph. Zedux v1 is supposed to be completely compatible with React 18, so I think it should still support this dev X.

To be clear, v2 will work with React 18 as well, but with some caveats. The dev X of seeing the component name that added a graph dependency in Zedux is not something that React itself officially supports. So I'm fine with this change being omitted in v2. When upgrading to Zedux v2, we'll recommend to also upgrade to React 19 to get this dev X back.