### PR TITLE
fix!: fix some types, return values, and relative imports

### DIFF
--- a/packages/atoms/src/classes/MappedSignal.ts
+++ b/packages/atoms/src/classes/MappedSignal.ts
@@ -87,7 +87,7 @@ export class MappedSignal<
     mutatable: Mutatable<G['State']>,
     events?: Partial<SendableEvents<G>>
   ) {
-    return doMutate(this, true, mutatable, events)
+    doMutate(this, true, mutatable, events)
   }
 
   public send<E extends UndefinedEvents<G['Events']>>(eventName: E): void

--- a/packages/atoms/src/classes/Signal.ts
+++ b/packages/atoms/src/classes/Signal.ts
@@ -174,7 +174,7 @@ export class Signal<
     mutatable: Mutatable<G['State']>,
     events?: Partial<SendableEvents<G>>
   ) {
-    return doMutate(this, false, mutatable, events)
+    doMutate(this, false, mutatable, events)
   }
 
   public send<E extends UndefinedEvents<G['Events']>>(eventName: E): void

--- a/packages/atoms/src/classes/templates/AtomTemplate.ts
+++ b/packages/atoms/src/classes/templates/AtomTemplate.ts
@@ -28,10 +28,7 @@ export type AtomTemplateRecursive<
 >
 
 export class AtomTemplate<
