### PR TITLE
feat(atoms)!: remove `createdAt` timestamp tracking

### DIFF
--- a/packages/atoms/src/classes/GraphNode.ts
+++ b/packages/atoms/src/classes/GraphNode.ts
@@ -695,7 +695,6 @@ export class ExternalNode extends GraphNode {
     this.i = source
 
     addEdge(this, source, {
-      createdAt: this.e._idGenerator.now(),
       flags,
       operation: operation,
     })

--- a/packages/atoms/src/classes/IdGenerator.ts
+++ b/packages/atoms/src/classes/IdGenerator.ts
@@ -22,10 +22,9 @@ export class IdGenerator {
    * Generate an id that is guaranteed to be unique in this ecosystem and
    * pretty-much-guaranteed to be unique globally.
    *
-   * This method and `IdGenerator#now()` are the only methods in Zedux that
-   * produce random values.
+   * This method is the only method in Zedux that produces random values.
    *
-   * Override these when testing to create reproducible graphs/dehydrations that
+   * Override this when testing to create reproducible graphs/dehydrations that
    * can be used easily in snapshot testing. See our setup in the Zedux repo at
    * `<repo root>/packages/react/test/utils/ecosystem.ts` for an example.
    */
@@ -67,22 +66,6 @@ export class IdGenerator {
           return result
         }, {} as Record<string, any>)
     })
