### PR TITLE
fix: fix some more v2 types

### DIFF
--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -392,7 +392,7 @@ export interface RefObject<T = any> {
   readonly current: T | null
 }
 
-export type Selectable<State = any, Params extends any[] = any[]> =
+export type Selectable<State = any, Params extends any[] = any> =
   | AtomSelectorOrConfig<State, Params>
   | SelectorInstance<{
       Params: Params

--- a/packages/stores/src/AtomTemplate.ts
+++ b/packages/stores/src/AtomTemplate.ts
@@ -22,10 +22,7 @@ export type AtomTemplateRecursive<
 >
 
 export class AtomTemplate<
-  G extends AtomGenerics & {
-    Node: AtomInstanceRecursive<G>
-    Template: AtomTemplateRecursive<G>
-  } = AnyAtomGenerics
+  G extends AtomGenerics = AnyAtomGenerics
 > extends AtomTemplateBase<G> {
   constructor(
     key: string,


### PR DESCRIPTION
@affects atoms, stores

## Description

Follow-up to #178, some more types are too strict and should just be `any`. These don't turn off types for any of Zedux's APIs, they just allow the user to extend them without TS complaining unnecessarily about a mismatch.