### PR TITLE
Josh/reactive get

### DIFF
--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -137,19 +137,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
     const get: AtomGetters['get'] = <G extends AtomGenerics>(
       atom: AtomTemplateBase<G>,
       params?: G['Params']
-    ) => {
-      const instance = this.getNode(atom, params as G['Params'])
-      const node = getEvaluationContext().n
-
-      // If get is called in a reactive context, track the required atom
-      // instances so we can add graph edges for them. When called outside a
-      // reactive context, get() is just an alias for ecosystem.get()
-      if (node) {
-        bufferEdge(instance, 'get', 0)
-      }
-
-      return instance.get()
-    }
+    ) => this.getNode(atom, params as G['Params']).get()
 
     const getInstance: AtomGetters['getInstance'] = <G extends AtomGenerics>(
       atom: AtomTemplateBase<G>,
@@ -444,7 +432,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
     params?: ParamsOf<A>
   ) {
     if ((atom as GraphNode).izn) {
-      return (atom as GraphNode).get()
+      return (atom as GraphNode).v
     }
 
     const instance = this.getInstance(
@@ -452,7 +440,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
       params as ParamsOf<A>
     ) as AnyAtomInstance
 
-    return instance.get()
+    return instance.v
   }
 
   public getInstance<A extends AnyAtomTemplate>(
@@ -633,7 +621,6 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
       instance = new SelectorInstance(this, id, selectorOrConfig, params || [])
 
       this.n.set(id, instance)
-      runSelector(instance, true)
 
       return instance
     }

--- a/packages/atoms/src/classes/GraphNode.ts
+++ b/packages/atoms/src/classes/GraphNode.ts
@@ -12,217 +12,16 @@ import {
 } from '@zedux/atoms/types/index'
 import { is, Job } from '@zedux/core'
 import { Ecosystem } from './Ecosystem'
-import { pluginActions } from '../utils/plugin-actions'
-import { Destroy, EventSent, ExplicitExternal, Static } from '../utils/general'
+import { EventSent, ExplicitExternal } from '../utils/general'
 import { AtomTemplateBase } from './templates/AtomTemplateBase'
 import {
-  ExplicitEvents,
   CatchAllListener,
   EventEmitter,
   SingleEventListener,
   ListenableEvents,
 } from '../types/events'
