### PR TITLE
fix: defer state changes during node evaluation

### DIFF
--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -241,10 +241,13 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
     const scheduler = this._scheduler
 
     const pre = scheduler.pre()
-    const result = callback()
-    scheduler.post(pre)
 
-    return result
+    try {
+      const result = callback()
+      return result
+    } finally {
+      scheduler.post(pre)
+    }
   }
 
   /**

--- a/packages/atoms/src/classes/MappedSignal.ts
+++ b/packages/atoms/src/classes/MappedSignal.ts
@@ -173,8 +173,15 @@ export class MappedSignal<
       // signals were updated. Either `set` was called with a different object
       // reference (making `this.N` undefined and this whole call a noop) or
       // `this.N` will contain one or more updates for non-signal inner values.
-      // No need to involve the scheduler. Update own state now.
-      if (!this.w.length && this.N) this.j()
+      if (!this.w.length && this.N) {
+        if (this.e._scheduler.I) {
+          // inner signals have updates, but they're deferred. Defer here too
+          this.e._scheduler.i(() => this.j())
+        } else {
+          // No need to involve the scheduler. Update own state now.
+          this.j()
+        }
+      }
     } finally {
       this.e._scheduler.post(pre)
     }

--- a/packages/atoms/src/classes/Signal.ts
+++ b/packages/atoms/src/classes/Signal.ts
@@ -28,10 +28,7 @@ export const doMutate = <G extends NodeGenerics>(
   events?: Partial<SendableEvents<G>>
 ) => {
   if (getEvaluationContext().n) {
-    node.e._scheduler.schedule(
-      { j: () => node.mutate(mutatable, events), T: 2 },
-      false
-    )
+    node.e._scheduler.i(() => node.mutate(mutatable, events))
 
     return
   }
@@ -225,10 +222,7 @@ export class Signal<
     events?: Partial<SendableEvents<G>>
   ) {
     if (getEvaluationContext().n) {
-      this.e._scheduler.schedule(
-        { j: () => this.set(settable, events), T: 2 },
-        false
-      )
+      this.e._scheduler.i(() => this.set(settable, events))
 
       return
     }

--- a/packages/atoms/src/utils/ecosystem.ts
+++ b/packages/atoms/src/utils/ecosystem.ts
@@ -132,7 +132,13 @@ export const getNode = <G extends AtomGenerics>(
       (params || []) as G['Params']
     ) as AnyAtomInstance
 
-    newInstance.i() // TODO: remove. Run this in AtomInstance constructor
+    const pre = ecosystem._scheduler.pre()
+    try {
+      newInstance.i() // TODO: remove. Run this in AtomInstance constructor
+    } finally {
+      ecosystem._scheduler.post(pre)
+    }
+
     ecosystem.n.set(newInstance.id, newInstance)
 
     return newInstance
@@ -169,16 +175,21 @@ export const getNode = <G extends AtomGenerics>(
     }
 
     // create the instance; it doesn't exist yet
-    instance = new SelectorInstance(
-      ecosystem,
-      id,
-      selectorOrConfig,
-      params || []
-    )
+    const pre = ecosystem._scheduler.pre()
+    try {
+      instance = new SelectorInstance(
+        ecosystem,
+        id,
+        selectorOrConfig,
+        params || []
+      )
 
-    ecosystem.n.set(instance.id, instance)
+      ecosystem.n.set(instance.id, instance)
 
-    return instance
+      return instance
+    } finally {
+      ecosystem._scheduler.post(pre)
+    }
   }
 
   throw new TypeError(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -150,9 +150,8 @@ export interface Job {
    * 1 - InformSubscribers
    * 2 - EvaluateGraphNode
    * 3 - UpdateExternalDependent
-   * 4 - RunEffect
    */