-  G extends AtomGenerics & {
-    Node: AtomInstanceRecursive<G>
-    Template: AtomTemplateRecursive<G>
-  } = AnyAtomGenerics
+  G extends AtomGenerics = AnyAtomGenerics
 > extends AtomTemplateBase<G> {
   /**
    * This method should be overridden when creating custom atom classes that

--- a/packages/atoms/src/classes/templates/IonTemplate.ts
+++ b/packages/atoms/src/classes/templates/IonTemplate.ts
@@ -1,4 +1,3 @@
-import { ion } from '@zedux/atoms/factories/ion'
 import {
   AtomConfig,
   IonStateFactory,
@@ -28,13 +27,8 @@ export type IonTemplateRecursive<
 >
 
 export class IonTemplate<
-  G extends AtomGenerics & {
-    Node: IonInstanceRecursive<G>
-    Template: IonTemplateRecursive<G>
-  } = AnyAtomGenerics
+  G extends AtomGenerics = AnyAtomGenerics
 > extends AtomTemplate<G> {
-  private _get: IonStateFactory<G>
-
   constructor(
     key: string,
     stateFactory: IonStateFactory<Omit<G, 'Node' | 'Template'>>,
@@ -45,13 +39,5 @@ export class IonTemplate<
       (...params: G['Params']) => stateFactory(injectEcosystem(), ...params),
       _config
     )
-
-    this._get = stateFactory
-  }
-
-  public override(newGet?: IonStateFactory<G>): IonTemplate<G> {
-    const newIon = ion(this.key, newGet || this._get, this._config)
-    newIon._isOverride = true
-    return newIon
   }
 }

--- a/packages/atoms/src/factories/atom.ts
+++ b/packages/atoms/src/factories/atom.ts
@@ -113,5 +113,5 @@ export const atom: {
     throw new TypeError('Zedux: All atoms must have a key')
   }
 
-  return new AtomTemplate(key, value, config) as any
+  return new AtomTemplate(key, value, config)
 }

--- a/packages/atoms/src/factories/ion.ts
+++ b/packages/atoms/src/factories/ion.ts
@@ -137,4 +137,4 @@ export const ion: {
     Promise: PromiseType
   }>,
   config?: AtomConfig<State>
-) => new IonTemplate(key, value, config) as any
+) => new IonTemplate(key, value, config)

--- a/packages/atoms/src/types/atoms.ts
+++ b/packages/atoms/src/types/atoms.ts
@@ -9,7 +9,7 @@ import {
   Selectable,
 } from './index'
 import { SelectorInstance } from '../classes/SelectorInstance'
-import { Signal } from '../classes/Signal'
+import type { Signal } from '../classes/Signal'
 import { MappedSignal } from '../classes/MappedSignal'
 
 export type AtomApiGenericsPartial<G extends Partial<AtomApiGenerics>> = Omit<
@@ -100,9 +100,12 @@ export type ExportsOf<A extends AnyAtomApi | AnyAtomTemplate | GraphNode> =
     ? G['Exports']
     : never
 
-export type GenericsOf<A extends GraphNode> = A extends GraphNode<infer G>
-  ? G
-  : never
+export type GenericsOf<A extends GraphNode | AtomTemplateBase> =
+  A extends GraphNode<infer G>
+    ? G
+    : A extends AtomTemplateBase<infer G>
+    ? G
+    : never
 
 export type NodeGenerics = Pick<
   AtomGenerics,

--- a/packages/atoms/src/utils/ecosystem.ts
+++ b/packages/atoms/src/utils/ecosystem.ts
@@ -15,33 +15,6 @@ import { getSelectorKey, SelectorInstance } from '../classes/SelectorInstance'
 import { getEvaluationContext } from './evaluationContext'
 import { DESTROYED } from './general'
 
-export const changeScopedNodeId = (
-  ecosystem: Ecosystem,
-  templateKey: string,
-  newNode: GraphNode
-) => {
-  // if this is the first scoped node of its template to evaluate, record the
-  // scope all future instances of the template will need to be provided
-  ecosystem.s ??= {}
-  ecosystem.s[templateKey] ??= [...newNode.V!.keys()]
-
-  // give the new scoped node a `@scope()`-suffixed id
-  const contextValueStrings = [...newNode.V!.values()].map(val => {
-    const resolvedVal =
-      val?.constructor?.name === WeakRef.name
-        ? (val as WeakRef<any>).deref()
-        : val
-
-    return is(resolvedVal, AtomInstance)
-      ? (resolvedVal as AtomInstance).id
-      : ecosystem._idGenerator.hashParams(resolvedVal, true)
-  })
-
-  const scopedId = `${newNode.id}-@scope(${contextValueStrings.join(',')})`
-
-  newNode.id = scopedId
-}
-
 const getContextualizedId = (
   ecosystem: Ecosystem,
   scopeKeys: Record<string, any>[],

--- a/packages/atoms/src/utils/events.ts
+++ b/packages/atoms/src/utils/events.ts
@@ -1,4 +1,5 @@
-import type { Ecosystem, GraphNode } from '../classes'
+import type { Ecosystem } from '../classes/Ecosystem'
+import type { GraphNode } from '../classes/GraphNode'
 import {
   CatchAllListener,
   EcosystemEvent,
@@ -7,7 +8,7 @@ import {
   ListenableEvents,
   ListenerConfig,
   SingleEventListener,
-} from '../types'
+} from '../types/index'
 import { ERROR, EventSent, makeReasonReadable } from './general'
 
 export const isListeningTo = (

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,7 +51,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=18.0.0"
+    "react": ">=19.0.0"
   },
   "repository": {
     "directory": "packages/react",

--- a/packages/react/src/inject.ts
+++ b/packages/react/src/inject.ts
@@ -1,6 +1,5 @@
-import { AtomTemplateBase, injectSelf, is, NodeOf } from '@zedux/atoms'
+import { AtomTemplateBase, injectSelf, NodeOf } from '@zedux/atoms'
 import { Context } from 'react'
-import { getReactContext } from './utils'
 
 export const inject = <T extends Context<any> | AtomTemplateBase>(
   context: T
@@ -25,7 +24,7 @@ export const inject = <T extends Context<any> | AtomTemplateBase>(
 
   if (!instance.e.S) {
     throw new Error(
-      `Scoped atom was initialized outside a scoped context. This atom needs to be initialized by a React component or inside \`ecosystem.withScope\``
+      `Scoped atom was used outside a scoped context. This atom needs to be used by a React component or inside \`ecosystem.withScope\``
     )
   }
 

--- a/packages/react/test/integrations/scoped-atoms.test.tsx
+++ b/packages/react/test/integrations/scoped-atoms.test.tsx
@@ -505,7 +505,7 @@ describe('scoped atoms', () => {
     const childAtom = atom('child', () => inject(atom1))
 
     expect(() => ecosystem.getNode(childAtom)).toThrowError(
-      /Scoped atom was initialized outside a scoped context/
+      /Scoped atom was used outside a scoped context/
     )
     expect(consoleMock).toHaveBeenCalledTimes(1)
   })

--- a/packages/react/test/stores/dependency-injection.test.tsx
+++ b/packages/react/test/stores/dependency-injection.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom/extend-expect'
 import { act } from '@testing-library/react'
 import {
   createStore,
+  injectEcosystem,
   injectEffect,
   useAtomInstance,
   useAtomValue,
@@ -127,7 +128,9 @@ describe('using atoms in components', () => {
     const atom1 = atom('1', 'a')
     const atom2 = ion('2', ({ get }) => get(atom1) + 'b')
     const atom1Override = atom1.override('aa')
-    const atom2Override = atom2.override(({ get }) => get(atom1) + 'bb')
+    const atom2Override = atom2.override(
+      () => injectEcosystem().get(atom1) + 'bb'
+    )
 
     function Test() {
       const two = useAtomValue(atom2)

--- a/packages/stores/src/AtomInstance.ts
+++ b/packages/stores/src/AtomInstance.ts
@@ -154,7 +154,7 @@ export class AtomInstance<
    *
    * An alias for `instance.store.getState()`.
    */
-  public get() {
+  public get(): G['State'] {
     super.get() // register graph edge
 
     return this.store.getState()

--- a/packages/stores/src/AtomTemplate.ts
+++ b/packages/stores/src/AtomTemplate.ts
@@ -1,4 +1,4 @@
-import { AtomTemplateBase, Ecosystem } from '@zedux/atoms'
+import { AtomConfig, AtomTemplateBase, Ecosystem } from '@zedux/atoms'
 import { atom } from './atom'
 import { AtomInstance } from './AtomInstance'
 import { AnyAtomGenerics, AtomGenerics, AtomValueOrFactory } from './types'
@@ -27,6 +27,14 @@ export class AtomTemplate<
     Template: AtomTemplateRecursive<G>
   } = AnyAtomGenerics
 > extends AtomTemplateBase<G> {
+  constructor(
+    key: string,
+    _value: AtomValueOrFactory<G>,
+    _config?: AtomConfig<G['State']> | undefined
+  ) {
+    super(key, _value, _config)
+  }
+
   /**
    * This method should be overridden when creating custom atom classes that
    * create a custom atom instance class. Return a new instance of your atom

--- a/packages/stores/src/IonTemplate.ts
+++ b/packages/stores/src/IonTemplate.ts
@@ -1,7 +1,6 @@
-import { AtomConfig, injectAtomGetters } from '@zedux/atoms'
+import { AtomConfig, injectEcosystem } from '@zedux/atoms'
 import { AtomInstance } from './AtomInstance'
 import { AtomTemplate } from './AtomTemplate'
-import { ion } from './ion'
 import { AnyAtomGenerics, AtomGenerics, IonStateFactory } from './types'
 
 export type IonInstanceRecursive<
@@ -23,13 +22,8 @@ export type IonTemplateRecursive<
 >
 
 export class IonTemplate<
-  G extends AtomGenerics & {
-    Node: IonInstanceRecursive<G>
-    Template: IonTemplateRecursive<G>
-  } = AnyAtomGenerics
+  G extends AtomGenerics = AnyAtomGenerics
 > extends AtomTemplate<G> {
-  private _get: IonStateFactory<G>
-
   constructor(
     key: string,
     stateFactory: IonStateFactory<Omit<G, 'Node' | 'Template'>>,
@@ -37,16 +31,8 @@ export class IonTemplate<
   ) {
     super(
       key,
-      (...params: G['Params']) => stateFactory(injectAtomGetters(), ...params),
+      (...params: G['Params']) => stateFactory(injectEcosystem(), ...params),
       _config
     )
-
-    this._get = stateFactory
-  }
-
-  public override(newGet?: IonStateFactory<G>): IonTemplate<G> {
-    const newIon = ion(this.key, newGet || this._get, this._config)
-    newIon._isOverride = true
-    return newIon
   }
 }

--- a/packages/stores/src/atom.ts
+++ b/packages/stores/src/atom.ts
@@ -102,5 +102,5 @@ export const atom: {
     throw new TypeError('Zedux: All atoms must have a key')
   }
 
-  return new AtomTemplate(key, value, config) as any
+  return new AtomTemplate(key, value, config)
 }

--- a/packages/stores/src/ion.ts
+++ b/packages/stores/src/ion.ts
@@ -132,4 +132,4 @@ export const ion: {
     Promise: PromiseType
   }>,
   config?: AtomConfig<State>
-) => new IonTemplate(key, get, config) as any
+) => new IonTemplate(key, get, config)


### PR DESCRIPTION
@affects atoms, react, stores

## Description

Finally using Zedux v2 in a real app, I quickly found several types we don't have tests for that are either broken or make it unnecessarily difficult to type functions that work with Zedux objects.

Also, `signal.mutate` was still claiming it returns a tuple, even though I got rid of that capability in #175.

The build of the last beta release also had a circular import in it that prevented `GraphNode` from being defined before `Signal` tried to extend it. Fix that

This will need follow-up work to test as much of this as possible - if we can get regression tests for all these changes, it'll guarantee a smoother process to upgrade Zedux in our apps in the future.

### Breaking Change

This includes one breaking change that we really should have changed a long time ago - the `override` method for `IonTemplate`s didn't match the signature of the method it overrides in `AtomTemplate`. This was to allow overriding an ion with a new state factory that also received an atom getters object as the first parameter.

This was never necessary - it's fine to override an ion and have to specify a normal atom state factory. And since these methods were mismatched, ions and atoms were not compatible with each other in TypeScript's eyes. This fixes that - ions now really are just atoms.