### PR TITLE
test(react): add regression tests for recent issues

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,15 +1,13 @@
 import '@testing-library/jest-dom/extend-expect'
 
 let callstacks: Record<string, string> = {}
-let id = 0
 let prevIds: string[] = []
-let useIdMode: 'overridden' | 'react19' | 'react18' = 'overridden'
+let useIdMode: 'react19' | 'react18' = 'react19'
 
 afterEach(() => {
   callstacks = {}
-  id = 0
   prevIds = []
-  useIdMode = 'overridden'
+  useIdMode = 'react19'
 })
 
 const react = jest.requireActual('react')
@@ -17,23 +15,14 @@ const react = jest.requireActual('react')
 const generateId = () => {
   if (useIdMode === 'react19') return react.useId()
 
-  if (useIdMode === 'react18') {
-    const id1 = react.useId()
-    const id2 = react.useId()
+  const id1 = react.useId()
+  const id2 = react.useId()
 
-    if (prevIds.includes(id1)) return id2
+  if (prevIds.includes(id1)) return id2
 
-    prevIds.push(id1)
+  prevIds.push(id1)
 
-    return id1
-  }
-
-  const stack =
-    (new Error().stack || '')
-      .split('\n')
-      .find(line => /\.test\.tsx:/.test(line)) || ''
-
-  return (callstacks[stack] ||= `:r${id++}:`)
+  return id1
 }
 
 jest.mock('react', () => ({
@@ -52,9 +41,6 @@ jest.mock('react', () => ({
   if (key) {
     delete callstacks[key]
   }
-}
-;(globalThis as any).useReact19UseId = () => {
-  useIdMode = 'react19'
 }
 ;(globalThis as any).useReact18UseId = () => {
   useIdMode = 'react18'

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -2,13 +2,32 @@ import '@testing-library/jest-dom/extend-expect'
 
 let callstacks: Record<string, string> = {}
 let id = 0
+let prevIds: string[] = []
+let useIdMode: 'overridden' | 'react19' | 'react18' = 'overridden'
 
 afterEach(() => {
   callstacks = {}
   id = 0
+  prevIds = []
+  useIdMode = 'overridden'
 })
 
+const react = jest.requireActual('react')
+
 const generateId = () => {
+  if (useIdMode === 'react19') return react.useId()
+
+  if (useIdMode === 'react18') {
+    const id1 = react.useId()
+    const id2 = react.useId()
+
+    if (prevIds.includes(id1)) return id2
+
+    prevIds.push(id1)
+
+    return id1
+  }
+
   const stack =
     (new Error().stack || '')
       .split('\n')
@@ -18,7 +37,7 @@ const generateId = () => {
 }
 
 jest.mock('react', () => ({
-  ...jest.requireActual('react'),
+  ...react,
   useId: generateId,
 }))
 
@@ -33,4 +52,10 @@ jest.mock('react', () => ({
   if (key) {
     delete callstacks[key]
   }
+}
+;(globalThis as any).useReact19UseId = () => {
+  useIdMode = 'react19'
+}
+;(globalThis as any).useReact18UseId = () => {
+  useIdMode = 'react18'
 }

--- a/packages/react/test/regressions/154.test.tsx
+++ b/packages/react/test/regressions/154.test.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react'
+import {
+  atom,
+  injectStore,
+  useAtomInstance,
+  useAtomSelector,
+  useAtomValue,
+} from '@zedux/react'
+import { renderInEcosystem } from '../utils/renderInEcosystem'
+import { act } from '@testing-library/react'
+import { ecosystem } from '../utils/ecosystem'
+
+describe('issue #154', () => {
+  test('repro', async () => {
+    ;(globalThis as any).useReact18UseId()
+
+    const poller = atom(
+      'poller',
+      () => {
+        const store = injectStore(0)
+
+        return store
+      },
+      { ttl: 0 }
+    )
+
+    function Counter({ id }: { id: number }) {
+      const count = useAtomValue(poller)
+      const instance = useAtomInstance(poller)
+
+      useAtomSelector(({ get }) => get(poller))
+
+      return (
+        <div>
+          <div>
+            count for {id} is {count} ({instance.getState()})
+          </div>
+        </div>
+      )
+    }
+
+    function App() {
+      const [showCounter, setShowCounter] = useState(true)
+      return (
+        <div>
+          <div className="card">
+            <button
+              style={{ marginBottom: 10 }}
+              onClick={() => {
+                setShowCounter(!showCounter)
+              }}
+            >
+              Toggle
+            </button>
+            {showCounter && (
+              <>
+                <Counter id={1} />
+                <Counter id={2} />
+              </>
+            )}
+          </div>
+        </div>
+      )
+    }
+
+    const { findByText } = renderInEcosystem(<App />, { useStrictMode: true })
+    const button = await findByText('Toggle')
+
+    expect(ecosystem._graph.nodes['poller'].dependents.size).toBe(6)
+
+    await act(() => {
+      button.click()
+    })
+
+    expect(ecosystem._graph.nodes['poller']).toBeUndefined()
+
+    await act(() => {
+      button.click()
+    })
+
+    expect(ecosystem._graph.nodes['poller'].dependents.size).toBe(6)
+  })
+})

--- a/packages/react/test/regressions/160.test.tsx
+++ b/packages/react/test/regressions/160.test.tsx
@@ -1,0 +1,121 @@
+import {
+  atom,
+  AtomGetters,
+  AtomInstanceType,
+  AtomProvider,
+  useAtomContext,
+  useAtomInstance,
+  useAtomSelector,
+} from '@zedux/react'
+import React from 'react'
+import { renderInEcosystem } from '../utils/renderInEcosystem'
+
+describe('issue #160', () => {
+  test('repro', async () => {
+    ;(globalThis as any).useReact19UseId()
+
+    const configAtom = atom('config', {
+      controls: [
+        {
+          counter: 0,
+          id: '1',
+        },
+        {
+          counter: 0,
+          id: '2',
+        },
+      ],
+    })
+
+    const useConfigAtomContext = () => useAtomContext(configAtom, true)
+
+    const useConfigAtomItems = (
+      instance: AtomInstanceType<typeof configAtom>
+    ) => instance.getState().controls ?? []
+
+    const selector = (
+      { get }: AtomGetters,
+      instance: AtomInstanceType<typeof configAtom>,
+      id: string
+    ) => get(instance).controls.find(t => t.id === id)
+
+    function Item({ id }: { id: string }) {
+      const instance = useConfigAtomContext()
+      const thisItem = useAtomSelector(selector, instance, id)
+
+      return <div data-testid={`item${id}`}>{thisItem?.counter}</div>
+    }
+
+    function Menu() {
+      const instance = useConfigAtomContext()
+      const items = useConfigAtomItems(instance)
+
+      return (
+        <div>
+          Menu: {instance.getState().controls[0].counter}
+          <ul>
+            {items?.map(item => (
+              <Item key={item.id} id={item.id} />
+            ))}
+          </ul>
+        </div>
+      )
+    }
+
+    function Content() {
+      const instance = useConfigAtomContext()
+      const items = useConfigAtomItems(instance)
+
+      return (
+        <div>
+          <span data-testid="content">
+            {instance.getState().controls[0].counter}
+          </span>
+          <ul>
+            {items?.map(item => (
+              <Item key={item.id} id={item.id} />
+            ))}
+          </ul>
+        </div>
+      )
+    }
+
+    function Outlet() {
+      const instance = useConfigAtomContext()
+
+      return (
+        <div>
+          <div>Outlet: {instance.getState().controls[0].counter}</div>
+          <Menu />
+          <Content />
+        </div>
+      )
+    }
+
+    function App() {
+      const instance = useAtomInstance(configAtom)
+
+      return (
+        <AtomProvider instance={instance}>
+          <Outlet />
+        </AtomProvider>
+      )
+    }
+
+    const { findByTestId, findAllByTestId } = renderInEcosystem(<App />, {
+      useStrictMode: true,
+    })
+
+    const content = await findByTestId('content')
+
+    expect(content.innerHTML).toBe('0')
+
+    const items1 = await findAllByTestId('item1')
+    const items2 = await findAllByTestId('item2')
+
+    expect(items1[0].innerHTML).toBe('0')
+    expect(items1[1].innerHTML).toBe('0')
+    expect(items2[0].innerHTML).toBe('0')
+    expect(items2[1].innerHTML).toBe('0')
+  })
+})

--- a/packages/react/test/regressions/160.test.tsx
+++ b/packages/react/test/regressions/160.test.tsx
@@ -12,8 +12,6 @@ import { renderInEcosystem } from '../utils/renderInEcosystem'
 
 describe('issue #160', () => {
   test('repro', async () => {
-    ;(globalThis as any).useReact19UseId()
-
     const configAtom = atom('config', {
       controls: [
         {

--- a/packages/react/test/units/__snapshots__/useAtomSelector.test.tsx.snap
+++ b/packages/react/test/units/__snapshots__/useAtomSelector.test.tsx.snap
@@ -21,10 +21,10 @@ exports[`useAtomSelector inline selector that returns a different object referen
       "1" => true,
     },
     "dependents": Map {
-      "Test-:r0:" => {
+      "Test-:ra:" => {
         "callback": [Function],
         "createdAt": 123456789,
-        "dependentKey": "Test-:r0:",
+        "dependentKey": "Test-:ra:",
         "flags": 2,
         "isMaterialized": true,
         "operation": "useAtomSelector",
@@ -58,10 +58,10 @@ exports[`useAtomSelector inline selector that returns a different object referen
       "1" => true,
     },
     "dependents": Map {
-      "Test-:r0:" => {
+      "Test-:ra:" => {
         "callback": [Function],
         "createdAt": 123456789,
-        "dependentKey": "Test-:r0:",
+        "dependentKey": "Test-:ra:",
         "flags": 2,
         "isMaterialized": true,
         "operation": "useAtomSelector",
@@ -96,10 +96,10 @@ exports[`useAtomSelector inline selector that returns a different object referen
       "1" => true,
     },
     "dependents": Map {
-      "Test-:r0:" => {
+      "Test-:rb:" => {
         "callback": [Function],
         "createdAt": 123456789,
-        "dependentKey": "Test-:r0:",
+        "dependentKey": "Test-:rb:",
         "flags": 2,
         "operation": "useAtomSelector",
       },
@@ -132,10 +132,10 @@ exports[`useAtomSelector inline selector that returns a different object referen
       "1" => true,
     },
     "dependents": Map {
-      "Test-:r0:" => {
+      "Test-:rb:" => {
         "callback": [Function],
         "createdAt": 123456789,
-        "dependentKey": "Test-:r0:",
+        "dependentKey": "Test-:rb:",
         "flags": 2,
         "operation": "useAtomSelector",
         "task": undefined,


### PR DESCRIPTION
## Description

Reproduce both #152 and #160 in tests and verify that the changes in #154 and #161, respectively, fix them. These tests will be crucial to ensuring we don't regress again in v1. I'll also cherry-pick to v2 so these can ensure that Zedux v2's completely updated logic also doesn't regress.

Create global helpers so tests can selectively use React 18's `useId` behavior. Default to React 19's `useId`.