### PR TITLE
fix(react): guard against circular `prevCache` refs in `useAtomSelector`

### DIFF
--- a/packages/react/src/hooks/useAtomInstance.ts
+++ b/packages/react/src/hooks/useAtomInstance.ts
@@ -117,13 +117,17 @@ export const useAtomInstance: {
     if (edge) {
       let prevEdge = edge.prevEdge?.deref()
 
+      edge.isMaterialized = true
+
       // clear out any junk edges added by StrictMode
       while (prevEdge && !prevEdge.isMaterialized) {
         ecosystem._graph.removeEdge(prevEdge.dependentKey!, instance.id)
+
+        // mark in case of circular references (shouldn't happen, but just for
+        // consistency with the prevCache algorithm)
+        prevEdge.isMaterialized = true
         prevEdge = prevEdge.prevEdge?.deref()
       }
-
-      edge.isMaterialized = true
     }
 
     // Try adding the edge again (will be a no-op unless React's StrictMode ran


### PR DESCRIPTION
## Description

Certain React rendering sequences can apparently cause the singly-linked WeakRef list added in #154 to reference in circles. This causes the `while` loop cleaning up weak refs to run infinitely. This can only happen in `useAtomSelector`'s `prevCache` linked list, not `useAtomSelector`'s or `useAtomInstance`'s `prevEdge` linked lists.

Mark each node as materialized when it's visited to kick out of the while loop when it hits a node it's already seen. Verify this fixes the problem for `useAtomSelector`'s `prevCache` linked list. Do the same for the `prevEdge` linked lists in `useAtomSelector` and `useAtomInstance` just in case something we change later possibly introduces the same problem for those.

I will add repro tests in a separate PR

## Issues

Resolves #160
