### PR TITLE
feat: implement scoped atoms, `inject`, and `ecosystem.withScope`

### DIFF
--- a/packages/atoms/src/classes/GraphNode.ts
+++ b/packages/atoms/src/classes/GraphNode.ts
@@ -54,6 +54,31 @@ export abstract class GraphNode<G extends NodeGenerics = AnyNodeGenerics>
   public T = 2 as const
 
   /**
+   * scope`V`alues - maps contexts (e.g. React context objects or atom
+   * templates) to their resolved, provided values. This is the "scope" of this
+   * graph node - these values need to be provided for this node and its entire
+   * tree of source nodes (a node's scope contains all provided context values
+   * used by it and any of its sources).
+   *
+   * When `inject` is called in a state factory, it makes the atom scoped - the
+   * atom evaluation will throw an error unless the value was provided either
+   * via React context in React or `ecosystem.withScope`.
+   *
+   * When the atom reevaluates normally, these cached values are retrieved.
+   *
+   * When the atom is retrieved from React or another scoped context (like
+   * `ecosystem.withScope`), Zedux makes sure the same values are still
+   * provided. If the values have changed, a new atom instance is created with
+   * the new scope.
+   */
+  public V:
+    | Map<
+        Record<string, any>,
+        WeakRef<any> | number | string | boolean | null | undefined
+      >
+    | undefined = undefined
+
+  /**
    * @see Job.W
    */
   public W = 1
@@ -201,7 +226,7 @@ export abstract class GraphNode<G extends NodeGenerics = AnyNodeGenerics>
    * refCount goes back up to 1, we call this to cancel the scheduled
    * destruction.
    */