-
-/**
- * Actually add an edge to the graph. When we buffer graph updates, we're
- * really just deferring the calling of this method.
- */
-export const addEdge = (
-  dependent: GraphNode,
-  dependency: GraphNode,
-  newEdge: GraphEdge
-) => {
-  const { _mods, modBus } = dependency.e
-
-  // draw the edge in both nodes. Dependent may not exist if it's an external
-  // pseudo-node
-  dependent && dependent.s.set(dependency, newEdge)
-  dependency.o.set(dependent, newEdge)
-  dependency.c?.()
-
-  // static dependencies don't change a node's weight
-  if (!(newEdge.flags & Static)) {
-    recalculateNodeWeight(dependency.W, dependent)
-  }
-
-  if (_mods.edgeCreated) {
-    modBus.dispatch(
-      pluginActions.edgeCreated({
-        dependency,
-        dependent: dependent, // unfortunate but not changing for now
-        edge: newEdge,
-      })
-    )
-  }
-
-  return newEdge
-}
-
-export const destroyNodeStart = (node: GraphNode, force?: boolean) => {
-  // If we're not force-destroying, don't destroy if there are dependents
-  if (node.l === 'Destroyed' || (!force && node.o.size)) return
-
-  node.c?.()
-  node.c = undefined
-
-  setNodeStatus(node, 'Destroyed')
-
-  if (node.w.length) node.e._scheduler.unschedule(node)
-
-  return true
-}
-
-// TODO: merge this into destroyNodeStart. We should be able to
-export const destroyNodeFinish = (node: GraphNode) => {
-  // first remove all edges between this node and its dependencies
-  for (const dependency of node.s.keys()) {
-    removeEdge(node, dependency)
-  }
-
-  // if an atom instance is force-destroyed, it could still have dependents.
-  // Inform them of the destruction
-  scheduleDependents(
-    {
-      r: node.w,
-      s: node,
-      t: Destroy,
-    },
-    true,
-    true
-  )
-
-  // now remove all edges between this node and its dependents
-  for (const [observer, edge] of node.o) {
-    if (!(edge.flags & Static)) {
-      recalculateNodeWeight(-node.W, observer)
-    }
-
-    observer.s.delete(node)
-
-    // we _probably_ don't need to send edgeRemoved mod events to plugins for
-    // these - it's better that they receive the duplicate edgeCreated event
-    // when the dependency is recreated by its dependent(s) so they can infer
-    // that the edge was "moved"
-  }
-
-  node.e.n.delete(node.id)
-}
-
-export const handleStateChange = <
-  G extends Pick<AtomGenerics, 'Events' | 'State'>
->(
-  node: GraphNode<G & { Params: any; Template: any }>,
-  oldState: G['State'],
-  events?: Partial<G['Events'] & ExplicitEvents>
-) => {
-  scheduleDependents({ e: events, p: oldState, r: node.w, s: node }, false)
-
-  if (node.e._mods.stateChanged) {
-    node.e.modBus.dispatch(
-      pluginActions.stateChanged({
-        node,
-        newState: node.get(),
-        oldState,
-        reasons: node.w,
-      })
-    )
-  }
-
-  // run the scheduler synchronously after any node state update
-  events?.batch || node.e._scheduler.flush()
-}
-
-export const normalizeNodeFilter = (options?: NodeFilter) =>
-  typeof options === 'object' && !is(options, AtomTemplateBase)
-    ? (options as NodeFilterOptions)
-    : { include: options ? [options as string | AnyAtomTemplate] : [] }
-
-const recalculateNodeWeight = (weightDiff: number, node?: GraphNode) => {
-  if (!node) return // happens when node is external
-
-  node.W += weightDiff
-
-  for (const observer of node.o.keys()) {
-    recalculateNodeWeight(weightDiff, observer)
-  }
-}
-
-/**
- * Remove the graph edge between two nodes. The dependent may not exist as a
- * node in the graph if it's external, e.g. a React component
- *
- * For some reason in React 18+, React destroys parents before children. This
- * means a parent EcosystemProvider may have already unmounted and wiped the
- * whole graph; this edge may already be destroyed.
- */
-export const removeEdge = (dependent: GraphNode, dependency: GraphNode) => {
-  // erase graph edge between dependent and dependency
-  dependent && dependent.s.delete(dependency)
-
-  // hmm could maybe happen when a dependency was force-destroyed if a child
-  // tries to destroy its edge before recreating it (I don't think we ever do
-  // that though)
-  if (!dependency) return
-
-  const edge = dependency.o.get(dependent)
-
-  // happens in React 18+ (see this method's jsdoc above)
-  if (!edge) return
-
-  dependency.o.delete(dependent)
-
-  // static dependencies don't change a node's weight
-  if (!(edge.flags & Static)) {
-    recalculateNodeWeight(-dependency.W, dependent)
-  }
-
-  if (dependency.e._mods.edgeRemoved) {
-    dependency.e.modBus.dispatch(
-      pluginActions.edgeRemoved({
-        dependency,
-        dependent: dependent,
-        edge: edge,
-      })
-    )
-  }
-
-  scheduleNodeDestruction(dependency)
-}
-
-export const scheduleDependents = (
-  reason: Omit<InternalEvaluationReason, 's'> & {
-    s: NonNullable<InternalEvaluationReason['s']>
-  },
-  defer?: boolean,
-  scheduleStaticDeps?: boolean
-) => {
-  for (const [observer, edge] of reason.s.o) {
-    // Static deps don't update on state change, only on promise change or node
-    // force-destruction
-    if (scheduleStaticDeps || !(edge.flags & Static)) observer.r(reason, defer)
-  }
-}
-
-/**
- * When a node's refCount hits 0, schedule destruction of that node.
- */
-export const scheduleNodeDestruction = (node: GraphNode) =>
-  node.o.size || node.l !== 'Active' || node.m()
-
-export const setNodeStatus = (node: GraphNode, newStatus: LifecycleStatus) => {
-  const oldStatus = node.l
-  node.l = newStatus
-
-  if (node.e._mods.statusChanged) {
-    node.e.modBus.dispatch(
-      pluginActions.statusChanged({
-        newStatus,
-        node,
-        oldStatus,
-      })
-    )
-  }
-}
+import { bufferEdge, getEvaluationContext } from '../utils/evaluationContext'
+import { addEdge, removeEdge, setNodeStatus } from '../utils/graph'
 
 export abstract class GraphNode<
   G extends Pick<AtomGenerics, 'Events' | 'Params' | 'State' | 'Template'> = {
@@ -258,6 +57,13 @@ export abstract class GraphNode<
   public W = 1
 
   /**
+   * `v`alue - the current state of this signal.
+   */
+  // @ts-expect-error only some node types have state. They will need to make
+  // sure they set this. This should be undefined for nodes that don't.
+  public v: G['State']
+
+  /**
    * Detach this node from the ecosystem and clean up all graph edges and other
    * subscriptions/effects created by this node.
    *
@@ -271,8 +77,31 @@ export abstract class GraphNode<
 
   /**
    * Get the current value of this node.
+   *
+   * This is reactive! When called inside a reactive context (e.g. an atom state
+   * factory or atom selector function), calling this method creates a graph
+   * edge between the evaluating node and the node whose value this returns.
+   *
+   * Outside reactive contexts, this behaves exactly the same as `.getOnce()`
+   *
+   * To retrieve the node's value non-reactively, use `.getOnce()` instead.
    */
-  public abstract get(): G['State']
+  public get() {
+    // If get is called in a reactive context, track the required atom
+    // instances so we can add graph edges for them. When called outside a
+    // reactive context, get() is just an alias for ecosystem.get()
+    getEvaluationContext().n && bufferEdge(this, 'get', 0)
+
+    return this.v
+  }
+
+  /**
+   * Get the current value of this node without registering any graph
+   * dependencies in reactive contexts.
+   */
+  public getOnce() {
+    return this.v
+  }
 
   /**
    * The unique id of this node in the graph. Zedux always tries to make this
@@ -322,7 +151,7 @@ export abstract class GraphNode<
           ? reason.e ?? {}
           : {
               ...reason.e,
-              change: { newState: this.get(), oldState: reason.p },
+              change: { newState: this.v, oldState: reason.p },
             }
       ) as ListenableEvents<G>
 
@@ -408,7 +237,9 @@ export abstract class GraphNode<
       excludeFlags = [],
       include = [],
       includeFlags = [],
-    } = normalizeNodeFilter(options)
+    } = typeof options === 'object' && !is(options, AtomTemplateBase)
+      ? (options as NodeFilterOptions)
+      : { include: options ? [options as string | AnyAtomTemplate] : [] }
 
     const isExcluded =
       exclude.some(templateOrKey =>

--- a/packages/atoms/src/classes/GraphNode.ts
+++ b/packages/atoms/src/classes/GraphNode.ts
@@ -12,7 +12,11 @@ import {
 } from '@zedux/atoms/types/index'
 import { is, Job } from '@zedux/core'
 import { Ecosystem } from './Ecosystem'
-import { EventSent, ExplicitExternal } from '../utils/general'
+import {
+  EventSent,
+  ExplicitExternal,
+  makeReasonReadable,
+} from '../utils/general'
 import { AtomTemplateBase } from './templates/AtomTemplateBase'
 import {
   CatchAllListener,
@@ -151,7 +155,7 @@ export abstract class GraphNode<
           ? reason.e ?? {}
           : {
               ...reason.e,
-              change: { newState: this.v, oldState: reason.p },
+              change: makeReasonReadable(reason, observer),
             }
       ) as ListenableEvents<G>
 

--- a/packages/atoms/src/classes/MappedSignal.ts
+++ b/packages/atoms/src/classes/MappedSignal.ts
@@ -208,7 +208,7 @@ export class MappedSignal<
       if (reason.s) this.N = { ...this.v }
     }
 
-    if (reason.s) this.N![this.I[reason.s.id]] = reason.s.get()
+    if (reason.s) this.N![this.I[reason.s.id]] = reason.s.v
 
     // forward events from wrapped signals to observers of this wrapper signal.
     // Use `super.send` for this 'cause `this.send` intercepts events and passes

--- a/packages/atoms/src/classes/SelectorInstance.ts
+++ b/packages/atoms/src/classes/SelectorInstance.ts
@@ -13,15 +13,15 @@ import {
   startBuffer,
 } from '../utils/evaluationContext'
 import { prefix } from '../utils/general'
-import { pluginActions } from '../utils/plugin-actions'
-import { Ecosystem } from './Ecosystem'
 import {
   destroyNodeFinish,
   destroyNodeStart,
-  GraphNode,
   scheduleDependents,
   setNodeStatus,
-} from './GraphNode'
+} from '../utils/graph'
+import { pluginActions } from '../utils/plugin-actions'
+import { Ecosystem } from './Ecosystem'
+import { GraphNode } from './GraphNode'
 
 const defaultResultsComparator = (a: any, b: any) => a === b
 
@@ -129,11 +129,6 @@ export class SelectorInstance<
 > extends GraphNode<G & { Events: any }> {
   public static $$typeof = Symbol.for(`${prefix}/SelectorInstance`)
 
-  /**
-   * `v`alue - the current cached selector result
-   */
-  public v?: G['State']
-
   constructor(
     /**
      * @see GraphNode.e
@@ -156,6 +151,7 @@ export class SelectorInstance<
     public p: G['Params']
   ) {
     super()
+    runSelector(this, true)
   }
 
   /**
@@ -170,17 +166,10 @@ export class SelectorInstance<
   }
 
   /**
-   * @see GraphNode.get
-   */
-  public get() {
-    return this.v as G['State']
-  }
-
-  /**
    * @see GraphNode.d
    */
   public d(options?: DehydrationFilter) {
-    if (this.f(options)) return this.get()
+    if (this.f(options)) return this.v
   }
 
   /**

--- a/packages/atoms/src/classes/Signal.ts
+++ b/packages/atoms/src/classes/Signal.ts
@@ -9,14 +9,14 @@ import {
   UndefinedEvents,
 } from '../types/index'
 import { EventSent } from '../utils/general'
-import { Ecosystem } from './Ecosystem'
 import {
   destroyNodeFinish,
   destroyNodeStart,
-  GraphNode,
   handleStateChange,
   scheduleDependents,
-} from './GraphNode'
+} from '../utils/graph'
+import { Ecosystem } from './Ecosystem'
+import { GraphNode } from './GraphNode'
 import { recursivelyMutate, recursivelyProxy } from './proxies'
 
 export class Signal<
@@ -59,7 +59,7 @@ export class Signal<
     public readonly id: string,
 
     /**
-     * `v`alue - the current state of this signal.
+     * @see GraphNode.v
      */
     public v: G['State'],
 
@@ -78,13 +78,6 @@ export class Signal<
    */
   public destroy(force?: boolean) {
     destroyNodeStart(this, force) && destroyNodeFinish(this)
-  }
-
-  /**
-   * @see GraphNode.get
-   */
-  public get() {
-    return this.v
   }
 
   /**

--- a/packages/atoms/src/classes/instances/AtomInstance.ts
+++ b/packages/atoms/src/classes/instances/AtomInstance.ts
@@ -19,6 +19,7 @@ import {
   Invalidate,
   prefix,
   PromiseChange,
+  Static,
 } from '@zedux/atoms/utils/general'
 import { pluginActions } from '@zedux/atoms/utils/plugin-actions'
 import {
@@ -35,8 +36,9 @@ import {
   destroyNodeStart,
   handleStateChange,
   scheduleDependents,
-} from '../GraphNode'
+} from '../../utils/graph'
 import {
+  bufferEdge,
   destroyBuffer,
   flushBuffer,
   getEvaluationContext,
@@ -104,7 +106,7 @@ const setPromise = <G extends Omit<AtomGenerics, 'Node'>>(
   promise: Promise<any>,
   isStateUpdater?: boolean
 ) => {
-  const currentState = instance.get()
+  const currentState = instance.v
   if (promise === instance.promise) return currentState
 
   instance.promise = promise as G['Promise']
@@ -161,6 +163,12 @@ export class AtomInstance<
 
   // @ts-expect-error same as exports
   public promise: G['Promise']
+
+  /**
+   * `a`lteredEdge - tracks whether we've altered the edge between this atom and
+   * its wrapped signal (if any).
+   */
+  public a: boolean | undefined = undefined
 
   /**
    * `b`ufferedEvents - when the wrapped signal emits events, we
@@ -237,9 +245,9 @@ export class AtomInstance<
    * value.
    */
   public get() {
-    const { S, v } = this
-
-    return S ? S.get() : v
+    // defer to `Signal#get` to auto-track usages of this signal in the current
+    // reactive context (if any)
+    return this.S ? this.S.get() : super.get()
   }
 
   /**
@@ -301,15 +309,14 @@ export class AtomInstance<
   public d(options?: DehydrationFilter) {
     if (!this.f(options)) return
 
-    const { t } = this
-    const state = this.get()
+    const { t, v } = this
     const transform =
       (typeof options === 'object' &&
         !is(options, AtomTemplateBase) &&
         (options as DehydrationOptions).transform) ??
       true
 
-    return transform && t.dehydrate ? t.dehydrate(state) : state
+    return transform && t.dehydrate ? t.dehydrate(v) : v
   }
 
   /**
@@ -321,7 +328,7 @@ export class AtomInstance<
 
   /**
    * `i`nit - Perform the initial run of this atom's state factory. Create the
-   * store, promise, exports, and hydrate (all optional except the store).
+   * `S`ignal (if any), promise, exports, and hydrate (all optional).
    */
   public i() {
     const { n, s } = getEvaluationContext()
@@ -345,6 +352,19 @@ export class AtomInstance<
    */
   public j() {
     const { n, s } = getEvaluationContext()
+
+    if (this.a && this.w.length === 1 && this.w[0].s === this.S) {
+      // if we altered the edge between this atom and its wrapped signal, the
+      // wrapped signal should not trigger an evaluation of this atom. Skip
+      // evaluation - just capture the state update and forward to this atom's
+      // observers.
+      const oldState = this.v
+      this.v = this.S!.v // `this.S`ignal must exist if `this.a`lteredEdge is true
+      handleStateChange(this, oldState, this.b)
+
+      return
+    }
+
     this._nextInjectors = []
     this._isEvaluating = true
     startBuffer(this)
@@ -376,6 +396,21 @@ export class AtomInstance<
 
         this.v === oldState || handleStateChange(this, oldState, this.b)
       }
+
+      if (this.S) {
+        const edge = this.s.get(newFactoryResult)
+
+        if (edge) {
+          // the edge between this atom and its wrapped signal needs to be
+          // reactive. Track whether we altered the `p`endingFlags added by
+          // `injectSignal`/similar. If we did, the edge was static and should
+          // not trigger a reevaluation of this atom.
+          this.a = !!(edge.p! & Static) // `.p!` - doesn't matter if undefined
+          edge.p = 0
+        } else {
+          bufferEdge(newFactoryResult, 'implicit', 0)
+        }
+      }
     } catch (err) {
       this._nextInjectors.forEach(injector => {
         injector.cleanup?.()
@@ -387,7 +422,7 @@ export class AtomInstance<
     } finally {
       this._isEvaluating = false
 
-      // even if evaluation errored, we need to update dependents if the store's
+      // even if evaluation errored, we need to update dependents if the `S`ignal's
       // state changed
       if (this.S && this.S.v !== this.v) {
         const oldState = this.v
@@ -482,16 +517,18 @@ export class AtomInstance<
     // status is Stale (and should we just always evaluate once when
     // waking up a stale atom)?
     if (this.l !== 'Destroyed' && this.w.push(reason) === 1) {
+      if (reason.s && reason.s === this.S) {
+        // when `this.S`ignal gives us events along with a state update, we need
+        // to buffer those and emit them together after this atom evaluates
+        if (reason.e) {
+          this.b = this.b
+            ? { ...this.b, ...(reason.e as typeof this.b) }
+            : (reason.e as unknown as typeof this.b)
+        }
+      }
+
       // refCount just hit 1; we haven't scheduled a job for this node yet
       this.e._scheduler.schedule(this, defer)
-
-      // when `this.S`ignal gives us events along with a state update, we need
-      // to buffer those and emit them together after this atom evaluates
-      if (reason.s === this.S && reason.e) {
-        this.b = this.b
-          ? { ...this.b, ...(reason.e as typeof this.b) }
-          : (reason.e as unknown as typeof this.b)
-      }
     }
   }
 

--- a/packages/atoms/src/index.ts
+++ b/packages/atoms/src/index.ts
@@ -1,8 +1,3 @@
-import {
-  destroyNodeFinish,
-  destroyNodeStart,
-  scheduleDependents,
-} from './classes/GraphNode'
 import { createInjector } from './factories/createInjector'
 import {
   destroyBuffer,
@@ -10,6 +5,11 @@ import {
   getEvaluationContext,
   startBuffer,
 } from './utils/evaluationContext'
+import {
+  destroyNodeFinish,
+  destroyNodeStart,
+  scheduleDependents,
+} from './utils/graph'
 
 export * from '@zedux/core'
 export * from './classes/index'

--- a/packages/atoms/src/injectors/injectAtomInstance.ts
+++ b/packages/atoms/src/injectors/injectAtomInstance.ts
@@ -59,7 +59,7 @@ export const injectAtomInstance: {
     params?: ParamsOf<A>,
     config?: InjectAtomInstanceConfig
   ) => {
-    const injectedInstance = instance.e.live.getInstance(
+    const injectedInstance = instance.e.live.getNode(
       atom as A,
       params as ParamsOf<A>,
       {
@@ -81,7 +81,7 @@ export const injectAtomInstance: {
     config?: InjectAtomInstanceConfig
   ) => {
     // make sure the dependency gets registered for this evaluation
-    const injectedInstance = instance.e.live.getInstance(
+    const injectedInstance = instance.e.live.getNode(
       atom as A,
       params as ParamsOf<A>,
       {

--- a/packages/atoms/src/injectors/injectAtomState.ts
+++ b/packages/atoms/src/injectors/injectAtomState.ts
@@ -41,5 +41,5 @@ export const injectAtomState: {
     subscribe: true,
   })
 
-  return [instance.get(), instance._infusedSetter]
+  return [instance.v, instance._infusedSetter]
 }

--- a/packages/atoms/src/injectors/injectAtomValue.ts
+++ b/packages/atoms/src/injectors/injectAtomValue.ts
@@ -24,4 +24,4 @@ export const injectAtomValue: {
   injectAtomInstance(atom, params, {
     operation: 'injectAtomValue',
     subscribe: true,
-  }).get()
+  }).v

--- a/packages/atoms/src/injectors/injectSelf.ts
+++ b/packages/atoms/src/injectors/injectSelf.ts
@@ -5,7 +5,7 @@ import { readInstance } from '../utils/evaluationContext'
  * An unrestricted injector (can actually be used in loops and if statements).
  *
  * Returns the currently-evaluating AtomInstance. Note that this instance will
- * not have its `exports`, `promise`, or `store` set yet on initial evaluation.
+ * not have its `exports`, `promise`, or `signal` set yet on initial evaluation.
  */
 export const injectSelf = readInstance as () =>
   | AnyAtomInstance

--- a/packages/atoms/src/injectors/injectSignal.ts
+++ b/packages/atoms/src/injectors/injectSignal.ts
@@ -2,7 +2,6 @@ import { Signal } from '../classes/Signal'
 import { EventMap, InjectSignalConfig, MapEvents, None } from '../types/index'
 import { readInstance } from '../utils/evaluationContext'
 import { Static } from '../utils/general'
-import { injectAtomGetters } from './injectAtomGetters'
 import { injectMemo } from './injectMemo'
 
 /**
@@ -51,7 +50,7 @@ export const injectSignal = <State, MappedEvents extends EventMap = None>(
   }, [])
 
   // create a graph edge between the current atom and the new signal
-  injectAtomGetters().getNode(signal, undefined, {
+  instance.e.live.getNode(signal, undefined, {
     f: config?.reactive === false ? Static : 0,
     op: 'injectSignal',
   })

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -277,13 +277,6 @@ export interface EvaluationReason<State = any> {
   type: EvaluationType
 }
 
-export type EvaluationSourceType =
-  | 'Atom'
-  | 'AtomSelector'
-  | 'External'
-  | 'Injector'
-  | 'Store'
-
 export type EvaluationType =
   | 'cache invalidated'
   | 'node destroyed'
@@ -451,7 +444,7 @@ export type ParamlessTemplate<
  */
 export type PartialAtomInstance = Omit<
   AnyAtomInstance,
-  'api' | 'exports' | 'promise' | 'store'
+  'api' | 'exports' | 'promise' | 'S'
 >
 
 // from Matt Pocock https://twitter.com/mattpocockuk/status/1622730173446557697

--- a/packages/atoms/src/utils/evaluationContext.ts
+++ b/packages/atoms/src/utils/evaluationContext.ts
@@ -1,14 +1,10 @@
 import { ActionFactoryPayloadType, is } from '@zedux/core'
 import { AnyAtomInstance } from '../types/index'
-import { ExplicitExternal, OutOfRange } from '../utils/general'
-import { pluginActions } from '../utils/plugin-actions'
-import {
-  addEdge,
-  GraphNode,
-  removeEdge,
-  scheduleNodeDestruction,
-} from '../classes/GraphNode'
+import { type GraphNode } from '../classes/GraphNode'
 import { AtomInstance } from '../classes/instances/AtomInstance'
+import { ExplicitExternal, OutOfRange } from './general'
+import { addEdge, removeEdge, scheduleNodeDestruction } from './graph'
+import { pluginActions } from './plugin-actions'
 
 export interface EvaluationContext {
   /**

--- a/packages/atoms/src/utils/general.ts
+++ b/packages/atoms/src/utils/general.ts
@@ -58,15 +58,20 @@ const reasonTypeMap = {
   4: 'state changed',
 } as const
 
+export const makeReasonReadable = (
+  reason: InternalEvaluationReason,
+  node?: GraphNode
+) => ({
+  newState: reason.s?.v,
+  oldState: reason.p,
+  operation: node?.s.get(reason.s!)?.operation,
+  reasons: reason.r && makeReasonsReadable(reason.s, reason.r),
+  source: reason.s,
+  type: reasonTypeMap[reason.t ?? 4],
+})
+
 export const makeReasonsReadable = (
   node?: GraphNode,
   internalReasons: InternalEvaluationReason[] | undefined = node?.w
 ): EvaluationReason[] | undefined =>
-  internalReasons?.map(reason => ({
-    newState: reason.s?.v,
-    oldState: reason.p,
-    operation: node?.s.get(reason.s!)?.operation,
-    reasons: reason.r && makeReasonsReadable(reason.s, reason.r),
-    source: reason.s,
-    type: reasonTypeMap[reason.t ?? 4],
-  }))
+  internalReasons?.map(reason => makeReasonReadable(reason, node))

--- a/packages/atoms/src/utils/general.ts
+++ b/packages/atoms/src/utils/general.ts
@@ -63,7 +63,7 @@ export const makeReasonsReadable = (
   internalReasons: InternalEvaluationReason[] | undefined = node?.w
 ): EvaluationReason[] | undefined =>
   internalReasons?.map(reason => ({
-    newState: reason.s?.get(),
+    newState: reason.s?.v,
     oldState: reason.p,
     operation: node?.s.get(reason.s!)?.operation,
     reasons: reason.r && makeReasonsReadable(reason.s, reason.r),

--- a/packages/atoms/src/utils/graph.ts
+++ b/packages/atoms/src/utils/graph.ts
@@ -1,0 +1,206 @@
+import {
+  AtomGenerics,
+  GraphEdge,
+  InternalEvaluationReason,
+  LifecycleStatus,
+} from '@zedux/atoms/types/index'
+import { type GraphNode } from '../classes/GraphNode'
+import { ExplicitEvents } from '../types/events'
+import { pluginActions } from './plugin-actions'
+import { Destroy, Static } from './general'
+
+/**
+ * Actually add an edge to the graph. When we buffer graph updates, we're
+ * really just deferring the calling of this method.
+ */
+export const addEdge = (
+  dependent: GraphNode,
+  dependency: GraphNode,
+  newEdge: GraphEdge
+) => {
+  const { _mods, modBus } = dependency.e
+
+  // draw the edge in both nodes. Dependent may not exist if it's an external
+  // pseudo-node
+  dependent && dependent.s.set(dependency, newEdge)
+  dependency.o.set(dependent, newEdge)
+  dependency.c?.()
+
+  // static dependencies don't change a node's weight
+  if (!(newEdge.flags & Static)) {
+    recalculateNodeWeight(dependency.W, dependent)
+  }
+
+  if (_mods.edgeCreated) {
+    modBus.dispatch(
+      pluginActions.edgeCreated({
+        dependency,
+        dependent: dependent, // unfortunate but not changing for now
+        edge: newEdge,
+      })
+    )
+  }
+
+  return newEdge
+}
+
+export const destroyNodeStart = (node: GraphNode, force?: boolean) => {
+  // If we're not force-destroying, don't destroy if there are dependents
+  if (node.l === 'Destroyed' || (!force && node.o.size)) return
+
+  node.c?.()
+  node.c = undefined
+
+  setNodeStatus(node, 'Destroyed')
+
+  if (node.w.length) node.e._scheduler.unschedule(node)
+
+  return true
+}
+
+// TODO: merge this into destroyNodeStart. We should be able to
+export const destroyNodeFinish = (node: GraphNode) => {
+  // first remove all edges between this node and its dependencies
+  for (const dependency of node.s.keys()) {
+    removeEdge(node, dependency)
+  }
+
+  // if an atom instance is force-destroyed, it could still have dependents.
+  // Inform them of the destruction
+  scheduleDependents(
+    {
+      r: node.w,
+      s: node,
+      t: Destroy,
+    },
+    true,
+    true
+  )
+
+  // now remove all edges between this node and its dependents
+  for (const [observer, edge] of node.o) {
+    if (!(edge.flags & Static)) {
+      recalculateNodeWeight(-node.W, observer)
+    }
+
+    observer.s.delete(node)
+
+    // we _probably_ don't need to send edgeRemoved mod events to plugins for
+    // these - it's better that they receive the duplicate edgeCreated event
+    // when the dependency is recreated by its dependent(s) so they can infer
+    // that the edge was "moved"
+  }
+
+  node.e.n.delete(node.id)
+}
+
+export const handleStateChange = <
+  G extends Pick<AtomGenerics, 'Events' | 'State'>
+>(
+  node: GraphNode<G & { Params: any; Template: any }>,
+  oldState: G['State'],
+  events?: Partial<G['Events'] & ExplicitEvents>
+) => {
+  scheduleDependents({ e: events, p: oldState, r: node.w, s: node }, false)
+
+  if (node.e._mods.stateChanged) {
+    node.e.modBus.dispatch(
+      pluginActions.stateChanged({
+        node,
+        newState: node.v,
+        oldState,
+        reasons: node.w,
+      })
+    )
+  }
+
+  // run the scheduler synchronously after any node state update
+  events?.batch || node.e._scheduler.flush()
+}
+
+const recalculateNodeWeight = (weightDiff: number, node?: GraphNode) => {
+  if (!node) return // happens when node is external
+
+  node.W += weightDiff
+
+  for (const observer of node.o.keys()) {
+    recalculateNodeWeight(weightDiff, observer)
+  }
+}
+
+/**
+ * Remove the graph edge between two nodes. The dependent may not exist as a
+ * node in the graph if it's external, e.g. a React component
+ *
+ * For some reason in React 18+, React destroys parents before children. This
+ * means a parent EcosystemProvider may have already unmounted and wiped the
+ * whole graph; this edge may already be destroyed.
+ */
+export const removeEdge = (dependent: GraphNode, dependency: GraphNode) => {
+  // erase graph edge between dependent and dependency
+  dependent && dependent.s.delete(dependency)
+
+  // hmm could maybe happen when a dependency was force-destroyed if a child
+  // tries to destroy its edge before recreating it (I don't think we ever do
+  // that though)
+  if (!dependency) return
+
+  const edge = dependency.o.get(dependent)
+
+  // happens in React 18+ (see this method's jsdoc above)
+  if (!edge) return
+
+  dependency.o.delete(dependent)
+
+  // static dependencies don't change a node's weight
+  if (!(edge.flags & Static)) {
+    recalculateNodeWeight(-dependency.W, dependent)
+  }
+
+  if (dependency.e._mods.edgeRemoved) {
+    dependency.e.modBus.dispatch(
+      pluginActions.edgeRemoved({
+        dependency,
+        dependent: dependent,
+        edge: edge,
+      })
+    )
+  }
+
+  scheduleNodeDestruction(dependency)
+}
+
+export const scheduleDependents = (
+  reason: Omit<InternalEvaluationReason, 's'> & {
+    s: NonNullable<InternalEvaluationReason['s']>
+  },
+  defer?: boolean,
+  scheduleStaticDeps?: boolean
+) => {
+  for (const [observer, edge] of reason.s.o) {
+    // Static deps don't update on state change, only on promise change or node
+    // force-destruction
+    if (scheduleStaticDeps || !(edge.flags & Static)) observer.r(reason, defer)
+  }
+}
+
+/**
+ * When a node's refCount hits 0, schedule destruction of that node.
+ */
+export const scheduleNodeDestruction = (node: GraphNode) =>
+  node.o.size || node.l !== 'Active' || node.m()
+
+export const setNodeStatus = (node: GraphNode, newStatus: LifecycleStatus) => {
+  const oldStatus = node.l
+  node.l = newStatus
+
+  if (node.e._mods.statusChanged) {
+    node.e.modBus.dispatch(
+      pluginActions.statusChanged({
+        newStatus,
+        node,
+        oldStatus,
+      })
+    )
+  }
+}

--- a/packages/react/src/hooks/useAtomInstance.ts
+++ b/packages/react/src/hooks/useAtomInstance.ts
@@ -82,7 +82,7 @@ export const useAtomInstance: {
   // It should be fine for this to run every render. It's possible to change
   // approaches if it is too heavy sometimes. But don't memoize this call:
   const instance: AtomInstance = ecosystem.getNode(atom, params)
-  const renderedValue = instance.get()
+  const renderedValue = instance.v
 
   let node =
     (ecosystem.n.get(observerId) as ExternalNode) ??
@@ -110,7 +110,7 @@ export const useAtomInstance: {
     // an unmounting component's effect cleanup can update or force-destroy the
     // atom instance before this component is mounted. If that happened, trigger
     // a rerender to recreate the atom instance and/or get its new state
-    if (instance.get() !== renderedValue || instance.l === 'Destroyed') {
+    if (instance.v !== renderedValue || instance.l === 'Destroyed') {
       render({})
     }
 

--- a/packages/react/src/hooks/useAtomState.ts
+++ b/packages/react/src/hooks/useAtomState.ts
@@ -74,5 +74,5 @@ export const useAtomState: {
     subscribe: true,
   })
 
-  return [instance.get(), instance._infusedSetter]
+  return [instance.v, instance._infusedSetter]
 }

--- a/packages/react/src/hooks/useAtomValue.ts
+++ b/packages/react/src/hooks/useAtomValue.ts
@@ -61,4 +61,4 @@ export const useAtomValue: {
   useAtomInstance(atom, params, {
     ...config,
     subscribe: true,
-  }).get()
+  }).v

--- a/packages/react/test/integrations/ecosystem.test.tsx
+++ b/packages/react/test/integrations/ecosystem.test.tsx
@@ -30,9 +30,9 @@ describe('ecosystem', () => {
 
     const atom1 = atom('atom1', () => {
       evaluate1()
-      const store = injectSignal('1')
+      const signal = injectSignal('1')
 
-      return store
+      return signal
     })
 
     const atom2 = atom('atom2', () => {

--- a/packages/react/test/integrations/injectors.test.tsx
+++ b/packages/react/test/integrations/injectors.test.tsx
@@ -84,6 +84,9 @@ describe('injectors', () => {
 
     instance.set('b')
 
+    // all those `get` calls shouldn't add any edges besides the one already
+    // added by `injectSignal`:
+    expect(instance.s.size).toBe(1)
     expect(vals).toEqual(['a', 'a', 'a', 'b', 'a', 'b'])
     expect(cbs).toEqual(['aa', 'aa', 'aa', 'bb', 'aa', 'bb'])
     expect(effects).toEqual(['b'])
@@ -165,7 +168,7 @@ describe('injectors', () => {
       const signal = injectSignal('a', { reactive: isReactive })
       const instance2 = injectAtomInstance(atom2)
 
-      vals.push([signal.get(), isReactive, instance2.get()])
+      vals.push([signal.get(), isReactive, instance2.getOnce()])
 
       return api(signal).setExports({
         invalidate,

--- a/packages/react/test/integrations/plugins.test.tsx
+++ b/packages/react/test/integrations/plugins.test.tsx
@@ -214,7 +214,7 @@ describe('plugins', () => {
                 >
               ).payload
 
-              const state = node.get()
+              const state = node.getOnce()
               updates.push(state)
             }
           },

--- a/packages/react/test/integrations/signals.test.tsx
+++ b/packages/react/test/integrations/signals.test.tsx
@@ -112,8 +112,19 @@ describe('signals', () => {
       state.b = []
     })
 
+    const commonChangeProps = {
+      operation: 'on',
+      reasons: [],
+      source: instance1.exports.signal,
+      type: 'state changed',
+    }
+
     const expectedEvents = {
-      change: { newState: { a: 1, b: [] }, oldState: { a: 1, b: [{ c: 2 }] } },
+      change: {
+        newState: { a: 1, b: [] },
+        oldState: { a: 1, b: [{ c: 2 }] },
+        ...commonChangeProps,
+      },
       mutate: [
         { k: ['b', '0', 'c'], v: 3 },
         { k: 'b', v: [] },
@@ -129,7 +140,11 @@ describe('signals', () => {
     instance1.exports.signal.set(state => ({ ...state, a: state.a + 1 }))
 
     const expectedEvents2 = {
-      change: { newState: { a: 2, b: [] }, oldState: { a: 1, b: [] } },
+      change: {
+        newState: { a: 2, b: [] },
+        oldState: { a: 1, b: [] },
+        ...commonChangeProps,
+      },
     }
 
     expect(calls).toEqual([['change', expectedEvents2.change, expectedEvents2]])

--- a/packages/react/test/integrations/signals.test.tsx
+++ b/packages/react/test/integrations/signals.test.tsx
@@ -134,6 +134,28 @@ describe('signals', () => {
 
     expect(calls).toEqual([['change', expectedEvents2.change, expectedEvents2]])
   })
+
+  test("a non-reactively-injected signal still updates the atom's value", () => {
+    const testAtom = atom('test', () => {
+      const signal = injectSignal(1, { reactive: false })
+
+      return api(signal).setExports({
+        increment: () => signal.set(state => state + 1),
+      })
+    })
+
+    const testInstance = ecosystem.getNode(testAtom)
+
+    expect(testInstance.v).toBe(1)
+    expect(testInstance.get()).toBe(1)
+    expect(testInstance.getOnce()).toBe(1)
+
+    testInstance.exports.increment()
+
+    expect(testInstance.v).toBe(2)
+    expect(testInstance.get()).toBe(2)
+    expect(testInstance.getOnce()).toBe(2)
+  })
 })
 
 describe('mapped signals', () => {

--- a/packages/react/test/types.test.tsx
+++ b/packages/react/test/types.test.tsx
@@ -615,7 +615,7 @@ describe('react types', () => {
       const val6 = injectCallback(() => true, [])
       const val7 = injectPromise(() => Promise.resolve(1), [])
 
-      return api(injectSignal(instance.get())).setExports({
+      return api(injectSignal(instance.getOnce())).setExports({
         val1,
         val2,
         val3,

--- a/packages/react/test/types.test.tsx
+++ b/packages/react/test/types.test.tsx
@@ -793,14 +793,23 @@ describe('react types', () => {
 
     signal.set(state => state + 1, { a: 11 })
 
+    const expectedChangeEvent = {
+      newState: 2,
+      oldState: 1,
+      operation: 'on',
+      reasons: [],
+      source: signal,
+      type: 'state changed',
+    }
+
     expect(calls).toEqual([
-      ['a', 11, { a: 11, change: { newState: 2, oldState: 1 } }],
+      ['a', 11, { a: 11, change: expectedChangeEvent }],
       [
         'change',
         { newState: 2, oldState: 1 },
-        { a: 11, change: { newState: 2, oldState: 1 } },
+        { a: 11, change: expectedChangeEvent },
       ],
-      ['*', { a: 11, change: { newState: 2, oldState: 1 } }],
+      ['*', { a: 11, change: expectedChangeEvent }],
     ])
     calls.splice(0, 3)
 

--- a/packages/stores/src/AtomInstance.ts
+++ b/packages/stores/src/AtomInstance.ts
@@ -157,7 +157,8 @@ export class AtomInstance<
    * An alias for `instance.store.getState()`. Returns the current state of this
    * atom instance's store.
    *
-   * @deprecated - use `.get()` instead @see AtomInstance.get
+   * @deprecated - use `.getOnce()` instead @see NewAtomInstance.getOnce. Also
+   * see `.get()` for automatic reactivity.
    */
   public getState(): G['State'] {
     return this.store.getState()
@@ -169,6 +170,8 @@ export class AtomInstance<
    * An alias for `instance.store.getState()`.
    */
   public get() {
+    super.get() // register graph edge
+
     return this.store.getState()
   }
 
@@ -248,6 +251,8 @@ export class AtomInstance<
             this._handleStateChange(newState, oldState, action)
           }
         )
+
+        this.v = this.store.getState()
       } else {
         const newStateType = getStateType(newFactoryResult)
 
@@ -392,6 +397,7 @@ export class AtomInstance<
     oldState: G['State'] | undefined,
     action: ActionChain
   ) {
+    this.v = newState
     zi.u({ p: oldState, r: this.w, s: this }, false)
 
     if (this.e._mods.stateChanged) {


### PR DESCRIPTION
## Description

In keeping with other signals libs, calls to `signal.get()` should register a dependency on the got signal in reactive contexts (e.g. in atom state factories and atom selector functions). Implement that and add `signal.getOnce()` for getting a node's value non-reactively. Update all our internal usages of `.get` accordingly - mostly moving off of `.get()` 'cause we never want to accidentally add edges in calls to other Zedux functions.

### Breaking Change

This is only a breaking change from the latest, beta version (`2.0.0-beta.0`) where `signal.get()` was just added and is not reactive.

## Issues

#115 (almost resolves! The only things left are the `cycle` event and making event listeners not prevent destruction)