### PR TITLE
fix(immer): import named `produce` export from immer

### DIFF
--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@zedux/atoms": "^2.0.0-alpha.1",
-    "immer": "^9.0.21"
+    "immer": "^10.1.1"
   },
   "exports": {
     ".": {

--- a/packages/immer/src/ImmerStore.ts
+++ b/packages/immer/src/ImmerStore.ts
@@ -1,5 +1,5 @@
 import { Store } from '@zedux/atoms'
-import produce, { Draft } from 'immer'
+import { Draft, produce } from 'immer'
 
 export class ImmerStore<State> extends Store<State> {
   public constructor(initialState?: State) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3315,10 +3315,10 @@ ignore@^5.0.4, ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
-immer@^9.0.21:
-  version "9.0.21"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
-  integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
+immer@^10.0.0:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-10.1.1.tgz#206f344ea372d8ea176891545ee53ccc062db7bc"
+  integrity sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
## Description

Immer v10 removed the default `produce` export. The `@zedux/immer` package claims to be compatible with all versions of immer above 9.0.19, but it's still using the default `produce` export. Update to use the named `produce` export instead which works in both immer v9 and v10.

## Issues

Resolves #145
