### PR TITLE
feat!: add `status` getter property to graph nodes

### DIFF
--- a/packages/atoms/src/classes/MappedSignal.ts
+++ b/packages/atoms/src/classes/MappedSignal.ts
@@ -11,7 +11,7 @@ import {
 import { flushBuffer, startBuffer } from '../utils/evaluationContext'
 import { Ecosystem } from './Ecosystem'
 import { doMutate, Signal } from './Signal'
-import { EventSent, TopPrio } from '../utils/general'
+import { ACTIVE, EventSent, INITIALIZING, TopPrio } from '../utils/general'
 import { setNodeStatus } from '../utils/graph'
 
 export type SignalMap = Record<string, Signal<AnyNodeGenerics> | unknown>
@@ -250,7 +250,7 @@ export class MappedSignal<
 
     // we shouldn't need try..catch here - no user code can run when getting
     // these already-defined nodes
-    if (this.l === 'Initializing') {
+    if (this.l === INITIALIZING) {
       this.v = Object.fromEntries(
         entries.map(([key, val]) => {
           if (!(val as Signal | undefined)?.izn) return [key, val as any]
@@ -264,7 +264,7 @@ export class MappedSignal<
         })
       )
 
-      setNodeStatus(this, 'Active')
+      setNodeStatus(this, ACTIVE)
     } else {
       for (const [key, val] of entries) {
         if ((val as Signal).izn) {

--- a/packages/atoms/src/classes/SelectorInstance.ts
+++ b/packages/atoms/src/classes/SelectorInstance.ts
@@ -12,7 +12,7 @@ import {
   startBuffer,
 } from '../utils/evaluationContext'
 import { isListeningTo, sendEcosystemErrorEvent } from '../utils/events'
-import { ERROR, prefix } from '../utils/general'
+import { ACTIVE, ERROR, prefix } from '../utils/general'
 import {
   destroyNodeFinish,
   destroyNodeStart,
@@ -91,7 +91,7 @@ export const runSelector = <G extends SelectorGenerics>(
   flushBuffer(prevNode)
 
   if (isInitializing) {
-    setNodeStatus(node, 'Active', getSelectorKey(node.e, node.t))
+    setNodeStatus(node, ACTIVE, getSelectorKey(node.e, node.t))
   }
 }
 

--- a/packages/atoms/src/classes/Signal.ts
+++ b/packages/atoms/src/classes/Signal.ts
@@ -8,7 +8,7 @@ import {
   Transaction,
   UndefinedEvents,
 } from '../types/index'
-import { EventSent } from '../utils/general'
+import { ACTIVE, EventSent } from '../utils/general'
 import {
   destroyNodeFinish,
   destroyNodeStart,
@@ -134,7 +134,7 @@ export class Signal<
   ) {
     super()
 
-    deferActiveStatus || setNodeStatus(this, 'Active')
+    deferActiveStatus || setNodeStatus(this, ACTIVE)
   }
 
   /**

--- a/packages/atoms/src/index.ts
+++ b/packages/atoms/src/index.ts
@@ -4,6 +4,7 @@ import {
   startBuffer,
 } from './utils/evaluationContext'
 import { sendImplicitEcosystemEvent } from './utils/events'
+import { DESTROYED, INITIALIZING } from './utils/general'
 import {
   destroyNodeFinish,
   destroyNodeStart,
@@ -23,8 +24,10 @@ export { untrack } from './utils/evaluationContext'
 export const zi = {
   a: scheduleStaticDependents,
   b: destroyNodeStart,
+  D: DESTROYED,
   d: destroyBuffer,
   e: destroyNodeFinish,
+  I: INITIALIZING,
   i: sendImplicitEcosystemEvent,
   f: flushBuffer,
   s: startBuffer,

--- a/packages/atoms/src/injectors/injectPrevDescriptor.ts
+++ b/packages/atoms/src/injectors/injectPrevDescriptor.ts
@@ -1,6 +1,7 @@
 import { InjectorDescriptor } from '../classes/instances/AtomInstance'
 import { AnyAtomInstance } from '../types'
 import { getEvaluationContext } from '../utils/evaluationContext'
+import { INITIALIZING } from '../utils/general'
 import { injectSelf } from './injectSelf'
 
 /**
@@ -25,7 +26,7 @@ export const injectPrevDescriptor = <T>(
 
   const { I, id, l, N } = instance
 
-  if (l === 'Initializing') return
+  if (l === INITIALIZING) return
 
   const prevDescriptor = I?.[N.length]
 

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -5,7 +5,10 @@ import { Ecosystem } from '../classes/Ecosystem'
 import { GraphNode } from '../classes/GraphNode'
 import { SelectorInstance } from '../classes/SelectorInstance'
 import { Signal } from '../classes/Signal'
-import { InternalEvaluationType } from '../utils/general'
+import {
+  InternalEvaluationType,
+  InternalLifecycleStatus,
+} from '../utils/general'
 import {
   AnyAtomGenerics,
   AnyAtomInstance,
@@ -277,13 +280,13 @@ export interface InternalEvaluationReason<State = any> {
    * `n`ewStateOrStatus - depending on `t`ype, this is either the new state or
    * new lifecycle status of the `s`ource node.
    */
-  n?: LifecycleStatus | State
+  n?: InternalLifecycleStatus | State
 
   /**
    * `o`ldStateOrStatus - depending on `t`ype, this is either the previous state
    * or previous lifecycle status of the `s`ource node.
    */
-  o?: LifecycleStatus | State
+  o?: InternalLifecycleStatus | State
 
   /**
    * `s`ource - the node that caused its observer to update

--- a/packages/atoms/src/utils/ecosystem.ts
+++ b/packages/atoms/src/utils/ecosystem.ts
@@ -13,6 +13,7 @@ import type { Ecosystem } from '../classes/Ecosystem'
 import { GraphNode } from '../classes/GraphNode'
 import { getSelectorKey, SelectorInstance } from '../classes/SelectorInstance'
 import { getEvaluationContext } from './evaluationContext'
+import { DESTROYED } from './general'
 
 export const changeScopedNodeId = (
   ecosystem: Ecosystem,
@@ -80,8 +81,7 @@ export const getNode = <G extends AtomGenerics>(
   if ((template as GraphNode).izn) {
     // if the passed atom instance is Destroyed, get(/create) the
     // non-Destroyed instance
-    return (template as GraphNode).l === 'Destroyed' &&
-      (template as GraphNode).t
+    return (template as GraphNode).l === DESTROYED && (template as GraphNode).t
       ? ecosystem.getNode((template as GraphNode).t, (template as GraphNode).p)
       : template
   }

--- a/packages/atoms/src/utils/general.ts
+++ b/packages/atoms/src/utils/general.ts
@@ -1,5 +1,9 @@
 import type { GraphNode } from '../classes/GraphNode'
-import { EvaluationReason, InternalEvaluationReason } from '../types/index'
+import {
+  EvaluationReason,
+  InternalEvaluationReason,
+  LifecycleStatus,
+} from '../types/index'
 
 /**
  * The EdgeFlags. These are used as bitwise flags.
@@ -36,6 +40,20 @@ export const Invalidate = 1
 export const Cycle = 2 // only causes evaluations when status becomes Destroyed
 export const PromiseChange = 3
 export const EventSent = 4
+
+/**
+ * Lifecycle statuses
+ */
+export const INITIALIZING = 1
+export const ACTIVE = 2
+export const STALE = 3
+export const DESTROYED = 4
+
+export type InternalLifecycleStatus =
+  | typeof ACTIVE
+  | typeof DESTROYED
+  | typeof INITIALIZING
+  | typeof STALE
 
 /**
  * Event names
@@ -86,8 +104,8 @@ export const makeReasonReadable = (
     reason.t === Cycle
       ? ({
           ...base,
-          oldStatus: reason.o,
-          newStatus: reason.n,
+          oldStatus: statusMap[reason.o as InternalLifecycleStatus],
+          newStatus: statusMap[reason.n as InternalLifecycleStatus],
           type: CYCLE,
         } as const)
       : reason.t === Invalidate
@@ -129,3 +147,10 @@ export const makeReasonsReadable = (
   internalReasons?.map(reason =>
     makeReasonReadable(reason, node, includeOperation)
   )
+
+export const statusMap: Record<InternalLifecycleStatus, LifecycleStatus> = {
+  [ACTIVE]: 'Active',
+  [DESTROYED]: 'Destroyed',
+  [INITIALIZING]: 'Initializing',
+  [STALE]: 'Stale',
+}

--- a/packages/react/src/hooks/useAtomContext.ts
+++ b/packages/react/src/hooks/useAtomContext.ts
@@ -5,6 +5,7 @@ import {
   AtomTemplateBase,
   NodeOf,
   ParamsOf,
+  zi,
 } from '@zedux/atoms'
 import { is } from '@zedux/core'
 import { useContext } from 'react'
@@ -57,7 +58,7 @@ export const useAtomContext: {
   )
 
   if (!defaultParams || is(instance, AtomInstance)) {
-    if (DEV && instance?.l === 'Destroyed') {
+    if (DEV && instance?.l === zi.D) {
       console.error(
         `Zedux: useAtomContext - A destroyed atom instance was provided with key "${instance.id}". This is not recommended. Provide an active atom instance instead e.g. by calling \`useAtomInstance()\` in the providing component.`
       )

--- a/packages/react/src/hooks/useAtomInstance.ts
+++ b/packages/react/src/hooks/useAtomInstance.ts
@@ -9,6 +9,7 @@ import {
   ParamsOf,
   Selectable,
   SelectorInstance,
+  zi,
 } from '@zedux/atoms'
 import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 import { ZeduxHookConfig } from '../types'
@@ -121,8 +122,7 @@ export const useAtomInstance: {
     new ExternalNode(ecosystem, observerId, render)
 
   const addEdge = () => {
-    node.l === 'Destroyed' &&
-      (node = new ExternalNode(ecosystem, observerId, render))
+    node.l === zi.D && (node = new ExternalNode(ecosystem, observerId, render))
     node.i === instance ||
       node.u(
         instance,
@@ -154,7 +154,7 @@ export const useAtomInstance: {
     // an unmounting component's effect cleanup can update or force-destroy the
     // atom instance before this component is mounted. If that happened, trigger
     // a rerender to recreate the atom instance and/or get its new state
-    if (instance.v !== renderedValue || instance.l === 'Destroyed') {
+    if (instance.v !== renderedValue || instance.l === zi.D) {
       render({})
     }
 

--- a/packages/react/src/hooks/useAtomSelector.ts
+++ b/packages/react/src/hooks/useAtomSelector.ts
@@ -4,6 +4,7 @@ import {
   Selectable,
   SelectorInstance,
   StateOf,
+  zi,
 } from '@zedux/atoms'
 import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 import { Eventless, External, reactContextScope } from '../utils'
@@ -65,8 +66,7 @@ export const useAtomSelector = <S extends Selectable>(
     new ExternalNode(ecosystem, observerId, render)
 
   const addEdge = () => {
-    node.l === 'Destroyed' &&
-      (node = new ExternalNode(ecosystem, observerId, render))
+    node.l === zi.D && (node = new ExternalNode(ecosystem, observerId, render))
     node.i === instance ||
       node.u(instance, 'useAtomSelector', Eventless | External)
   }
@@ -92,7 +92,7 @@ export const useAtomSelector = <S extends Selectable>(
     // or update the state of its dependencies (causing it to rerun) before we
     // set `render.m`ounted. If that happened, trigger a rerender to recreate
     // the selector and/or get its new state
-    if (instance.v !== renderedValue || instance.l === 'Destroyed') {
+    if (instance.v !== renderedValue || instance.l === zi.D) {
       render({})
     }
 

--- a/packages/react/test/integrations/events.test.tsx
+++ b/packages/react/test/integrations/events.test.tsx
@@ -83,13 +83,13 @@ describe('events', () => {
 
     cleanup()
 
-    expect(node1.l).toBe('Active')
+    expect(node1.status).toBe('Active')
 
     const cleanup2 = node1.on('cycle', () => {}, { active: true })
 
     cleanup2()
 
-    expect(node1.l).toBe('Destroyed')
+    expect(node1.status).toBe('Destroyed')
   })
 
   test('cycle event', () => {

--- a/packages/react/test/integrations/lifecycle.test.tsx
+++ b/packages/react/test/integrations/lifecycle.test.tsx
@@ -169,11 +169,11 @@ describe('ttl', () => {
     const atom1 = atom('1', () => api().setTtl(promise))
     const instance1 = ecosystem.getInstance(atom1)
 
-    expect(instance1.l).toBe('Active')
+    expect(instance1.status).toBe('Active')
 
     instance1.on(() => {}, { active: true })() // add dependent and immediately clean it up
 
-    expect(instance1.l).toBe('Stale')
+    expect(instance1.status).toBe('Stale')
 
     jest.runAllTimers()
 
@@ -181,7 +181,7 @@ describe('ttl', () => {
     // chained `.then` inside `AtomInstance.ts`
     await promise.then(() => {})
 
-    expect(instance1.l).toBe('Destroyed')
+    expect(instance1.status).toBe('Destroyed')
   })
 
   test('a promise ttl cancels destruction if the instance is revived', async () => {
@@ -195,31 +195,31 @@ describe('ttl', () => {
     const atom1 = atom('1', () => api().setTtl(promise))
     const instance1 = ecosystem.getInstance(atom1)
 
-    expect(instance1.l).toBe('Active')
+    expect(instance1.status).toBe('Active')
 
     instance1.on(() => {}, { active: true })() // add dependent and immediately clean it up
 
-    expect(instance1.l).toBe('Stale')
+    expect(instance1.status).toBe('Stale')
 
     jest.runAllTimers()
     const cleanup = instance1.on(() => {}, { active: true })
 
-    expect(instance1.l).toBe('Active')
+    expect(instance1.status).toBe('Active')
 
     // this `.then()` creates a new promise that's guaranteed to run after the
     // chained `.then` inside `AtomInstance.ts`
     await promise.then(() => {})
 
-    expect(instance1.l).toBe('Active')
+    expect(instance1.status).toBe('Active')
 
     cleanup()
 
-    expect(instance1.l).toBe('Stale')
+    expect(instance1.status).toBe('Stale')
 
     jest.runAllTimers()
     await promise.then(() => {})
 
-    expect(instance1.l).toBe('Destroyed')
+    expect(instance1.status).toBe('Destroyed')
   })
 
   test('an observable ttl waits until the observable emits to destroy the instance', async () => {
@@ -229,15 +229,15 @@ describe('ttl', () => {
     const atom1 = atom('1', () => api().setTtl(observable))
     const instance1 = ecosystem.getInstance(atom1)
 
-    expect(instance1.l).toBe('Active')
+    expect(instance1.status).toBe('Active')
 
     instance1.on(() => {}, { active: true })() // add dependent and immediately clean it up
 
-    expect(instance1.l).toBe('Stale')
+    expect(instance1.status).toBe('Stale')
 
     jest.runAllTimers()
 
-    expect(instance1.l).toBe('Destroyed')
+    expect(instance1.status).toBe('Destroyed')
   })
 
   test('an observable ttl cancels destruction if the instance is revived', async () => {
@@ -247,24 +247,24 @@ describe('ttl', () => {
     const atom1 = atom('1', () => api().setTtl(observable))
     const instance1 = ecosystem.getInstance(atom1)
 
-    expect(instance1.l).toBe('Active')
+    expect(instance1.status).toBe('Active')
 
     instance1.on(() => {}, { active: true })() // add dependent and immediately clean it up
 
-    expect(instance1.l).toBe('Stale')
+    expect(instance1.status).toBe('Stale')
 
     jest.advanceTimersByTime(1)
     const cleanup = instance1.on(() => {}, { active: true })
 
-    expect(instance1.l).toBe('Active')
+    expect(instance1.status).toBe('Active')
 
     cleanup()
 
-    expect(instance1.l).toBe('Stale')
+    expect(instance1.status).toBe('Stale')
 
     jest.runAllTimers()
 
-    expect(instance1.l).toBe('Destroyed')
+    expect(instance1.status).toBe('Destroyed')
   })
 
   test('ecosystem `atomDefaults.ttl` is used as a default', () => {

--- a/packages/react/test/units/SelectorInstance.test.tsx
+++ b/packages/react/test/units/SelectorInstance.test.tsx
@@ -70,7 +70,7 @@ describe('the SelectorInstance class', () => {
     const instance = ecosystem.getNode(selector3)
     instance.destroy()
 
-    expect(instance.l).toBe('Destroyed')
+    expect(instance.status).toBe('Destroyed')
     expect(ecosystem.viewGraph()).toEqual({})
 
     expect(() => instance.destroy()).not.toThrow()
@@ -86,8 +86,8 @@ describe('the SelectorInstance class', () => {
     ecosystem.getNode(selector1).destroy() // does nothing
     ecosystem.getNode(selector2).destroy() // does nothing
 
-    expect(instance1.l).toBe('Active')
-    expect(instance2.l).toBe('Active')
+    expect(instance1.status).toBe('Active')
+    expect(instance2.status).toBe('Active')
     expect(ecosystem.dehydrate('@@selector')).toEqual({
       '@@selector-selector1-2': 'ab',
       '@@selector-selector2-1': 'abc',
@@ -97,8 +97,8 @@ describe('the SelectorInstance class', () => {
     ecosystem.getNode(selector2, []).destroy(true) // destroys both 1 & 2
     jest.runAllTimers()
 
-    expect(instance1.l).toBe('Destroyed')
-    expect(instance2.l).toBe('Destroyed')
+    expect(instance1.status).toBe('Destroyed')
+    expect(instance2.status).toBe('Destroyed')
     expect(ecosystem.dehydrate('@@selector')).toEqual({
       // ids 2 & 1 - the refs are still cached in the Selector class's
       // `_refBaseKeys`

--- a/packages/react/test/utils/ecosystem.ts
+++ b/packages/react/test/utils/ecosystem.ts
@@ -24,7 +24,7 @@ export const getNodes = () =>
         observers: getEdges(node.o),
         sources: getEdges(node.s),
         state: node.get(),
-        status: node.l,
+        status: node.status,
         weight: node.W,
       },
     ])

--- a/packages/stores/src/AtomInstance.ts
+++ b/packages/stores/src/AtomInstance.ts
@@ -212,7 +212,7 @@ export class AtomInstance<
     try {
       const newFactoryResult = this._eval()
 
-      if (this.l === 'Initializing') {
+      if (this.l === zi.I) {
         ;[this._stateType, this.store] = getStateStore(newFactoryResult)
 
         this._subscription = this.store.subscribe(
@@ -298,7 +298,7 @@ export class AtomInstance<
       this.N = undefined
     }
 
-    if (this.l !== 'Initializing') {
+    if (this.l !== zi.I) {
       // let this.i flush updates after status is set to Active
       zi.f(prevNode)
     }
@@ -312,7 +312,7 @@ export class AtomInstance<
     // user's part. Notify them. TODO: Can we pause evaluations while
     // status is Stale (and should we just always evaluate once when
     // waking up a stale atom)?
-    if (this.l !== 'Destroyed' && this.w.push(reason) === 1) {
+    if (this.l !== zi.D && this.w.push(reason) === 1) {
       // refCount just hit 1; we haven't scheduled a job for this node yet
       this.e._scheduler.schedule(this, shouldSetTimeout)
     }
@@ -355,7 +355,7 @@ export class AtomInstance<
       const api = (this.api = val as AtomApi<AtomGenericsToAtomApiGenerics<G>>)
 
       // Exports can only be set on initial evaluation
-      if (this.l === 'Initializing' && api.exports) {
+      if (this.l === zi.I && api.exports) {
         this.exports = api.exports
       }
 


### PR DESCRIPTION
@affects atoms, react, stores

## Description

The `l`ifecycleStatus property of graph nodes is already obfuscated, what with being a single-letter property. We can get a micro performance and build size boost by further obfuscating its value to be a number rather than a full status string.

Since this makes the property unreadable, add a new `status` getter property to all graph nodes. This reads from `this.l`ifecycleStatus and translates it to the old `Active | Initializing | Stale | Destroyed` strings.

### Breaking Change

This is technically a breaking change over previous v2 beta versions since `node.l` is an obfuscated number now. Use `node.status` instead.