### PR TITLE
fix(react): only trigger rerender in `useAtomInstance` if `subscribe:…

### DIFF
--- a/packages/react/src/hooks/useAtomInstance.ts
+++ b/packages/react/src/hooks/useAtomInstance.ts
@@ -144,7 +144,7 @@ export const useAtomInstance: {
     // atom instance before this component is mounted. If that happened, trigger
     // a rerender to recreate the atom instance and/or get its new state
     if (
-      instance.getState() !== renderedState ||
+      (subscribe && instance.getState() !== renderedState) ||
       instance.status === 'Destroyed'
     ) {
       render({})

--- a/packages/react/test/regressions/182.test.tsx
+++ b/packages/react/test/regressions/182.test.tsx
@@ -1,0 +1,75 @@
+import { atom, injectStore, api } from '@zedux/atoms'
+import { useAtomValue, useAtomInstance } from '@zedux/react'
+import React, { act, useEffect } from 'react'
+import { renderInEcosystem } from '../utils/renderInEcosystem'
+
+describe('issue #182', () => {
+  test('repro', async () => {
+    const someAtom = atom('some', () => {
+      const store = injectStore<{ items: number[] }>({
+        items: [],
+      })
+
+      function fillItems() {
+        store.setState({
+          items: [1, 2, 3],
+        })
+      }
+
+      return api(store).setExports({
+        fillItems,
+      })
+    })
+
+    function ItemList() {
+      const { items } = useAtomValue(someAtom)
+      return (
+        <>
+          {items.map(item => (
+            <div key={item}>{item}</div>
+          ))}
+        </>
+      )
+    }
+
+    let counter = 0
+
+    function App() {
+      const { fillItems } = useAtomInstance(someAtom).exports
+      counter++
+
+      // Calling api function inside use effect triggers re-render
+      // count should be 2 (from strict mode double-render), not 4
+      useEffect(() => {
+        fillItems()
+      }, [])
+
+      return (
+        <div className="App">
+          <button
+            data-testid="button"
+            onClick={() => {
+              // Calling api function inside button click works as expected,
+              // it won't render the app
+              fillItems()
+            }}
+          >
+            Fill
+          </button>
+          <ItemList />
+        </div>
+      )
+    }
+
+    const { findByTestId } = renderInEcosystem(<App />, { useStrictMode: true })
+    const button = await findByTestId('button')
+
+    expect(counter).toBe(2)
+
+    act(() => {
+      button.click()
+    })
+
+    expect(counter).toBe(2)
+  })
+})


### PR DESCRIPTION
## Description

`useAtomInstance` does need to trigger rerender on atom instance force-destruction, regardless of whether `useAtomInstance` is subscribed to atom state. However, anything short of that should not cause a rerender when `subscribe: false` (the default).

In React StrictMode, when the component has other effects that update the atom's state before `useAtomInstance`'s effect double-invokes, the atom's state can be different when `useAtomInstance`'s effect does run the second time. Don't even check this if `subscribe: false`.

## Issues

Resolves #182