-  public c?: Cleanup
+  public c: Cleanup | undefined = undefined
 
   /**
    * `d`ehydrate - a function called internally by `ecosystem.dehydrate()` to

--- a/packages/atoms/src/classes/IdGenerator.ts
+++ b/packages/atoms/src/classes/IdGenerator.ts
@@ -52,9 +52,7 @@ export class IdGenerator {
       if (!isPlainObject(param)) {
         if (!acceptComplexParams || Array.isArray(param)) return param
         if (typeof param === 'function') return this.cacheFn(param)
-        if (typeof param?.constructor === 'function') {
-          return this.cacheClass(param)
-        }
+        if (typeof param === 'object') return this.cacheClass(param)
 
         return param // let engine try to resolve it or throw the error
       }

--- a/packages/atoms/src/classes/IdGenerator.ts
+++ b/packages/atoms/src/classes/IdGenerator.ts
@@ -42,8 +42,8 @@ export class IdGenerator {
    * acceptComplexParams is true, map class instances and functions to a
    * consistent id for the reference.
    *
-   * Note that recursive objects are not supported - they would add way too much
-   * overhead here and are really just unnecessary.
+   * Note that circular object references are not supported - they would add way
+   * too much overhead here and are really just unnecessary.
    */
   public hashParams(params: any[], acceptComplexParams?: boolean): string {
     return JSON.stringify(params, (_, param) => {

--- a/packages/atoms/src/classes/SelectorInstance.ts
+++ b/packages/atoms/src/classes/SelectorInstance.ts
@@ -68,9 +68,11 @@ export const runSelector = <G extends SelectorGenerics>(
     const oldState = node.v
     node.v = result
 
-    if (isInitializing) {
-      setNodeStatus(node, 'Active')
-    } else if (!suppressNotify && !resultsComparator(result, oldState)) {
+    if (
+      !isInitializing &&
+      !suppressNotify &&
+      !resultsComparator(result, oldState)
+    ) {
       handleStateChange(node, oldState)
     }
   } catch (err) {
@@ -87,6 +89,10 @@ export const runSelector = <G extends SelectorGenerics>(
   }
 
   flushBuffer(prevNode)
+
+  if (isInitializing) {
+    setNodeStatus(node, 'Active', getSelectorKey(node.e, node.t))
+  }
 }
 
 export const swapSelectorRefs = <G extends SelectorGenerics>(

--- a/packages/atoms/src/classes/instances/AtomInstance.ts
+++ b/packages/atoms/src/classes/instances/AtomInstance.ts
@@ -372,17 +372,15 @@ export class AtomInstance<
     const { n } = getEvaluationContext()
     this.j()
 
-    setNodeStatus(this, 'Active')
-    flushBuffer(n)
-
     // hydrate if possible
     const hydration = this.e._consumeHydration(this)
 
-    if (this.t.manualHydration || typeof hydration === 'undefined') {
-      return
+    if (!this.t.manualHydration && typeof hydration !== 'undefined') {
+      this.set(hydration)
     }
 
-    this.set(hydration)
+    flushBuffer(n)
+    setNodeStatus(this, 'Active')
   }
 
   /**

--- a/packages/atoms/src/utils/ecosystem.ts
+++ b/packages/atoms/src/utils/ecosystem.ts
@@ -1,0 +1,235 @@
+import { detailedTypeof, is } from '@zedux/core'
+import {
+  AnyAtomInstance,
+  AnyAtomTemplate,
+  AtomGenerics,
+  AtomSelectorConfig,
+  AtomSelectorOrConfig,
+} from '../types'
+import { AtomInstance } from '../classes/instances/AtomInstance'
+import { AtomTemplateBase } from '../classes/templates/AtomTemplateBase'
+import { AtomTemplate } from '../classes/templates/AtomTemplate'
+import type { Ecosystem } from '../classes/Ecosystem'
+import { GraphNode } from '../classes/GraphNode'
+import { getSelectorKey, SelectorInstance } from '../classes/SelectorInstance'
+import { getEvaluationContext } from './evaluationContext'
+
+const changeScopedNodeId = (
+  ecosystem: Ecosystem,
+  templateKey: string,
+  newInstance: GraphNode,
+  nonContextualizedId: string
+) => {
+  // if this is the first scoped node of its template to evaluate, record the
+  // scope all future instances of the template will need to be provided
+  ecosystem.s ??= {}
+  ecosystem.s[templateKey] ??= [...newInstance.V!.keys()]
+
+  // give the new scoped node a `@scope()`-suffixed id
+  const contextValueStrings = [...newInstance.V!.values()].map(val => {
+    const resolvedVal =
+      val?.constructor?.name === WeakRef.name
+        ? (val as WeakRef<any>).deref()
+        : val
+
+    return is(resolvedVal, AtomInstance)
+      ? (resolvedVal as AtomInstance).id
+      : ecosystem._idGenerator.hashParams(resolvedVal)
+  })
+
+  const scopedId = `${nonContextualizedId}-@scope(${contextValueStrings.join(
+    ','
+  )})`
+
+  newInstance.id = scopedId
+}
+
+const getContextualizedId = (
+  ecosystem: Ecosystem,
+  scopeKeys: Record<string, any>[],
+  id: string
+) => {
+  let allResolved = true
+
+  const contextValueStrings = scopeKeys.map(context => {
+    // this ultimately pulls from either a React/user-provided scope or from a
+    // currently-evaluating observer's cached scope. Since scoped atoms
+    // propagate their scope to all observers, this means you have to provide
+    // every transitive context for all nodes up the source tree when getting
+    // any node that uses other scoped nodes. We could remove that requirement
+    // by merging cached scope with passed scope. That would only help when e.g.
+    // setting a scoped atom inside a `ecosystem.withScope` call, not when
+    // initializing nodes. I think that's a rare case, so not doing for now.
+    const resolvedVal = ecosystem.S!(ecosystem, context)
+
+    if (typeof resolvedVal === 'undefined') {
+      allResolved = false
+      return
+    }
+
+    return is(resolvedVal, AtomInstance)
+      ? (resolvedVal as AtomInstance).id
+      : ecosystem._idGenerator.hashParams(resolvedVal)
+  })
+
+  return allResolved && `${id}-@scope(${contextValueStrings.join(',')})`
+}
+
+export const getNode = <G extends AtomGenerics>(
+  ecosystem: Ecosystem,
+  template: AtomTemplateBase<G> | GraphNode<G> | AtomSelectorOrConfig<G>,
+  params?: G['Params']
+): GraphNode => {
+  if ((template as GraphNode).izn) {
+    // if the passed atom instance is Destroyed, get(/create) the
+    // non-Destroyed instance
+    return (template as GraphNode).l === 'Destroyed' &&
+      (template as GraphNode).t
+      ? ecosystem.getNode((template as GraphNode).t, (template as GraphNode).p)
+      : template
+  }
+
+  if (DEV) {
+    if (typeof params !== 'undefined' && !Array.isArray(params)) {
+      throw new TypeError(
+        `Zedux: Expected atom params to be an array. Received ${detailedTypeof(
+          params
+        )}`
+      )
+    }
+  }
+
+  if (is(template, AtomTemplateBase)) {
+    const id = (template as AtomTemplate).getInstanceId(ecosystem, params)
+
+    // try to find an existing instance
+    const instance = ecosystem.n.get(id) as AtomInstance
+    if (instance) return instance
+
+    const templateScope = ecosystem.s?.[(template as AtomTemplate).key]
+
+    if (templateScope && (ecosystem.S || getEvaluationContext().n?.V)) {
+      // if no atom was found, but we're in a contextual scope (or able to
+      // create one from a currently-evaluating contextual node), look for an
+      // atom with a scoped id.
+      const contextualizedId = ecosystem.S
+        ? getContextualizedId(ecosystem, templateScope, id)
+        : ecosystem.withScope(getEvaluationContext().n!.V!, () =>
+            getContextualizedId(ecosystem, templateScope, id)
+          )
+
+      if (contextualizedId) {
+        const instance = ecosystem.n.get(contextualizedId)
+
+        if (instance) return instance
+      }
+    }
+
+    // create a new instance
+    const newInstance = resolveAtom(
+      ecosystem,
+      template as AtomTemplate
+    )._createInstance(
+      ecosystem,
+      id,
+      (params || []) as G['Params']
+    ) as AnyAtomInstance
+
+    newInstance.i() // TODO: remove. Run this in AtomInstance constructor
+
+    // scoped atoms change their id after initial evaluation
+    if (newInstance.V) {
+      changeScopedNodeId(
+        ecosystem,
+        (template as AtomTemplateBase).key,
+        newInstance,
+        id
+      )
+    }
+
+    ecosystem.n.set(newInstance.id, newInstance)
+
+    return newInstance
+  }
+
+  if (
+    typeof template === 'function' ||
+    (template && (template as AtomSelectorConfig).selector)
+  ) {
+    const selectorOrConfig = template as AtomSelectorOrConfig<G>
+    const id = ecosystem.hash(selectorOrConfig, params)
+    let instance = ecosystem.n.get(id) as SelectorInstance<G>
+
+    if (instance) return instance
+
+    const selectorKey = getSelectorKey(ecosystem, selectorOrConfig)
+    const templateScope = ecosystem.s?.[selectorKey]
+
+    if (templateScope && (ecosystem.S || getEvaluationContext().n?.V)) {
+      // if no selector was found, but we're in a contextual scope (or able to
+      // create one from a currently-evaluating contextual node), look for a
+      // selector with a scoped id.
+      const contextualizedId = ecosystem.S
+        ? getContextualizedId(ecosystem, templateScope, id)
+        : ecosystem.withScope(getEvaluationContext().n!.V!, () =>
+            getContextualizedId(ecosystem, templateScope, id)
+          )
+
+      if (contextualizedId) {
+        const instance = ecosystem.n.get(contextualizedId)
+
+        if (instance) return instance
+      }
+    }
+
+    // create the instance; it doesn't exist yet
+    instance = new SelectorInstance(
+      ecosystem,
+      id,
+      selectorOrConfig,
+      params || []
+    )
+
+    // scoped selectors change their id after initial evaluation
+    if (instance.V) {
+      changeScopedNodeId(ecosystem, selectorKey, instance, id)
+    }
+
+    ecosystem.n.set(instance.id, instance)
+
+    return instance
+  }
+
+  throw new TypeError(
+    `Zedux: Expected a template or node. Received ${detailedTypeof(template)}`
+  )
+}
+
+const resolveAtom = <A extends AnyAtomTemplate>(
+  { flags, overrides }: Ecosystem,
+  template: A
+) => {
+  const override = overrides[template.key]
+  const maybeOverriddenAtom = (override || template) as A
+
+  // to turn off flag checking, just don't pass a `flags` prop
+  if (flags) {
+    const badFlag = maybeOverriddenAtom.flags?.find(
+      flag => !flags.includes(flag)
+    )
+
+    if (DEV && badFlag) {
+      console.error(
+        `Zedux: encountered unsafe atom template "${template.key}" with flag "${badFlag}". This should be overridden in the current environment.`
+      )
+    }
+  }
+
+  return maybeOverriddenAtom
+}
+
+export const mapOverrides = (overrides: AnyAtomTemplate[]) =>
+  overrides.reduce((map, atom) => {
+    map[atom.key] = atom
+    return map
+  }, {} as Record<string, AnyAtomTemplate>)

--- a/packages/atoms/src/utils/ecosystem.ts
+++ b/packages/atoms/src/utils/ecosystem.ts
@@ -34,7 +34,7 @@ const changeScopedNodeId = (
 
     return is(resolvedVal, AtomInstance)
       ? (resolvedVal as AtomInstance).id
-      : ecosystem._idGenerator.hashParams(resolvedVal)
+      : ecosystem._idGenerator.hashParams(resolvedVal, true)
   })
 
   const scopedId = `${nonContextualizedId}-@scope(${contextValueStrings.join(
@@ -69,7 +69,7 @@ const getContextualizedId = (
 
     return is(resolvedVal, AtomInstance)
       ? (resolvedVal as AtomInstance).id
-      : ecosystem._idGenerator.hashParams(resolvedVal)
+      : ecosystem._idGenerator.hashParams(resolvedVal, true)
   })
 
   return allResolved && `${id}-@scope(${contextValueStrings.join(',')})`

--- a/packages/atoms/src/utils/graph.ts
+++ b/packages/atoms/src/utils/graph.ts
@@ -32,6 +32,17 @@ export const addEdge = (
     recalculateNodeWeight(source.W, observer)
   }
 
+  // scoped atoms propagate their scope to all observers. Any node that uses a
+  // scoped atom was run in a scoped context and needs to remember the used
+  // scope so it can find its scoped atoms when it reevaluates.
+  if (source.V) {
+    observer.V ??= new Map()
+
+    for (const [key, val] of source.V) {
+      observer.V.set(key, val)
+    }
+  }
+
   if (isListeningTo(source.e, EDGE)) {
     sendEcosystemEvent(source.e, {
       action: 'add',
@@ -140,6 +151,9 @@ export const removeEdge = (observer: GraphNode, source: GraphNode) => {
   if (!(edge.flags & Static)) {
     recalculateNodeWeight(-source.W, observer)
   }
+
+  // Note: We don't remove scope added by the edge here. Once scope is added to
+  // a graph node, it keeps that scope forever.
 
   if (isListeningTo(source.e, EDGE)) {
     sendEcosystemEvent(source.e, {

--- a/packages/atoms/src/utils/graph.ts
+++ b/packages/atoms/src/utils/graph.ts
@@ -12,6 +12,7 @@ import {
   sendEcosystemEvent,
   sendImplicitEcosystemEvent,
 } from './events'
+import { changeScopedNodeId } from './ecosystem'
 
 /**
  * Actually add an edge to the graph. When we buffer graph updates, we're
@@ -231,9 +232,18 @@ export const scheduleStaticDependents = (
 export const scheduleNodeDestruction = (node: GraphNode) =>
   node.o.size - (node.L ? 1 : 0) || node.l !== 'Active' || node.m()
 
-export const setNodeStatus = (node: GraphNode, newStatus: LifecycleStatus) => {
+export const setNodeStatus = (
+  node: GraphNode,
+  newStatus: LifecycleStatus,
+  templateKey?: string
+) => {
   const oldStatus = node.l
   node.l = newStatus
+
+  if (node.V && oldStatus === 'Initializing' && node.t) {
+    // scoped nodes change their id after initial evaluation
+    changeScopedNodeId(node.e, templateKey ?? node.t.key, node)
+  }
 
   const isListeningToCycle = isListeningTo(node.e, CYCLE)
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -65,6 +65,10 @@ On top of these, `@zedux/react` exports the following APIs:
 - [`useAtomValue()`](https://omnistac.github.io/zedux/docs/api/hooks/useAtomValue)
 - [`useEcosystem()`](https://omnistac.github.io/zedux/docs/api/hooks/useEcosystem)
 
+### Utils
+
+- [`inject()`](https://omnistac.github.io/zedux/docs/api/utils/inject)
+
 ## For Authors
 
 The [Zedux documentation](https://omnistac.github.io/zedux) assumes you are using this package. Plugin and integration authors may want to depend directly on [`@zedux/core`](https://www.npmjs.com/package/@zedux/core) or [`@zedux/atoms`](https://www.npmjs.com/package/@zedux/atoms). However, if your package uses any of these React-specific APIs, it is recommended to only import this `@zedux/react` package.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,5 @@
 export * from '@zedux/atoms'
 export * from './components/index'
 export * from './hooks/index'
+export * from './inject'
 export * from './types'

--- a/packages/react/src/inject.ts
+++ b/packages/react/src/inject.ts
@@ -1,0 +1,57 @@
+import { AtomTemplateBase, injectSelf, is, NodeOf } from '@zedux/atoms'
+import { Context } from 'react'
+import { getReactContext } from './utils'
+
+export const inject = <T extends Context<any> | AtomTemplateBase>(
+  context: T
+): T extends Context<infer V>
+  ? V
+  : T extends AtomTemplateBase
+  ? NodeOf<T>
+  : never => {
+  const instance = injectSelf()
+  instance.V ??= new Map()
+  const prevValue = instance.V.get(context)
+
+  const resolvedPrevValue =
+    prevValue?.constructor?.name === WeakRef.name
+      ? (prevValue as WeakRef<any>).deref()
+      : prevValue
+
+  // if there's a cached context value, it's the value cached previously (we
+  // create a new instance if a scoped atom is accessed in a scoped context
+  // with different context values)
+  if (typeof resolvedPrevValue !== 'undefined') return resolvedPrevValue
+
+  if (!instance.e.S) {
+    throw new Error(
+      `Scoped atom was initialized outside a scoped context. This atom needs to be initialized by a React component or inside \`ecosystem.withScope\``
+    )
+  }
+
+  // This atom is initializing in a scoped context (e.g. a React hook or
+  // `ecosystem.withScope` call). Get the provided value
+  const value = instance.e.S(instance.e, context)
+
+  if (typeof value === 'undefined') {
+    throw new Error(
+      `Value was not provided to scoped atom. See attached cause`,
+      {
+        cause: context,
+      }
+    )
+  }
+
+  // use a WeakRef if possible
+  let weakValue
+
+  try {
+    weakValue = new WeakRef(value)
+  } catch (err) {
+    weakValue = value
+  }
+
+  instance.V.set(context, weakValue)
+
+  return value
+}

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,5 +1,5 @@
-import { AnyAtomTemplate, Ecosystem } from '@zedux/atoms'
-import React, { createContext } from 'react'
+import { AnyAtomTemplate, AtomTemplateBase, Ecosystem, is } from '@zedux/atoms'
+import React, { Context, createContext, use } from 'react'
 
 export const ecosystemContext = createContext('@@global')
 
@@ -39,3 +39,13 @@ export const getReactContext = (
     undefined
   ) as React.Context<any>)
 }
+
+export const reactContextScope = (
+  ecosystem: Ecosystem,
+  context: Record<string, any>
+) =>
+  use(
+    is(context, AtomTemplateBase)
+      ? getReactContext(ecosystem, context as AtomTemplateBase)
+      : (context as Context<any>)
+  )

--- a/packages/react/test/integrations/__snapshots__/scoped-atoms.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/scoped-atoms.test.tsx.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`scoped atoms scoped nodes propagate scope recursively to all observers 1`] = `
+[
+  "@@selector-bottomSource-0-@scope(parent2-[2],parent1-[1],"a")",
+  "@@selector-bottomSource-0-@scope(parent2-[2],parent1-[1],"b")",
+  "@@selector-bottomSource-0-@scope(parent2-[200],parent1-[100],"a")",
+  "@@selector-bottomSource-0-@scope(parent2-[200],parent1-[100],"b")",
+  "child-@scope(parent2-[2],parent1-[1],"a")",
+  "child-@scope(parent2-[2],parent1-[1],"b")",
+  "child-@scope(parent2-[200],parent1-[100],"a")",
+  "child-@scope(parent2-[200],parent1-[100],"b")",
+  "middleSource-@scope(parent2-[2],parent1-[1],"a")",
+  "middleSource-@scope(parent2-[2],parent1-[1],"b")",
+  "middleSource-@scope(parent2-[200],parent1-[100],"a")",
+  "middleSource-@scope(parent2-[200],parent1-[100],"b")",
+  "parent1-[1]",
+  "parent1-[100]",
+  "parent2-[2]",
+  "parent2-[200]",
+  "topSource-@scope(parent1-[1],"a")",
+  "topSource-@scope(parent1-[1],"b")",
+  "topSource-@scope(parent1-[100],"a")",
+  "topSource-@scope(parent1-[100],"b")",
+]
+`;
+
+exports[`scoped atoms scoped nodes propagate scope recursively to all observers 2`] = `
+[
+  "@@selector-bottomSource-0-@scope(parent2-[2],parent1-[1],"aa")",
+  "@@selector-bottomSource-0-@scope(parent2-[2],parent1-[1],"b")",
+  "@@selector-bottomSource-0-@scope(parent2-[200],parent1-[100],"aa")",
+  "@@selector-bottomSource-0-@scope(parent2-[200],parent1-[100],"b")",
+  "child-@scope(parent2-[2],parent1-[1],"aa")",
+  "child-@scope(parent2-[2],parent1-[1],"b")",
+  "child-@scope(parent2-[200],parent1-[100],"aa")",
+  "child-@scope(parent2-[200],parent1-[100],"b")",
+  "middleSource-@scope(parent2-[2],parent1-[1],"aa")",
+  "middleSource-@scope(parent2-[2],parent1-[1],"b")",
+  "middleSource-@scope(parent2-[200],parent1-[100],"aa")",
+  "middleSource-@scope(parent2-[200],parent1-[100],"b")",
+  "parent1-[1]",
+  "parent1-[100]",
+  "parent2-[2]",
+  "parent2-[200]",
+  "topSource-@scope(parent1-[1],"aa")",
+  "topSource-@scope(parent1-[1],"b")",
+  "topSource-@scope(parent1-[100],"aa")",
+  "topSource-@scope(parent1-[100],"b")",
+]
+`;
+
+exports[`scoped atoms scoped nodes propagate scope recursively to all observers 3`] = `
+[
+  "@@selector-bottomSource-0-@scope(parent2-[2],parent1-[1],"aa")",
+  "@@selector-bottomSource-0-@scope(parent2-[2],parent1-[1],"b")",
+  "@@selector-bottomSource-0-@scope(parent2-[200],parent1-[100],"aa")",
+  "@@selector-bottomSource-0-@scope(parent2-[200],parent1-[100],"b")",
+  "child-@scope(parent2-[2],parent1-[1],"aa")",
+  "child-@scope(parent2-[2],parent1-[1],"b")",
+  "child-@scope(parent2-[200],parent1-[100],"aa")",
+  "child-@scope(parent2-[200],parent1-[100],"b")",
+  "middleSource-@scope(parent2-[2],parent1-[1],"aa")",
+  "middleSource-@scope(parent2-[2],parent1-[1],"b")",
+  "middleSource-@scope(parent2-[200],parent1-[100],"aa")",
+  "middleSource-@scope(parent2-[200],parent1-[100],"b")",
+  "parent1-[1]",
+  "parent1-[100]",
+  "parent2-[2]",
+  "parent2-[200]",
+  "topSource-@scope(parent1-[1],"aa")",
+  "topSource-@scope(parent1-[1],"b")",
+  "topSource-@scope(parent1-[100],"aa")",
+  "topSource-@scope(parent1-[100],"b")",
+]
+`;
+
+exports[`scoped atoms scoped nodes propagate scope recursively to all observers 4`] = `
+[
+  "@@selector-bottomSource-0-@scope(parent2-[2],parent1-[1],"aa")",
+  "@@selector-bottomSource-0-@scope(parent2-[2],parent1-[1],"b")",
+  "@@selector-bottomSource-0-@scope(parent2-[200],parent1-[100],"aa")",
+  "@@selector-bottomSource-0-@scope(parent2-[200],parent1-[100],"b")",
+  "child-@scope(parent2-[2],parent1-[1],"aa")",
+  "child-@scope(parent2-[2],parent1-[1],"b")",
+  "child-@scope(parent2-[200],parent1-[100],"aa")",
+  "child-@scope(parent2-[200],parent1-[100],"b")",
+  "middleSource-@scope(parent2-[2],parent1-[1],"aa")",
+  "middleSource-@scope(parent2-[2],parent1-[1],"b")",
+  "middleSource-@scope(parent2-[200],parent1-[100],"aa")",
+  "middleSource-@scope(parent2-[200],parent1-[100],"b")",
+  "parent1-[1]",
+  "parent1-[100]",
+  "parent2-[2]",
+  "parent2-[200]",
+  "topSource-@scope(parent1-[1],"aa")",
+  "topSource-@scope(parent1-[1],"b")",
+  "topSource-@scope(parent1-[100],"aa")",
+  "topSource-@scope(parent1-[100],"b")",
+]
+`;

--- a/packages/react/test/integrations/ecosystem.test.tsx
+++ b/packages/react/test/integrations/ecosystem.test.tsx
@@ -92,12 +92,12 @@ describe('ecosystem', () => {
     const { findByText } = renderInEcosystem(<Child />)
 
     expect([...ecosystem.n.keys()]).toEqual([
-      'atom5',
-      'atom2',
-      'atom1',
       '@signal(atom1)-0',
-      'atom4',
+      'atom1',
+      'atom2',
       'atom3-["1"]',
+      'atom4',
+      'atom5',
       'Child-:r0:',
       'Child-:r1:',
       'Child-:r2:',

--- a/packages/react/test/integrations/plugins.test.tsx
+++ b/packages/react/test/integrations/plugins.test.tsx
@@ -350,8 +350,8 @@ describe('plugins', () => {
 
     expect(calls).toEqual([
       ['runStart'],
-      ['cycle'],
       ['runEnd'],
+      ['cycle'],
       ['resetStart'],
       ['cycle'],
       ['resetEnd'],

--- a/packages/react/test/integrations/scoped-atoms.test.tsx
+++ b/packages/react/test/integrations/scoped-atoms.test.tsx
@@ -1,0 +1,549 @@
+import {
+  atom,
+  AtomProvider,
+  Ecosystem,
+  inject,
+  injectAtomValue,
+  NodeOf,
+  useAtomInstance,
+  useAtomValue,
+} from '@zedux/react'
+import React, { createContext, useState } from 'react'
+import { renderInEcosystem } from '../utils/renderInEcosystem'
+import { ecosystem } from '../utils/ecosystem'
+import { act } from '@testing-library/react'
+import { expectTypeOf } from 'expect-type'
+import { mockConsole } from '../utils/console'
+
+describe('scoped atoms', () => {
+  test('read provided atoms', async () => {
+    const parentAtom = atom('parent', () => 1)
+
+    const childAtom = atom('child', () => {
+      const instance = inject(parentAtom)
+
+      expectTypeOf(instance).toEqualTypeOf<NodeOf<typeof parentAtom>>()
+
+      return instance
+    })
+
+    function Child() {
+      const childVal = useAtomValue(childAtom)
+
+      return <div data-testid="child">{childVal}</div>
+    }
+
+    function Parent() {
+      const parentInstance = useAtomInstance(parentAtom)
+
+      return (
+        <AtomProvider instance={parentInstance}>
+          <Child />
+        </AtomProvider>
+      )
+    }
+
+    const { findByTestId } = renderInEcosystem(<Parent />)
+    const child = await findByTestId('child')
+
+    expect(child).toHaveTextContent('1')
+
+    act(() => {
+      ecosystem.getNode(parentAtom).set(2)
+    })
+
+    expect(child).toHaveTextContent('2')
+  })
+
+  test('read provided React context values', async () => {
+    const context = createContext(1)
+
+    const childAtom = atom('child', () => {
+      const value = inject(context)
+
+      expectTypeOf(value).toEqualTypeOf<number>()
+
+      return value
+    })
+
+    function Child() {
+      const childVal = useAtomValue(childAtom)
+
+      return <div data-testid="child">{childVal}</div>
+    }
+
+    function Parent() {
+      const [state, setState] = useState(1)
+
+      return (
+        <context.Provider value={state}>
+          <Child />
+          <button
+            data-testid="button"
+            onClick={() => setState(state => state + 1)}
+          >
+            Update
+          </button>
+        </context.Provider>
+      )
+    }
+
+    const { findByTestId } = renderInEcosystem(<Parent />)
+    const button = await findByTestId('button')
+    const child = await findByTestId('child')
+
+    expect(child).toHaveTextContent('1')
+
+    act(() => {
+      button.click()
+    })
+
+    expect(child).toHaveTextContent('2')
+  })
+
+  test('when a scoped atom is provided different values, creates a new instance with a scoped id', async () => {
+    const calls: any[] = []
+    const context = createContext('a')
+    const parentAtom = atom('parent', (initialValue: number) => initialValue)
+
+    const nestedContextualAtom = atom('nested', () => {
+      const parentInstance = inject(parentAtom)
+
+      return parentInstance.get()
+    })
+
+    const childAtom = atom(
+      'child',
+      () => {
+        const reactValue = inject(context)
+        const parentInstance = inject(parentAtom)
+        const nestedContextualValue = injectAtomValue(nestedContextualAtom)
+
+        expectTypeOf(reactValue).toEqualTypeOf<string>()
+        expectTypeOf(parentInstance).toEqualTypeOf<NodeOf<typeof parentAtom>>()
+
+        return `${reactValue}${parentInstance.get()} ${nestedContextualValue}`
+      },
+      { ttl: 0 }
+    )
+
+    function Child() {
+      const childVal = useAtomValue(childAtom)
+
+      calls.push(childVal)
+
+      return <div data-testid="child">{childVal}</div>
+    }
+
+    function Parent() {
+      const [state1, setState1] = useState('a')
+      const instance1 = useAtomInstance(parentAtom, [1])
+      const instance2 = useAtomInstance(parentAtom, [2])
+
+      // 4 pairs: context1+atom1, context1+atom2, context2+atom1, context2+atom2
+      return (
+        <>
+          {[state1, 'b'].map((value, index) => (
+            <context.Provider key={index} value={value}>
+              {[instance1, instance2].map(instance => (
+                <AtomProvider key={instance.id} instance={instance}>
+                  <Child />
+                </AtomProvider>
+              ))}
+            </context.Provider>
+          ))}
+          <button
+            data-testid="button1"
+            onClick={() => setState1(state => state + 'a')}
+          >
+            Update 1
+          </button>
+        </>
+      )
+    }
+
+    const { findAllByTestId, findByTestId } = renderInEcosystem(<Parent />)
+    const button1 = await findByTestId('button1')
+    const children = await findAllByTestId('child')
+
+    expect(children[0]).toHaveTextContent('a1 1')
+    expect(children[1]).toHaveTextContent('a2 2')
+    expect(children[2]).toHaveTextContent('b1 1')
+    expect(children[3]).toHaveTextContent('b2 2')
+
+    expect(calls).toEqual(['a1 1', 'a2 2', 'b1 1', 'b2 2'])
+    calls.splice(0, calls.length)
+
+    // 2 parents, 4 children, 2 nested, 6 external
+    expect(ecosystem.n.size).toBe(14)
+
+    expect(Object.keys(ecosystem.findAll())).toEqual([
+      'child-@scope("a",parent-[1])',
+      'child-@scope("a",parent-[2])',
+      'child-@scope("b",parent-[1])',
+      'child-@scope("b",parent-[2])',
+      'nested-@scope(parent-[1])',
+      'nested-@scope(parent-[2])',
+      'parent-[1]',
+      'parent-[2]',
+    ])
+
+    act(() => {
+      button1.click()
+    })
+
+    expect(children[0]).toHaveTextContent('aa1 1')
+    expect(children[1]).toHaveTextContent('aa2 2')
+    expect(children[2]).toHaveTextContent('b1 1')
+    expect(children[3]).toHaveTextContent('b2 2')
+
+    expect(calls).toEqual(['aa1 1', 'aa2 2', 'b1 1', 'b2 2'])
+    calls.splice(0, calls.length)
+
+    expect(ecosystem.n.size).toBe(14) // 2 new children, 2 destroyed
+
+    expect(Object.keys(ecosystem.findAll())).toEqual([
+      'child-@scope("aa",parent-[1])',
+      'child-@scope("aa",parent-[2])',
+      'child-@scope("b",parent-[1])',
+      'child-@scope("b",parent-[2])',
+      'nested-@scope(parent-[1])',
+      'nested-@scope(parent-[2])',
+      'parent-[1]',
+      'parent-[2]',
+    ])
+
+    act(() => {
+      ecosystem.getNode(parentAtom, [1]).set(11)
+    })
+
+    expect(children[0]).toHaveTextContent('aa11 11')
+    expect(children[1]).toHaveTextContent('aa2 2')
+    expect(children[2]).toHaveTextContent('b11 11')
+    expect(children[3]).toHaveTextContent('b2 2')
+
+    // atoms = fewer rerenders :muscle:
+    expect(calls).toEqual(['aa11 11', 'b11 11'])
+    calls.splice(0, calls.length)
+
+    expect(ecosystem.n.size).toBe(14) // no changes
+
+    expect(Object.keys(ecosystem.findAll())).toEqual([
+      'child-@scope("aa",parent-[1])',
+      'child-@scope("aa",parent-[2])',
+      'child-@scope("b",parent-[1])',
+      'child-@scope("b",parent-[2])',
+      'nested-@scope(parent-[1])',
+      'nested-@scope(parent-[2])',
+      'parent-[1]',
+      'parent-[2]',
+    ])
+  })
+
+  test('scoped nodes propagate scope recursively to all observers', async () => {
+    const calls: any[] = []
+    const context = createContext('a')
+    const parentAtom1 = atom('parent1', (initialValue: number) => initialValue)
+    const parentAtom2 = atom('parent2', (initialValue: number) => initialValue)
+
+    const topSource = atom(
+      'topSource',
+      () => {
+        const parentInstance1 = inject(parentAtom1)
+        const reactValue = inject(context)
+
+        return reactValue + parentInstance1.get()
+      },
+      { ttl: 0 }
+    )
+
+    const middleSource = atom(
+      'middleSource',
+      () => {
+        const parentInstance2 = inject(parentAtom2)
+
+        return `${injectAtomValue(topSource)} ${parentInstance2.get()}`
+      },
+      { ttl: 0 }
+    )
+
+    const bottomSource = ({ get }: Ecosystem) => get(middleSource)
+
+    const childAtom = atom(
+      'child',
+      () => {
+        const value = injectAtomValue(bottomSource)
+
+        expectTypeOf(value).toEqualTypeOf<string>()
+        calls.push(value)
+
+        return value
+      },
+      { ttl: 0 }
+    )
+
+    function Child() {
+      const childVal = useAtomValue(childAtom)
+
+      return <div data-testid="child">{childVal}</div>
+    }
+
+    function Parent() {
+      const [state1, setState1] = useState('a')
+      const instance1 = useAtomInstance(parentAtom1, [1])
+      const instance100 = useAtomInstance(parentAtom1, [100])
+      const instance2 = useAtomInstance(parentAtom2, [2])
+      const instance200 = useAtomInstance(parentAtom2, [200])
+
+      // 8 pairs
+      return (
+        <>
+          {[state1, 'b'].map((value, index) => (
+            <context.Provider key={index} value={value}>
+              {[
+                [instance1, instance2],
+                [instance100, instance200],
+              ].map(([instanceA, instanceB]) => (
+                <AtomProvider key={instanceA.id} instance={instanceA}>
+                  <AtomProvider key={instanceB.id} instance={instanceB}>
+                    <Child />
+                  </AtomProvider>
+                </AtomProvider>
+              ))}
+            </context.Provider>
+          ))}
+          <button
+            data-testid="button1"
+            onClick={() => setState1(state => state + 'a')}
+          >
+            Update 1
+          </button>
+        </>
+      )
+    }
+
+    const { findAllByTestId, findByTestId } = renderInEcosystem(<Parent />)
+    const button1 = await findByTestId('button1')
+    const children = await findAllByTestId('child')
+
+    expect(children[0]).toHaveTextContent('a1 2')
+    expect(children[1]).toHaveTextContent('a100 200')
+    expect(children[2]).toHaveTextContent('b1 2')
+    expect(children[3]).toHaveTextContent('b100 200')
+
+    expect(calls).toEqual(['a1 2', 'a100 200', 'b1 2', 'b100 200'])
+    calls.splice(0, calls.length)
+
+    // 4 parents, 4 children, 4 nested, 4 middle, 4 top, 8 external
+    expect(ecosystem.n.size).toBe(28)
+
+    expect(Object.keys(ecosystem.findAll())).toMatchSnapshot()
+
+    act(() => {
+      button1.click()
+    })
+
+    expect(children[0]).toHaveTextContent('aa1 2')
+    expect(children[1]).toHaveTextContent('aa100 200')
+    expect(children[2]).toHaveTextContent('b1 2')
+    expect(children[3]).toHaveTextContent('b100 200')
+
+    expect(calls).toEqual(['aa1 2', 'aa100 200'])
+    calls.splice(0, calls.length)
+
+    // 4 parents, 4 children, 4 nested, 4 middle, 4 top, 8 external
+    expect(ecosystem.n.size).toBe(28)
+
+    expect(Object.keys(ecosystem.findAll())).toMatchSnapshot()
+
+    const scope = new Map<Record<string, any>, any>([
+      [context, 'b'],
+      [parentAtom1, ecosystem.getNode(parentAtom1, [1])],
+      [parentAtom2, ecosystem.getNode(parentAtom2, [2])],
+    ])
+
+    const childInstance = ecosystem.withScope(scope, () =>
+      ecosystem.getNode(childAtom)
+    )
+
+    act(() => {
+      childInstance.invalidate()
+    })
+
+    expect(calls).toEqual(['b1 2'])
+    calls.splice(0, calls.length)
+
+    // 4 parents, 4 children, 4 nested, 4 middle, 4 top, 8 external
+    expect(ecosystem.n.size).toBe(28)
+
+    expect(Object.keys(ecosystem.findAll())).toMatchSnapshot()
+
+    act(() => {
+      childInstance.destroy(true)
+    })
+
+    expect(calls).toEqual(['b1 2'])
+    calls.splice(0, calls.length)
+
+    // 4 parents, 4 children, 4 nested, 4 middle, 4 top, 8 external
+    expect(ecosystem.n.size).toBe(28)
+
+    expect(Object.keys(ecosystem.findAll())).toMatchSnapshot()
+  })
+
+  test('React context reference changes create new scopes', async () => {
+    const calls: any[] = []
+    const context = createContext({ a: { b: 1 } })
+
+    const childAtom = atom('child', () => {
+      const value = inject(context)
+
+      expectTypeOf(value).toEqualTypeOf<{ a: { b: number } }>()
+      calls.push(value)
+
+      return value
+    }) // no ttl
+
+    function Child() {
+      const childVal = useAtomValue(({ get }) => get(childAtom))
+
+      return <div data-testid="child">{childVal.a.b}</div>
+    }
+
+    function Parent() {
+      const [state, setState] = useState(1)
+
+      return (
+        <context.Provider value={{ a: { b: state } }}>
+          <Child />
+          <button
+            data-testid="button"
+            onClick={() => setState(state => state + 1)}
+          >
+            Update
+          </button>
+        </context.Provider>
+      )
+    }
+
+    const { findByTestId } = renderInEcosystem(<Parent />)
+    const button = await findByTestId('button')
+    const child = await findByTestId('child')
+
+    expect(child).toHaveTextContent('1')
+    expect(calls).toEqual([{ a: { b: 1 } }])
+    calls.splice(0, calls.length)
+
+    expect(Object.keys(ecosystem.findAll())).toEqual([
+      '@@selector-unnamed-0-@scope({"a":{"b":1}})',
+      'child-@scope({"a":{"b":1}})',
+    ])
+
+    act(() => {
+      button.click()
+    })
+
+    expect(child).toHaveTextContent('2')
+    expect(calls).toEqual([{ a: { b: 2 } }])
+
+    expect(Object.keys(ecosystem.findAll())).toEqual([
+      '@@selector-unnamed-0-@scope({"a":{"b":1}})',
+      'child-@scope({"a":{"b":1}})',
+      'child-@scope({"a":{"b":2}})',
+    ])
+  })
+
+  test('when a value is not provided, the thrown error attaches the requested context object', async () => {
+    const consoleMock = mockConsole('error')
+    const context = createContext<undefined | string>(undefined)
+    const atom1 = atom('1', () => 'a')
+    const childAtom1 = atom('child', () => inject(context))
+    const childAtom2 = atom('child', () => inject(atom1))
+
+    function Child1() {
+      const childVal = useAtomValue(childAtom1)
+
+      return <div data-testid="child">{childVal}</div>
+    }
+
+    function Child2() {
+      const childVal = useAtomValue(childAtom2)
+
+      return <div data-testid="child">{childVal}</div>
+    }
+
+    let error: Error | undefined = undefined
+
+    try {
+      renderInEcosystem(<Child1 />)
+    } catch (err) {
+      error = err as Error
+    }
+
+    expect(error?.message).toMatch(
+      /Value was not provided to scoped atom. See attached cause/
+    )
+    expect(error?.cause).toBe(context)
+    expect(consoleMock).toHaveBeenCalledTimes(2) // both Zedux and React log it
+
+    try {
+      renderInEcosystem(<Child2 />)
+    } catch (err) {
+      error = err as Error
+    }
+
+    expect(error?.message).toMatch(
+      /Value was not provided to scoped atom. See attached cause/
+    )
+    expect(error?.cause).toBe(atom1)
+    expect(consoleMock).toHaveBeenCalledTimes(4)
+  })
+
+  test('scoped atoms throw an error when retrieved outside a scoped context', () => {
+    const consoleMock = mockConsole('error')
+    const atom1 = atom('1', () => 'a')
+    const childAtom = atom('child', () => inject(atom1))
+
+    expect(() => ecosystem.getNode(childAtom)).toThrowError(
+      /Scoped atom was initialized outside a scoped context/
+    )
+    expect(consoleMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('scopes are recursive', () => {
+    const context1 = atom('context1', () => 'a')
+    const context2 = atom('context2', () => 'b')
+    const context3 = atom('context3', () => 'c')
+
+    const scope1 = [ecosystem.getNode(context1)]
+    const scope2 = new Map([[context2, ecosystem.getNode(context2)]])
+    const scope3 = [ecosystem.getNode(context3)]
+
+    const scoped1 = atom('scoped1', () => inject(context1))
+    const scoped2 = atom('scoped2', () => inject(context2))
+    const scoped3 = atom('scoped3', () => inject(context3))
+
+    const result1 = ecosystem.withScope(scope1, () => {
+      const node1 = ecosystem.getNode(scoped1)
+
+      const result2 = ecosystem.withScope(scope2, () => {
+        const node1 = ecosystem.getNode(scoped1)
+        const node2 = ecosystem.getNode(scoped2)
+
+        const result3 = ecosystem.withScope(scope3, () => {
+          const node1 = ecosystem.getNode(scoped1)
+          const node2 = ecosystem.getNode(scoped2)
+          const node3 = ecosystem.getNode(scoped3)
+
+          return node1.get() + node2.get() + node3.get()
+        })
+
+        return `${node1.get() + node2.get()} ${result3}`
+      })
+
+      return `${node1.get()} ${result2}`
+    })
+
+    expect(result1).toBe('a ab abc')
+  })
+})

--- a/packages/stores/src/AtomInstance.ts
+++ b/packages/stores/src/AtomInstance.ts
@@ -369,7 +369,7 @@ export class AtomInstance<
       return api.value as G['Store'] | G['State']
     } catch (err) {
       console.error(
-        `Zedux: Error while evaluating atom "${this.t.key}" with params:`,
+        `Zedux: Error while evaluating atom "${this.id}" with params:`,
         this.p,
         err
       )


### PR DESCRIPTION
@affects atoms, react, stores

## Description

I spent a few days exploring the `inject` utility discussed in #129. I was mostly just experimenting but I somehow actually knocked the whole thing out. It is pretty complex but so powerful that I really want to start using it now 💪 . So here we are.

Implement `inject`. This is a new injector that is a thin wrapper around React's `use` util (hence the name) but with a few key differences:

- `inject` does not support promises. It will if we ever introduce async atoms (which are currently waiting on the TC39 async context proposal).
- `inject` accepts atom templates and will pull a provided instance from `<AtomProvider>`.
- `inject` should not be used conditionally, though it can be used in loops, unlike normal injectors, as long as a given context is passed to `inject` at least once on every evaluation. `inject` calls should also, preferably, not be reordered, as that could result in ids generating with those values reordered in rare edge cases (extremely rare - you'd have to reset the ecosystem then restore some value that depended on the old id. Not likely to ever happen). If `inject` is used conditionally, Zedux might not capture a contextual value that is actually required.
- we can provide contextual values to scoped atoms (including those using React context) outside of React

Implement `ecosystem.withScope`, a new utility that accepts a scope and a callback function and runs the callback function in a scoped context with the passed scope. This is recursive - any `ecosystem.withScope` calls inside an existing scope will recursively look up through all scopes to find a provided context.

## Scope

This is a new concept in Zedux. Some definitions:

- "scope" - a set of contextual values. Specifically, this is a JS Map that maps "contexts" to their provided values.
- "scoped context" - a function evaluation that has access to atom scope.
- "contextual value" - a provided value of a given context.
- "context"  - can mean one of two completely different things:
  - a function evaluation (as in "scoped context")
  - a stable object reference (as in "contextual value". This is a React context object or an atom template returned from the `atom()` factory)

## Examples

**Scope in React:**

```ts
import { createContext } from 'react'
import { AtomProvider, atom, inject, useAtomInstance, useAtomValue } from '@zedux/react'

// it's highly recommended to make React contexts default to `undefined` so
// Zedux detects them as unprovided. This is just good practice in general
const reactContext = createContext<string | undefined>(undefined)
const contextAtom = atom('context', () => 'atom context')

const scopedAtom = atom('scoped', () => {
  return `${inject(reactContext)} and ${inject(contextAtom)}`
})

function Child() {
  const scopedValue = useAtomValue(scopedAtom)

  return <div>{scopedValue}</div> // "react context and atom context"
}

function Parent() {
  const contextInstance = useAtomInstance(contextAtom)

  return (
    <reactContext.Provider value="react value">
      <AtomProvider instance={contextInstance}>
        <Child />
      </AtomProvider>
    </reactContext.Provider>
  )
}
```

This is typically how scoped atoms should be consumed. When used this way, you basically don't have to think about it. Scopes "just work". Zedux will throw an error if you forget to provide a contextual value.

**Scopes outside React:**

```ts
// reusing the atoms and React context from the previous example:
const contextNode = ecosystem.getNode(contextAtom)

// a scope just maps context objects to their provided values:
const scope = new Map([[reactContext, 'react value'], [contextAtom, contextNode]])

// get the scopedAtom in a scoped context:
const scopedNode = ecosystem.withScope(scope, () => ecosystem.getNode(scopedAtom))
```

## Extra Considerations

Some things we may want to address later.

### String hash vs WeakMap

Scoped atoms get their scope as part of their id. This currently uses Zedux's React Query-esque key hashing algorithm. While this is very convenient for DX, it may be preferable to create an id for every provided object reference we encounter (using the ecosystem's existing `b`aseKeys WeakMap) for performance reasons. This is a candidate for an ecosystem config option so you can hash in dev, map in prod. Though note that they have slightly different behavior:

- When hashing, it doesn't matter if object references match; Zedux only detects when keys or values change.
- When using the WeakMap, object reference is all that matters.

### Implicit Dependencies

Scopes implicitly change the behavior/needs of the atom they're scoping. This is why we need `inject` to not be called conditionally - so Zedux can figure out everything that's implicitly needed while we have scope, so we can use those values when we're no longer in a scoped context.

Rather than putting this no-conditional-calls requirement on `inject`, we could give atoms the ability to define their scope explicitly, up-front as a config option passed to `atom()`/similar:

```ts
const scopedAtom = atom('scoped', () => {
  return `${inject(reactContext)} and ${inject(contextAtom)}`
}, {
  scope: [reactContext, contextAtom]
})
```

And Zedux would always capture those contextual values regardless of what `inject` actually uses.

### Scope Propagation

Scoped nodes propagate their scope to all observers. This makes scopes kind of a leaky abstraction - scoped nodes "leak" scope into everything that uses them. There are maybe helper APIs we could introduce to make working with multiple scopes easier.

### Hydration

Scoped atoms can't be hydrated. They shouldn't need to be - their whole purpose is to pull values from a current, live scope.

While we could make it so scoped atoms are given an initial hydration (by making scopes explicit, see above), it would be counterproductive: The primary purpose of hydration is a page load speed boost. Hydrated scoped atoms would always make initial load slower since they must evaluate once before we know their scope anyway, then we'd find the hydration, hydrate, and reevaluate. While that's all fast, the tiny bit of extra overhead means hydrating scoped atoms will just never be good.

We should add a way to easily filter out scoped atoms when dehydrating the ecosystem.

Don't hydrate scoped atoms; hydrate the scope. I'll make sure this is documented.