-  }
-
-  /**
-   * Generate a timestamp. Pass true to make it a high res timestamp if possible
-   *
-   * This method and `IdGenerator#generateId()` are the only methods in Zedux
-   * that produce random values.
-   *
-   * Override these when testing to create reproducible graphs/dehydrations that
-   * can be used easily in snapshot testing. See our setup in the Zedux repo at
-   * `<repo root>/packages/react/test/utils/ecosystem.ts` for an example.
-   */
-  public now(highRes?: boolean) {
-    return highRes && typeof performance !== 'undefined'
-      ? performance.now()
-      : Date.now()
   }
 
   private cacheClass(instance: { new (): any }) {

--- a/packages/atoms/src/classes/instances/AtomInstance.ts
+++ b/packages/atoms/src/classes/instances/AtomInstance.ts
@@ -178,7 +178,6 @@ export class AtomInstance<
    * @see Signal.c
    */
   public c?: Cleanup
-  public _createdAt: number
   public _injectors?: InjectorDescriptor[]
   public _isEvaluating?: boolean
   public _nextInjectors?: InjectorDescriptor[]
@@ -204,7 +203,6 @@ export class AtomInstance<
     public readonly p: G['Params']
   ) {
     super(e, id, undefined) // TODO NOW: fix this undefined
-    this._createdAt = e._idGenerator.now()
   }
 
   /**

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -320,7 +320,6 @@ export interface GraphEdgeConfig {
 
 // TODO: optimize this internal object to use single-letter properties
 export interface GraphEdge {
-  createdAt: number
   flags: number // calculated from the EdgeFlags
   operation: string
 

--- a/packages/react/test/__snapshots__/types.test.tsx.snap
+++ b/packages/react/test/__snapshots__/types.test.tsx.snap
@@ -6,17 +6,14 @@ exports[`react types signals 1`] = `
     "className": "Signal",
     "observers": {
       "no-1": {
-        "createdAt": 123456789,
         "flags": 3,
         "operation": "on",
       },
       "no-2": {
-        "createdAt": 123456789,
         "flags": 3,
         "operation": "on",
       },
       "no-3": {
-        "createdAt": 123456789,
         "flags": 3,
         "operation": "on",
       },
@@ -31,7 +28,6 @@ exports[`react types signals 1`] = `
     "observers": {},
     "sources": {
       "@signal-0": {
-        "createdAt": 123456789,
         "flags": 3,
         "operation": "on",
       },
@@ -45,7 +41,6 @@ exports[`react types signals 1`] = `
     "observers": {},
     "sources": {
       "@signal-0": {
-        "createdAt": 123456789,
         "flags": 3,
         "operation": "on",
       },
@@ -59,7 +54,6 @@ exports[`react types signals 1`] = `
     "observers": {},
     "sources": {
       "@signal-0": {
-        "createdAt": 123456789,
         "flags": 3,
         "operation": "on",
       },

--- a/packages/react/test/integrations/__snapshots__/selection.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/selection.test.tsx.snap
@@ -6,14 +6,12 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "className": "AtomInstance",
     "observers": {
       "no-1": {
-        "createdAt": 123456789,
         "flags": 3,
         "operation": "on",
       },
     },
     "sources": {
       "@@selector-common-name-0": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "select",
         "p": undefined,
@@ -27,7 +25,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "className": "SelectorInstance",
     "observers": {
       "1": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "select",
         "p": undefined,
@@ -35,7 +32,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     },
     "sources": {
       "root": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -50,7 +46,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "observers": {},
     "sources": {
       "1": {
-        "createdAt": 123456789,
         "flags": 3,
         "operation": "on",
       },
@@ -63,7 +58,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "className": "AtomInstance",
     "observers": {
       "@@selector-common-name-0": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -83,14 +77,12 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "className": "AtomInstance",
     "observers": {
       "no-3": {
-        "createdAt": 123456789,
         "flags": 3,
         "operation": "on",
       },
     },
     "sources": {
       "@@selector-common-name-2": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "select",
         "p": undefined,
@@ -104,7 +96,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "className": "SelectorInstance",
     "observers": {
       "2": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "select",
         "p": undefined,
@@ -112,7 +103,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     },
     "sources": {
       "root": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -127,7 +117,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "observers": {},
     "sources": {
       "2": {
-        "createdAt": 123456789,
         "flags": 3,
         "operation": "on",
       },
@@ -140,7 +129,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "className": "AtomInstance",
     "observers": {
       "@@selector-common-name-2": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -160,14 +148,12 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "className": "AtomInstance",
     "observers": {
       "no-4": {
-        "createdAt": 123456789,
         "flags": 3,
         "operation": "on",
       },
     },
     "sources": {
       "@@selector-common-name-0": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "select",
         "p": undefined,
@@ -181,14 +167,12 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "className": "AtomInstance",
     "observers": {
       "no-3": {
-        "createdAt": 123456789,
         "flags": 3,
         "operation": "on",
       },
     },
     "sources": {
       "@@selector-common-name-2": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "select",
         "p": undefined,
@@ -202,7 +186,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "className": "SelectorInstance",
     "observers": {
       "1": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "select",
         "p": undefined,
@@ -210,7 +193,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     },
     "sources": {
       "root": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -224,7 +206,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "className": "SelectorInstance",
     "observers": {
       "2": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "select",
         "p": undefined,
@@ -232,7 +213,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     },
     "sources": {
       "root": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -247,7 +227,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "observers": {},
     "sources": {
       "2": {
-        "createdAt": 123456789,
         "flags": 3,
         "operation": "on",
       },
@@ -261,7 +240,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "observers": {},
     "sources": {
       "1": {
-        "createdAt": 123456789,
         "flags": 3,
         "operation": "on",
       },
@@ -274,13 +252,11 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "className": "AtomInstance",
     "observers": {
       "@@selector-common-name-0": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
       },
       "@@selector-common-name-2": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -300,14 +276,12 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "className": "AtomInstance",
     "observers": {
       "no-4": {
-        "createdAt": 123456789,
         "flags": 3,
         "operation": "on",
       },
     },
     "sources": {
       "@@selector-common-name-0": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "select",
         "p": undefined,
@@ -321,7 +295,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "className": "SelectorInstance",
     "observers": {
       "1": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "select",
         "p": undefined,
@@ -329,7 +302,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     },
     "sources": {
       "root": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -344,7 +316,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "observers": {},
     "sources": {
       "1": {
-        "createdAt": 123456789,
         "flags": 3,
         "operation": "on",
       },
@@ -357,7 +328,6 @@ exports[`selection same-name selectors share the namespace when destroyed and re
     "className": "AtomInstance",
     "observers": {
       "@@selector-common-name-0": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,

--- a/packages/react/test/stores/__snapshots__/graph.test.tsx.snap
+++ b/packages/react/test/stores/__snapshots__/graph.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`graph getInstance(atom) returns the instance 1`] = `
     "className": "AtomInstance",
     "observers": {
       "ion1": {
-        "createdAt": 123456789,
         "flags": 4,
         "operation": "getNode",
         "p": undefined,
@@ -21,7 +20,6 @@ exports[`graph getInstance(atom) returns the instance 1`] = `
     "className": "AtomInstance",
     "observers": {
       "ion1": {
-        "createdAt": 123456789,
         "flags": 4,
         "operation": "getNode",
         "p": undefined,
@@ -37,13 +35,11 @@ exports[`graph getInstance(atom) returns the instance 1`] = `
     "observers": {},
     "sources": {
       "atom1": {
-        "createdAt": 123456789,
         "flags": 4,
         "operation": "getNode",
         "p": undefined,
       },
       "atom2": {
-        "createdAt": 123456789,
         "flags": 4,
         "operation": "getNode",
         "p": undefined,
@@ -175,7 +171,6 @@ exports[`graph on reevaluation, get() updates the graph 1`] = `
     "className": "AtomInstance",
     "observers": {
       "d": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "injectAtomValue",
         "p": undefined,
@@ -190,7 +185,6 @@ exports[`graph on reevaluation, get() updates the graph 1`] = `
     "className": "AtomInstance",
     "observers": {
       "d": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -206,13 +200,11 @@ exports[`graph on reevaluation, get() updates the graph 1`] = `
     "observers": {},
     "sources": {
       "a": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "injectAtomValue",
         "p": undefined,
       },
       "b-["b"]": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -231,7 +223,6 @@ exports[`graph on reevaluation, get() updates the graph 2`] = `
     "className": "AtomInstance",
     "observers": {
       "d": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "injectAtomValue",
         "p": undefined,
@@ -254,7 +245,6 @@ exports[`graph on reevaluation, get() updates the graph 2`] = `
     "className": "AtomInstance",
     "observers": {
       "d": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -270,13 +260,11 @@ exports[`graph on reevaluation, get() updates the graph 2`] = `
     "observers": {},
     "sources": {
       "a": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "injectAtomValue",
         "p": undefined,
       },
       "c": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,

--- a/packages/react/test/stores/graph.test.tsx
+++ b/packages/react/test/stores/graph.test.tsx
@@ -61,7 +61,6 @@ describe('graph', () => {
     expect(div).toHaveTextContent('3')
 
     const expectedEdges = {
-      createdAt: expect.any(Number),
       flags: 0,
       operation: 'get',
     }

--- a/packages/react/test/units/__snapshots__/SelectorInstance.test.tsx.snap
+++ b/packages/react/test/units/__snapshots__/SelectorInstance.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`the SelectorInstance class deeply nested selectors get auto-created 1`]
     "className": "SelectorInstance",
     "observers": {
       "@@selector-selector2-1": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "select",
         "p": undefined,
@@ -14,7 +13,6 @@ exports[`the SelectorInstance class deeply nested selectors get auto-created 1`]
     },
     "sources": {
       "1": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -28,7 +26,6 @@ exports[`the SelectorInstance class deeply nested selectors get auto-created 1`]
     "className": "SelectorInstance",
     "observers": {
       "@@selector-selector3-0": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "select",
         "p": undefined,
@@ -36,7 +33,6 @@ exports[`the SelectorInstance class deeply nested selectors get auto-created 1`]
     },
     "sources": {
       "@@selector-selector1-2": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "select",
         "p": undefined,
@@ -51,7 +47,6 @@ exports[`the SelectorInstance class deeply nested selectors get auto-created 1`]
     "observers": {},
     "sources": {
       "@@selector-selector2-1": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "select",
         "p": undefined,

--- a/packages/react/test/units/__snapshots__/useAtomSelector.test.tsx.snap
+++ b/packages/react/test/units/__snapshots__/useAtomSelector.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "className": "AtomInstance",
     "observers": {
       "@@selector-unnamed-0": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -23,14 +22,12 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "className": "SelectorInstance",
     "observers": {
       "Test-:r0:": {
-        "createdAt": 123456789,
         "flags": 2,
         "operation": "useAtomSelector",
       },
     },
     "sources": {
       "1": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -47,7 +44,6 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "observers": {},
     "sources": {
       "@@selector-unnamed-0": {
-        "createdAt": 123456789,
         "flags": 2,
         "operation": "useAtomSelector",
       },
@@ -65,7 +61,6 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "className": "AtomInstance",
     "observers": {
       "@@selector-unnamed-0": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -82,14 +77,12 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "className": "SelectorInstance",
     "observers": {
       "Test-:r0:": {
-        "createdAt": 123456789,
         "flags": 2,
         "operation": "useAtomSelector",
       },
     },
     "sources": {
       "1": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -106,7 +99,6 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "observers": {},
     "sources": {
       "@@selector-unnamed-0": {
-        "createdAt": 123456789,
         "flags": 2,
         "operation": "useAtomSelector",
       },
@@ -124,7 +116,6 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "className": "AtomInstance",
     "observers": {
       "@@selector-unnamed-1": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -141,14 +132,12 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "className": "SelectorInstance",
     "observers": {
       "Test-:r0:": {
-        "createdAt": 123456789,
         "flags": 2,
         "operation": "useAtomSelector",
       },
     },
     "sources": {
       "1": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -165,7 +154,6 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "observers": {},
     "sources": {
       "@@selector-unnamed-1": {
-        "createdAt": 123456789,
         "flags": 2,
         "operation": "useAtomSelector",
       },
@@ -183,7 +171,6 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "className": "AtomInstance",
     "observers": {
       "@@selector-unnamed-1": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -200,14 +187,12 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "className": "SelectorInstance",
     "observers": {
       "Test-:r0:": {
-        "createdAt": 123456789,
         "flags": 2,
         "operation": "useAtomSelector",
       },
     },
     "sources": {
       "1": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -224,7 +209,6 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "observers": {},
     "sources": {
       "@@selector-unnamed-1": {
-        "createdAt": 123456789,
         "flags": 2,
         "operation": "useAtomSelector",
       },
@@ -242,14 +226,12 @@ exports[`useAtomSelector inline selectors are swapped out in strict mode double-
     "className": "SelectorInstance",
     "observers": {
       "Test-:r0:": {
-        "createdAt": 123456789,
         "flags": 2,
         "operation": "useAtomSelector",
       },
     },
     "sources": {
       "1": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,
@@ -268,14 +250,12 @@ exports[`useAtomSelector inline selectors are swapped out in strict mode double-
     "className": "SelectorInstance",
     "observers": {
       "Test-:r0:": {
-        "createdAt": 123456789,
         "flags": 2,
         "operation": "useAtomSelector",
       },
     },
     "sources": {
       "1": {
-        "createdAt": 123456789,
         "flags": 0,
         "operation": "get",
         "p": undefined,

--- a/packages/react/test/utils/ecosystem.ts
+++ b/packages/react/test/utils/ecosystem.ts
@@ -37,14 +37,7 @@ export const getSelectorNodes = () =>
     )
   )
 
-const now = 123456789
-
-export const nowMock = jest.fn((highRes?: boolean) =>
-  highRes ? performance.now() : now
-)
-
 ecosystem._idGenerator.generateId = generateIdMock
-ecosystem._idGenerator.now = nowMock
 
 afterAll(() => ecosystem.destroy())
 

--- a/packages/stores/src/AtomInstance.ts
+++ b/packages/stores/src/AtomInstance.ts
@@ -90,7 +90,6 @@ export class AtomInstance<
    * @see NewAtomInstance.c
    */
   public c?: Cleanup
-  public _createdAt: number
   public _injectors?: InjectorDescriptor[]
   public _isEvaluating?: boolean
   public _nextInjectors?: InjectorDescriptor[]
@@ -124,7 +123,6 @@ export class AtomInstance<
     public readonly p: G['Params']
   ) {
     super(e, t, id, p)
-    this._createdAt = e._idGenerator.now()
   }
 
   /**


### PR DESCRIPTION
## Description

Zedux core has never needed to track timestamps when nodes are created. It's always been possible for plugins to implement this and will be much easier with the new plugin system in Zedux v2.

Since this functionality is so rarely useful, it isn't worth the constant overhead, especially in prod. We'll make sure plugins can implement this. I'll also probably implement it as part of the official Zedux dev tools.

### Breaking Changes

`ecosystem._idGenerator.now` is gone as well as the `createdAt` property on all atom instances and graph edges. Instead, a plugin can listen to:

- (v1) `edgeCreated`, `evaluationFinished`, and `statusChanged` plugin actions
- (v2) `edge` (which we're possibly renaming to `link`), `runStart`, and `cycle` ecosystem events.

and either track creation time in a separate WeakMap/similar or (not recommended) by mutating the node or edge itself.