### PR TITLE
fix: use singly-linked WeakRefs to clean up React 18 StrictMode trash

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,6 @@
   },
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "packageManager": "yarn@1.22.4+sha512.a1833b862fe52169bd6c2a033045a07df5bc6a23595c259e675fed1b2d035ab37abe6ce309720abb6636d68f03615054b6292dc0a70da31c8697fda228b50d18"
 }

--- a/packages/atoms/src/classes/Selectors.ts
+++ b/packages/atoms/src/classes/Selectors.ts
@@ -4,6 +4,7 @@ import {
   AtomSelectorOrConfig,
   Cleanup,
   DependentCallback,
+  DependentEdge,
   EvaluationReason,
   Selectable,
 } from '../types/index'
@@ -16,10 +17,13 @@ const defaultResultsComparator = (a: any, b: any) => a === b
 export class SelectorCache<T = any, Args extends any[] = any[]> {
   public static $$typeof = Symbol.for(`${prefix}/SelectorCache`)
   public isDestroyed?: boolean
+  public isMaterialized?: boolean
   public nextReasons: EvaluationReason[] = []
   public prevReasons?: EvaluationReason[]
   public result?: T
   public task?: () => void
+  public _lastEdge?: WeakRef<DependentEdge>
+  public _prevCache?: WeakRef<SelectorCache>
 
   constructor(
     public id: string,
@@ -40,6 +44,11 @@ export class Selectors {
    * Map selectorKey + params id strings to the SelectorCache for the selector
    */
   public _items: Record<string, SelectorCache<any, any>> = {}
+
+  /**
+   * A workaround for React StrictMode
+   */
+  public _lastCache?: WeakRef<SelectorCache<any, any>>
 
   /**
    * Map selectors (or selector config objects) to a base selectorKey that can

--- a/packages/atoms/src/classes/instances/AtomInstance.ts
+++ b/packages/atoms/src/classes/instances/AtomInstance.ts
@@ -14,6 +14,7 @@ import {
   AtomGenerics,
   AtomGenericsToAtomApiGenerics,
   Cleanup,
+  DependentEdge,
   EvaluationReason,
   EvaluationSourceType,
   ExportsInfusedSetter,
@@ -87,6 +88,7 @@ export class AtomInstance<
   public _createdAt: number
   public _injectors?: InjectorDescriptor[]
   public _isEvaluating?: boolean
+  public _lastEdge?: WeakRef<DependentEdge>
   public _nextInjectors?: InjectorDescriptor[]
   public _promiseError?: Error
   public _promiseStatus?: PromiseStatus

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -174,8 +174,11 @@ export type DependentCallback = (
 export interface DependentEdge {
   callback?: DependentCallback
   createdAt: number
+  dependentKey?: string
   flags: number // calculated from the EdgeFlags
+  isMaterialized?: boolean
   operation: string
+  prevEdge?: WeakRef<DependentEdge>
   task?: () => void // for external edges - so they can unschedule jobs
 }
 

--- a/packages/react/src/hooks/useAtomSelector.ts
+++ b/packages/react/src/hooks/useAtomSelector.ts
@@ -1,6 +1,7 @@
 import {
   AtomSelectorConfig,
   AtomSelectorOrConfig,
+  DependentEdge,
   haveDepsChanged,
   SelectorCache,
 } from '@zedux/atoms'
@@ -71,15 +72,32 @@ export const useAtomSelector = <T, Args extends any[]>(
     ;(render as any).mounted = true
   }
 
-  const cache = isSwappingRefs
+  let cache = isSwappingRefs
     ? (existingCache as SelectorCache<T, Args>)
     : selectors.getCache(selectorOrConfig, resolvedArgs)
 
+  let edge: DependentEdge | undefined
+
   const addEdge = () => {
     if (!_graph.nodes[cache.id]?.dependents.get(dependentKey)) {
-      _graph.addEdge(dependentKey, cache.id, OPERATION, External, () => {
+      edge = _graph.addEdge(dependentKey, cache.id, OPERATION, External, () => {
         if ((render as any).mounted) render({})
       })
+
+      if (edge) {
+        edge.dependentKey = dependentKey
+
+        if (cache._lastEdge) {
+          edge.prevEdge = cache._lastEdge
+        }
+        cache._lastEdge = new WeakRef(edge)
+      }
+
+      if (selectors._lastCache && selectors._lastCache.deref() !== cache) {
+        cache._prevCache = selectors._lastCache
+      }
+
+      selectors._lastCache = new WeakRef(cache)
     }
   }
 
@@ -90,6 +108,32 @@ export const useAtomSelector = <T, Args extends any[]>(
   ;(render as any).cache = cache as SelectorCache<any, any[]>
 
   useEffect(() => {
+    cache = isSwappingRefs
+      ? (existingCache as SelectorCache<T, Args>)
+      : selectors.getCache(selectorOrConfig, resolvedArgs)
+
+    if (edge) {
+      let prevEdge = edge.prevEdge?.deref()
+
+      // clear out any junk edges added by StrictMode
+      while (prevEdge && !prevEdge.isMaterialized) {
+        ecosystem._graph.removeEdge(prevEdge.dependentKey!, cache.id)
+        prevEdge = prevEdge.prevEdge?.deref()
+      }
+
+      edge.isMaterialized = true
+    }
+
+    let prevCache = cache._prevCache?.deref()
+
+    // clear out any junk caches created by StrictMode
+    while (prevCache && !prevCache.isMaterialized) {
+      selectors.destroyCache(prevCache, [], true)
+      prevCache = prevCache._prevCache?.deref()
+    }
+
+    cache.isMaterialized = true
+
     // Try adding the edge again (will be a no-op unless React's StrictMode ran
     // this effect's cleanup unnecessarily)
     addEdge()

--- a/packages/react/test/units/__snapshots__/useAtomSelector.test.tsx.snap
+++ b/packages/react/test/units/__snapshots__/useAtomSelector.test.tsx.snap
@@ -24,7 +24,9 @@ exports[`useAtomSelector inline selector that returns a different object referen
       "Test-:r0:" => {
         "callback": [Function],
         "createdAt": 123456789,
+        "dependentKey": "Test-:r0:",
         "flags": 2,
+        "isMaterialized": true,
         "operation": "useAtomSelector",
       },
     },
@@ -59,7 +61,9 @@ exports[`useAtomSelector inline selector that returns a different object referen
       "Test-:r0:" => {
         "callback": [Function],
         "createdAt": 123456789,
+        "dependentKey": "Test-:r0:",
         "flags": 2,
+        "isMaterialized": true,
         "operation": "useAtomSelector",
         "task": undefined,
       },
@@ -95,6 +99,7 @@ exports[`useAtomSelector inline selector that returns a different object referen
       "Test-:r0:" => {
         "callback": [Function],
         "createdAt": 123456789,
+        "dependentKey": "Test-:r0:",
         "flags": 2,
         "operation": "useAtomSelector",
       },
@@ -130,6 +135,7 @@ exports[`useAtomSelector inline selector that returns a different object referen
       "Test-:r0:" => {
         "callback": [Function],
         "createdAt": 123456789,
+        "dependentKey": "Test-:r0:",
         "flags": 2,
         "operation": "useAtomSelector",
         "task": undefined,

--- a/packages/react/test/units/useAtomSelector.test.tsx
+++ b/packages/react/test/units/useAtomSelector.test.tsx
@@ -443,8 +443,11 @@ describe('useAtomSelector', () => {
     expect(ecosystem.selectors.findAll()).toMatchInlineSnapshot(`
       {
         "@@selector-unnamed-1": SelectorCache {
+          "_lastEdge": WeakRef {},
+          "_prevCache": WeakRef {},
           "args": [],
           "id": "@@selector-unnamed-1",
+          "isMaterialized": true,
           "nextReasons": [],
           "prevReasons": [],
           "result": 1,
@@ -464,8 +467,11 @@ describe('useAtomSelector', () => {
     expect(ecosystem.selectors.findAll()).toMatchInlineSnapshot(`
       {
         "@@selector-unnamed-1": SelectorCache {
+          "_lastEdge": WeakRef {},
+          "_prevCache": WeakRef {},
           "args": [],
           "id": "@@selector-unnamed-1",
+          "isMaterialized": true,
           "nextReasons": [],
           "prevReasons": [],
           "result": 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1385,22 +1385,16 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.2.tgz#4c62fae93eb479660c3bd93f9d24d561597a8281"
   integrity sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==
 
-"@types/prop-types@*":
-  version "15.7.14"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.14.tgz#1433419d73b2a7ebfc6918dcefd2ec0d5cd698f2"
-  integrity sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==
+"@types/react-dom@^19.0.2":
+  version "19.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.0.3.tgz#0804dfd279a165d5a0ad8b53a5b9e65f338050a4"
+  integrity sha512-0Knk+HJiMP/qOZgMyNFamlIjw9OFCsyC2ZbigmEEyXXixgre6IQpm/4V+r3qH4GC1JPvRJKInw+on2rV6YZLeA==
 
-"@types/react-dom@^18.3.0":
-  version "18.3.5"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.5.tgz#45f9f87398c5dcea085b715c58ddcf1faf65f716"
-  integrity sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==
-
-"@types/react@^18.3.0":
-  version "18.3.16"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.16.tgz#5326789125fac98b718d586ad157442ceb44ff28"
-  integrity sha512-oh8AMIC4Y2ciKufU8hnKgs+ufgbA/dhPTACaZPM86AbwX9QwnFtSoPWEeRUj8fge+v6kFt78BXcDhAU1SrrAsw==
+"@types/react@^19.0.1":
+  version "19.0.7"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.0.7.tgz#c451968b999d1cb2d9207dc5ff56496164cf511d"
+  integrity sha512-MoFsEJKkAtZCrC1r6CM8U22GzhG7u2Wir8ons/aCKH6MBdD1ibV24zOSSkdZVUKqN5i396zG5VKLYZ3yaUZdLA==
   dependencies:
-    "@types/prop-types" "*"
     csstype "^3.0.2"
 
 "@types/semver@^7.3.12":
@@ -3300,7 +3294,7 @@ ignore@^5.0.4, ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
-immer@^10.0.0:
+immer@^10.1.1:
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/immer/-/immer-10.1.1.tgz#206f344ea372d8ea176891545ee53ccc062db7bc"
   integrity sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==


### PR DESCRIPTION
@affects atoms, react

## Description

Thanks to the excellent, simple repro by @joprice in #152, I was able to get a much better handle on React 18's StrictMode bugs that many previous Zedux versions failed to fully work around.

This takes a previous idea of using WeakRefs to track garbage cache items and graph edges created by StrictMode. Build on that idea by making each WeakRef reference a node in a singly-linked list of WeakRefs that walk back through StrictMode's destruction.

As soon as any hook's `useEffect` runs, walk back through the list its last node has access to and clean up everything node until reaching any that have materialized - any real, non-StrictMode-junk nodes will run after the first node. They'll point back to valid nodes, bailing out immediately.

Iterate up through the linked list to be handle multiple hook usages in the same component that add dependencies to the same atom or selector instance.

This is non-StrictMode compatible since no junk nodes will be created, leading to all `isMaterialized` checks being noops.

### Breakdown

Given this example:

```ts
function Counter() {
  const count = useAtomValue(countAtom)
  const instance = useAtomInstance(countAtom)

   ...
}

function App() {
  return (
    <StrictMode>
      <Counter />
      <Counter />
    </StrictMode>
  )
}
```

StrictMode will create the following dependencies on `countAtom` (in order):

- `Counter1-useAtomValue1` - junk, should be deleted
- `Counter1-useAtomInstance1` - junk, should be deleted
- `Counter1-useAtomValue2`
- `Counter1-useAtomInstance2`
- `Counter2-useAtomValue1` - junk, should be deleted
- `Counter2-useAtomInstance1` - junk, should be deleted
- `Counter2-useAtomValue2`
- `Counter2-useAtomInstance2`

As React renders these components, we create one singly-linked lists of WeakRef'd graph edges for each atom used (just the `countAtom` in this case):

- `Counter1-useAtomValue1` <- `Counter1-useAtomInstance1` <- `Counter1-useAtomValue2` <- `Counter1-useAtomInstance2` <- `Counter2-useAtomValue1` <- `Counter2-useAtomInstance1` <- `Counter2-useAtomValue2` <- `Counter2-useAtomInstance2`

All of these nodes are "unmaterialized" since `isMaterialized` is not set on any of them. StrictMode's junk runs never call `useEffect`. So when `useEffect` runs, we walk back up through the list starting at the currently-running node, mark the current node as materialized, and delete any nodes before it that were unmaterialized:

- `Counter1-useAtomValue2`'s `useEffect` runs. Walk up to `Counter1-useAtomInstance1`, delete it since it's unmaterialized. Walk up to `Counter1-useAtomValue1` and delete it too. Stop 'cause we reached the end of the list. Mark `Counter1-useAtomValue2` as materialized.
- `Counter1-useAtomInstance2`'s `useEffect` runs. Walk up to `Counter1-useAtomValue2`. Stop 'cause `Counter1-useAtomValue2` is materialized.
- `Counter2-useAtomValue2`'s `useEffect` runs. Walk up to `Counter2-useAtomInstance1`, delete it since it's unmaterialized. Walk up to `Counter2-useAtomValue1` and delete it too. Stop 'cause we reached the end of the list. Mark `Counter2-useAtomValue2` as materialized.
- `Counter2-useAtomInstance2`'s `useEffect` runs. Walk up to `Counter1-useAtomValue2`. Stop 'cause `Counter1-useAtomValue2` is materialized.

Outside StrictMode, nothing will be deleted since every node's `useEffect` will run and see that either there is no previous node or the previous node is already materialized.

For selectors, there's an extra complication, since StrictMode also creates junk SelectorCache instances. So use this singly-linked list algorithm in `useAtomSelector` for both edges and caches.