### PR TITLE
feat(atoms)!: make `injectMemo` reactive when no deps are passed

### DIFF
--- a/packages/atoms/src/classes/SelectorInstance.ts
+++ b/packages/atoms/src/classes/SelectorInstance.ts
@@ -97,7 +97,10 @@ export const swapSelectorRefs = <G extends SelectorGenerics>(
 ) => {
   const baseKey = ecosystem.b.get(oldInstance.t)
 
-  if (!baseKey) return // TODO: remove
+  // TODO: remove. This is currently needed for selectors created outside the
+  // ecosystem (e.g. via `new SelectorInstance`). Only the ecosystem `getNode*`
+  // methods add the selector ref to `ecosystem.b`aseKeys. Change that.
+  if (!baseKey) return
 
   ecosystem.b.set(newRef, baseKey)
   ecosystem.b.delete(oldInstance.t)

--- a/packages/atoms/src/injectors/injectMemo.ts
+++ b/packages/atoms/src/injectors/injectMemo.ts
@@ -1,13 +1,20 @@
+import { SelectorInstance } from '../classes/SelectorInstance'
 import { InjectorDeps } from '../types/index'
 import { untrack } from '../utils/evaluationContext'
 import { compare } from '../utils/general'
 import { injectPrevDescriptor, setNextInjector } from './injectPrevDescriptor'
+import { injectSelf } from './injectSelf'
 
 interface MemoValue<T> {
   /**
    * `d`eps - the cached `injectMemo` deps array
    */
   d: InjectorDeps
+
+  /**
+   * `n`ode - the cached selector instance for an injectMemo call with no deps
+   */
+  n: SelectorInstance | undefined
 
   /**
    * `v`alue - the cached `injectMemo` result
@@ -26,17 +33,32 @@ export const injectMemo = <T = any>(
   valueFactory: () => T,
   deps?: InjectorDeps
 ): T => {
+  const instance = injectSelf()
   const prevDescriptor = injectPrevDescriptor<MemoValue<T>>(TYPE)
+  const depsUnchanged = compare(prevDescriptor?.v.d, deps)
+
+  if (depsUnchanged) return setNextInjector(prevDescriptor!).v.v
+
+  // define this object first so the callback has access to it
+  const value: MemoValue<T> = {
+    d: deps,
+    n: prevDescriptor?.v.n,
+    v: undefined as T,
+  }
+
+  value.v = deps
+    ? untrack(valueFactory)
+    : (value.n ??= new SelectorInstance(
+        instance.e,
+        instance.e._idGenerator.generateId(`injectMemo(${instance.id})-`),
+        valueFactory,
+        []
+      )).get()
 
   return setNextInjector({
     c: undefined,
     i: undefined,
     t: TYPE,
-    v: {
-      d: deps,
-      v: compare(prevDescriptor?.v.d, deps)
-        ? prevDescriptor!.v.v
-        : untrack(valueFactory),
-    },
+    v: value,
   }).v.v
 }

--- a/packages/atoms/src/utils/graph.ts
+++ b/packages/atoms/src/utils/graph.ts
@@ -15,7 +15,7 @@ import {
 
 /**
  * Actually add an edge to the graph. When we buffer graph updates, we're
- * really just deferring the calling of this method.
+ * really just deferring the calling of this function.
  */
 export const addEdge = (
   observer: GraphNode,
@@ -46,7 +46,7 @@ export const addEdge = (
 
 export const destroyNodeStart = (node: GraphNode, force?: boolean) => {
   // If we're not force-destroying, don't destroy if there are dependents. Also
-  // don't destroy of `node.K`eep is set
+  // don't destroy if `node.K`eep is set
   if (node.l === 'Destroyed' || (!force && node.o.size - (node.L ? 1 : 0))) {
     return
   }

--- a/packages/react/test/stores/injectors.test.tsx
+++ b/packages/react/test/stores/injectors.test.tsx
@@ -80,16 +80,16 @@ describe('injectors', () => {
 
     instance.setState('b')
 
-    expect(vals).toEqual(['a', 'a', 'a', 'b', 'a', 'b'])
-    expect(cbs).toEqual(['aa', 'aa', 'aa', 'bb', 'aa', 'bb'])
+    expect(vals).toEqual(['a', 'a', 'a', 'a', 'a', 'b'])
+    expect(cbs).toEqual(['aa', 'aa', 'aa', 'aa', 'aa', 'bb'])
     expect(effects).toEqual(['a', 'b'])
     expect(cleanups).toEqual(['b'])
     expect(refs).toEqual([ref, ref])
 
     instance.setState('c')
 
-    expect(vals).toEqual(['a', 'a', 'a', 'b', 'a', 'b', 'c', 'a', 'c'])
-    expect(cbs).toEqual(['aa', 'aa', 'aa', 'bb', 'aa', 'bb', 'bb', 'aa', 'bb'])
+    expect(vals).toEqual(['a', 'a', 'a', 'a', 'a', 'b', 'a', 'a', 'c'])
+    expect(cbs).toEqual(['aa', 'aa', 'aa', 'aa', 'aa', 'bb', 'aa', 'aa', 'bb'])
     expect(effects).toEqual(['a', 'b', 'c'])
     expect(cleanups).toEqual(['b', 'c'])
     expect(refs).toEqual([ref, ref, ref])


### PR DESCRIPTION
## Description

When called with no deps, `injectMemo` currently behaves like React's `useMemo` - it runs on every evaluation. This is pointless, obviously. Instead of mimicking React, we can add a new behavior that aligns with Zedux's new status as an official signals implementation:

When called with no deps, make `injectMemo`'s callback a new reactive context that tracks signal usages. This creates a new SelectorInstance under the hood that observes all used signals. Make the calling atom, in turn, an observer of that selector.

This usage comes with some caveats:

- The function reference passed to `injectMemo` is never updated. It can't be, or that would defeat the point of `injectMemo` since, technically, every time you call `injectMemo`, you typically pass a new function reference. That means any values it closes over can become stale. This is a common problem with signals libraries - signals become a leaky abstraction, leaking into all other values. If you go this route, you have to embrace reactivity and make everything a signal. This is usually better anyway, so we're officially adopting this pattern.
- Related to that, you can't swap out the callback conditionally

```ts
injectMemo(() => closedOverValue + mySignal.get()) // bad
injectMemo(useA ? callbackA : callbackB) // bad
injectMemo(() => closedOverSignal.get() + mySignal.get()) // good
```

We could apply the same behavior to `injectPromise` and `injectEffect`, though those come with an additional caveat of having to remember to only use reactive values before any `await` calls or asynchronous code, otherwise the calls won't be tracked.

Some signals libs (as well as React's own `startTransition`) just leave the user to deal with that caveat. I'd rather wait until the async context TC39 proposal is finalized (which fixes it), but I will implement them if there's demand. I'll wait until then though.

### Breaking Change

`injectMemo` behavior has changed when called with no deps.

```ts
// this used to run every evaluation. Now it runs only when `mySignal` changes:
injectMemo(() => mySignal.get())
```