### PR TITLE
release: v2.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## v2.0.0-beta.2 (Feb 12, 2025)
+
+### New Features:
+
+- **Breaking Change** `atoms`: make `injectMemo` reactive when no deps are passed (#171)
+- **Breaking Change** `atoms`, `react`: replace atom getters with ecosystem function properties (#169)
+- **Breaking Change** `atoms`, `react`, `stores`: add `status` getter property to graph nodes (#173)
+- **Breaking Change** `atoms`, `react`, `stores`: implement `untrack` and rework injectors (#170)
+- **Breaking Change** `atoms`, `react`, `stores`: implement new plugins spec (#168)
+- **Breaking Change** `atoms`, `immer`, `machines`, `react`, `stores`: make listeners passive, implement all implicit events (#158)
+- `atoms`, `react`, `stores`: implement scoped atoms, `inject`, and `ecosystem.withScope` (#172)
+
+### Fixes:
+
+- `atoms`: add tests for proxies and fix several edge case bugs (#176)
+- `atoms`, `core`: defer state changes during node evaluation (#175)
+
 ## v2.0.0-beta.1 (Jan 21, 2025)
 
 ### New Features:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zedux",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "A Molecular State Engine for React",
   "type": "module",
   "author": "Joshua Claunch (bowheart <bowheart31@gmail.com>)",

--- a/packages/atoms/package.json
+++ b/packages/atoms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/atoms",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/core": "2.0.0-beta.1"
+    "@zedux/core": "2.0.0-beta.2"
   },
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/core",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "A high-level, declarative, composable form of Redux",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/immer",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Official Immer integration for Zedux's store and atomic APIs",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "devDependencies": {
-    "@zedux/atoms": "2.0.0-beta.1",
+    "@zedux/atoms": "2.0.0-beta.2",
     "immer": "^10.1.1"
   },
   "exports": {
@@ -35,7 +35,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/atoms": "2.0.0-beta.1",
+    "@zedux/atoms": "2.0.0-beta.2",
     "immer": ">=9.0.19"
   },
   "repository": {

--- a/packages/machines/package.json
+++ b/packages/machines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/machines",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Simple native state machine implementation for Zedux atoms",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,8 +10,8 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "devDependencies": {
-    "@zedux/atoms": "2.0.0-beta.1",
-    "@zedux/core": "2.0.0-beta.1"
+    "@zedux/atoms": "2.0.0-beta.2",
+    "@zedux/core": "2.0.0-beta.2"
   },
   "exports": {
     ".": {
@@ -36,8 +36,8 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/atoms": "2.0.0-beta.1",
-    "@zedux/core": "2.0.0-beta.1"
+    "@zedux/atoms": "2.0.0-beta.2",
+    "@zedux/core": "2.0.0-beta.2"
   },
   "repository": {
     "directory": "packages/machines",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/react",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/atoms": "2.0.0-beta.1"
+    "@zedux/atoms": "2.0.0-beta.2"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/stores",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "The legacy composable store model of Zedux",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,8 +10,8 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/atoms": "2.0.0-beta.1",
-    "@zedux/core": "2.0.0-beta.1"
+    "@zedux/atoms": "2.0.0-beta.2",
+    "@zedux/core": "2.0.0-beta.2"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
## Description

Increment monorepo package versions and update the CHANGELOG for version 2.0.0-beta.2.

This PR was generated by the release script at https://github.com/Omnistac/zedux/tree/master/scripts/release.js

The packages will be published to npm and a GitHub release will be created after this PR merges.