-  T: 0 | 1 | 2 | 3 | 4
+  T: 0 | 1 | 2 | 3
 }
 
 /**

--- a/packages/react/test/integrations/signals.test.tsx
+++ b/packages/react/test/integrations/signals.test.tsx
@@ -4,6 +4,7 @@ import {
   atom,
   ChangeEvent,
   GraphNode,
+  injectEcosystem,
   injectSignal,
   ion,
   Signal,
@@ -57,8 +58,18 @@ describe('signals', () => {
 
   test('mutating a signal generates a transaction', () => {
     const instance1 = ecosystem.getNode(atom1)
+    let transactions
+    let newState
 
-    const [newState, transactions] = instance1.exports.mutateSignal('a', 2)
+    instance1.exports.signal.on(
+      'mutate',
+      (receivedTransactions, { change }) => {
+        transactions = receivedTransactions
+        newState = change?.newState
+      }
+    )
+
+    instance1.exports.mutateSignal('a', 2)
 
     expect(newState).toEqual({ a: 2, b: [{ c: 2 }] })
     expect(transactions).toEqual([{ k: 'a', v: 2 }])
@@ -66,8 +77,18 @@ describe('signals', () => {
 
   test('deeply mutating a signal generates a transaction with a nested key', () => {
     const instance1 = ecosystem.getNode(atom1)
+    let transactions
+    let newState
 
-    const [newState, transactions] = instance1.exports.signal.mutate(state => {
+    instance1.exports.signal.on(
+      'mutate',
+      (receivedTransactions, { change }) => {
+        transactions = receivedTransactions
+        newState = change?.newState
+      }
+    )
+
+    instance1.exports.signal.mutate(state => {
       state.b[0].c = 3
     })
 
@@ -215,6 +236,7 @@ describe('signals', () => {
   })
 
   test('calling `.get()` in a reactive context registers graph edges', () => {
+    const calls: any[] = []
     const atom1 = atom('1', 'a')
 
     const atom2 = ion('2', ({ getNode }) => {
@@ -223,6 +245,8 @@ describe('signals', () => {
       const signal = injectSignal('')
       signal.set(node1.get() + 'b')
 
+      calls.push(signal.get())
+
       return signal
     })
 
@@ -230,18 +254,22 @@ describe('signals', () => {
     const node2 = ecosystem.getNode(atom2)
 
     expect(node2.get()).toBe('ab')
+    expect(calls).toEqual(['', 'ab'])
 
     node1.set('aa')
 
     expect(node2.get()).toBe('aab')
+    expect(calls).toEqual(['', 'ab', 'ab', 'aab'])
 
-    node2.set('c') // essentially a no-op; node2's state is always derived
+    node2.set('c') // will flip then flip back; node2's state is always derived
 
     expect(node2.get()).toBe('aab')
+    expect(calls).toEqual(['', 'ab', 'ab', 'aab', 'c', 'aab'])
 
     node1.set('aaa')
 
     expect(node2.get()).toBe('aaab')
+    expect(calls).toEqual(['', 'ab', 'ab', 'aab', 'c', 'aab', 'aab', 'aaab'])
   })
 
   test('calling `.getOnce()` in a reactive context does not register graph edges', () => {
@@ -263,5 +291,30 @@ describe('signals', () => {
     ecosystem.getNode(atom1).set('aa')
 
     expect(node2.get()).toBe('ab')
+  })
+
+  test('setting a signal during atom evaluation eventually resolves', () => {
+    const calls: any[] = []
+    const atom1 = atom('1', 1)
+
+    const atom2 = atom('2', () => {
+      const { get } = injectEcosystem()
+      const val1 = get(atom1)
+      const signal = injectSignal(2)
+
+      if (signal.get() !== val1) signal.set(val1)
+
+      calls.push([val1, signal.get()])
+
+      return signal
+    })
+
+    const node2 = ecosystem.getNode(atom2)
+
+    expect(node2.get()).toBe(1)
+    expect(calls).toEqual([
+      [1, 2],
+      [1, 1],
+    ])
   })
 })


### PR DESCRIPTION
@affects atoms, core

## Description

Just like React, Zedux allows updating state synchronously during node evaluation. With stores, it was possible to prevent such state updates from triggering a reevaluation because stores propagate the change immediately to all child stores. That means you wouldn't see state tearing between composed stores in the atom.

With signals, on the other hand, we can't propagate the change to observers until after the current node finishes evaluating. That means composed signals (via `injectMappedSignal`) can get out of sync with signals they're composed of. Example:

```ts
const tearingAtom = atom('tearing', () => {
  const signal = injectSignal('initial state')
  const mappedSignal = injectMappedSignal({ signal })

  signal.set('new state')

  signal.get() // 'new state'
  mappedSignal.get() // { signal: 'initial state' }
})
```

This may seem like a disadvantage of signals compared to stores, but it really isn't. Stores had the same problem, but more hidden - since stores ultimately update atoms, updating a store in another atom, then comparing the store's state to that atom's value would give this same state tear.

The problem is more prominent in signals-based atoms since it can happen with locally-injected signals. Because of this, I think it finally warrants fixing.

Add a new "interrupt" job type that gets highest priority in the normal job queue. Always run interrupt jobs in the order they were added. Make `signal.set`, `signal.mutate`, and `mappedSignal.set` (in the special mapped signal case of only local keys being updated) add interrupt jobs when called during node evaluation. Add tests.

Now the behavior is like so:

```ts
const glitchlessAtom = atom('glitchless', () => {
  const signal = injectSignal('initial state')
  const mappedSignal = injectMappedSignal({ signal })

  signal.set('new state')

  signal.get() // first run: 'initial state', second run: 'new state'
  mappedSignal.get() // first run: { signal: 'initial state' }, second run: { signal: 'new state' }
})
```

### What This Means for You

During evaluation, when setting state of a signal that the evaluating node has a reactive dependency on, the evaluating node will evaluate again, whereas previously it wouldn't.

This is also the first and only time state updates are deferred in Zedux. Normally new state is available to `.get` immediately after `.set`ting it. Now, when updating state during atom or selector evaluation, the new state will not be set yet. This makes it much more important to use the callback overloads of `.set` and `.mutate`, just like in React, to ensure that you're operating on the actual most recent state, not an older value.

If effects specify the changed signal's state as a dep, they will run twice, with a cleanup in-between. It is actually possible to change this if we find it causes problems.

Consumers of the double-evaluating node will be able to see both evaluation reasons when inspecting via `injectWhy`/`ecosystem.why`, but will otherwise be unaffected - the extra reevaluation will happen before consumers get a chance to run.

And the upside is that the previous restriction mentioned in the docs of never updating one atom while another atom is evaluating is now lifted - you can set any atom or signal anywhere to your heart's content.