### PR TITLE
feat(atoms): wrap exports and `injectCallback` in current atom's scope

### DIFF
--- a/packages/atoms/src/classes/Scheduler.ts
+++ b/packages/atoms/src/classes/Scheduler.ts
@@ -249,16 +249,21 @@ export class Scheduler implements SchedulerInterface {
       : '_isRunning'
 
     const nows = this.nows
+    let errors: any[] | undefined
 
     this[runningKey] = true
-    try {
-      while (jobs.length) {
-        const job = (nows.length ? nows : jobs).shift() as Job
+    while (jobs.length) {
+      const job = (nows.length ? nows : jobs).shift() as Job
+      try {
         job.j()
+      } catch (err) {
+        errors ??= []
+        errors.push(err)
       }
-    } finally {
-      this[runningKey] = false
     }
+
+    this[runningKey] = false
+    if (errors) throw errors[0]
 
     if (this._runAfterNows) {
       this._runAfterNows = false

--- a/packages/atoms/src/classes/instances/AtomInstance.ts
+++ b/packages/atoms/src/classes/instances/AtomInstance.ts
@@ -458,18 +458,18 @@ export class AtomInstance<
       this.N = undefined
       destroyBuffer(prevNode)
 
-      throw err
-    } finally {
-      this._isEvaluating = false
-
-      // even if evaluation errored, we need to update dependents if the
-      // `S`ignal's state changed. TODO: move this to `catch` block
+      // even if evaluation errored, we need to keep this atom in sync with its
+      // signal (and update dependents if the `S`ignal's state changed).
       if (this.S && this.S.v !== this.v) {
         const oldState = this.v
         this.v = this.S.v
 
         handleStateChange(this, oldState)
       }
+
+      throw err
+    } finally {
+      this._isEvaluating = false
 
       this.w = []
     }

--- a/packages/atoms/src/factories/api.ts
+++ b/packages/atoms/src/factories/api.ts
@@ -12,7 +12,7 @@ import { Signal } from '../classes/Signal'
  * the atom.
  *
  *   - Any exports on the AtomApi are set as the atom instance's exports on
- *     initial evaluation and ignored forever after.
+ *     initial evaluation (and ignored on all subsequent evaluations).
  *   - If promise or state references change on subsequent evaluations, it
  *     triggers the appropriate updates in all the atom's dynamic dependents.
  */

--- a/packages/atoms/src/injectors/injectCallback.ts
+++ b/packages/atoms/src/injectors/injectCallback.ts
@@ -1,26 +1,33 @@
 import { InjectorDeps } from '../types/index'
-import { injectEcosystem } from './injectEcosystem'
 import { injectMemo } from './injectMemo'
+import { injectSelf } from './injectSelf'
 
 /**
- * Memoizes a callback function and wraps it in an `ecosystem.batch()` call.
+ * Memoizes a callback function and wraps it in an `ecosystem.batch()` call and,
+ * if the injecting atom is scoped, an `ecosystem.withScope()` call.
  *
- * To memoize a callback without automatic batching, use `injectMemo` instead:
+ * To memoize a callback without automatic batching/scoping, use `injectMemo`
+ * instead:
  *
  * ```ts
- * injectMemo(() => myCallback, [])
+ * - injectCallback(myCallback, [])
+ * + injectMemo(() => myCallback, [])
  * ```
  */
 export const injectCallback = <Args extends any[] = [], Ret = any>(
   callback: (...args: Args) => Ret,
   deps?: InjectorDeps
 ) => {
-  const ecosystem = injectEcosystem()
+  const self = injectSelf()
 
   return injectMemo(
     () =>
       (...args: Args) =>
-        ecosystem.batch(() => callback(...args)),
+        self.e.batch(() =>
+          self.V
+            ? self.e.withScope(self.V, () => callback(...args))
+            : callback(...args)
+        ),
     deps
   )
 }

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -139,6 +139,10 @@ export type EventMap = {
   [K in keyof ExplicitEvents & ImplicitEvents]?: never
 } & Record<string, () => any>
 
+export interface ExportsConfig {
+  wrap?: boolean
+}
+
 export type ExportsInfusedSetter<State, Exports> = Exports & {
   (settable: Settable<State>, meta?: any): State
 }

--- a/packages/react/test/integrations/__snapshots__/graph.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/graph.test.tsx.snap
@@ -1,0 +1,360 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`graph ecosystem getters 1`] = `
+{
+  "@signal(atom4)-0": {
+    "dependencies": [],
+    "dependents": [
+      {
+        "key": "@signal(atom4)-2",
+        "operation": "get",
+      },
+      {
+        "key": "atom4",
+        "operation": "injectSignal",
+      },
+    ],
+    "weight": 1,
+  },
+  "@signal(atom4)-1": {
+    "dependencies": [],
+    "dependents": [
+      {
+        "key": "@signal(atom4)-2",
+        "operation": "get",
+      },
+      {
+        "key": "atom4",
+        "operation": "injectSignal",
+      },
+    ],
+    "weight": 1,
+  },
+  "Test-:r0:": {
+    "dependencies": [
+      {
+        "key": "atom4",
+        "operation": "useAtomValue",
+      },
+    ],
+    "dependents": [],
+    "weight": 9,
+  },
+  "Test-:r1:": {
+    "dependencies": [
+      {
+        "key": "atom4",
+        "operation": "useAtomInstance",
+      },
+    ],
+    "dependents": [],
+    "weight": 1,
+  },
+  "atom1": {
+    "dependencies": [],
+    "dependents": [
+      {
+        "key": "atom4",
+        "operation": "get",
+      },
+    ],
+    "weight": 1,
+  },
+  "atom2": {
+    "dependencies": [],
+    "dependents": [],
+    "weight": 1,
+  },
+  "atom3": {
+    "dependencies": [],
+    "dependents": [
+      {
+        "key": "atom4",
+        "operation": "get",
+      },
+    ],
+    "weight": 1,
+  },
+  "atom4": {
+    "dependencies": [
+      {
+        "key": "@signal(atom4)-0",
+        "operation": "injectSignal",
+      },
+      {
+        "key": "@signal(atom4)-1",
+        "operation": "injectSignal",
+      },
+      {
+        "key": "@signal(atom4)-2",
+        "operation": "injectMappedSignal",
+      },
+      {
+        "key": "atom1",
+        "operation": "get",
+      },
+      {
+        "key": "atom3",
+        "operation": "get",
+      },
+    ],
+    "dependents": [
+      {
+        "key": "Test-:r0:",
+        "operation": "useAtomValue",
+      },
+      {
+        "key": "Test-:r1:",
+        "operation": "useAtomInstance",
+      },
+    ],
+    "weight": 8,
+  },
+}
+`;
+
+exports[`graph ecosystem getters 2`] = `
+{
+  "Test-:r0:": {
+    "atom4": {
+      "@signal(atom4)-0": {},
+      "@signal(atom4)-1": {},
+      "@signal(atom4)-2": {
+        "@signal(atom4)-0": {},
+        "@signal(atom4)-1": {},
+      },
+      "atom1": {},
+      "atom3": {},
+    },
+  },
+  "Test-:r1:": {
+    "atom4": {
+      "@signal(atom4)-0": {},
+      "@signal(atom4)-1": {},
+      "@signal(atom4)-2": {
+        "@signal(atom4)-0": {},
+        "@signal(atom4)-1": {},
+      },
+      "atom1": {},
+      "atom3": {},
+    },
+  },
+  "atom2": {},
+  "atom4": {
+    "@signal(atom4)-0": {},
+    "@signal(atom4)-1": {},
+    "@signal(atom4)-2": {
+      "@signal(atom4)-0": {},
+      "@signal(atom4)-1": {},
+    },
+    "atom1": {},
+    "atom3": {},
+  },
+}
+`;
+
+exports[`graph ecosystem getters 3`] = `
+{
+  "@signal(atom4)-0": {
+    "@signal(atom4)-2": {
+      "atom4": {
+        "Test-:r0:": {},
+        "Test-:r1:": {},
+      },
+    },
+    "atom4": {
+      "Test-:r0:": {},
+      "Test-:r1:": {},
+    },
+  },
+  "@signal(atom4)-1": {
+    "@signal(atom4)-2": {
+      "atom4": {
+        "Test-:r0:": {},
+        "Test-:r1:": {},
+      },
+    },
+    "atom4": {
+      "Test-:r0:": {},
+      "Test-:r1:": {},
+    },
+  },
+  "atom1": {
+    "atom4": {
+      "Test-:r0:": {},
+      "Test-:r1:": {},
+    },
+  },
+  "atom2": {},
+  "atom3": {
+    "atom4": {
+      "Test-:r0:": {},
+      "Test-:r1:": {},
+    },
+  },
+}
+`;
+
+exports[`graph getNode(atom) returns the instance 1`] = `
+{
+  "atom1": {
+    "className": "AtomInstance",
+    "observers": {
+      "ion1": {
+        "flags": 9,
+        "operation": "getNode",
+        "p": undefined,
+      },
+    },
+    "sources": {},
+    "state": 1,
+    "status": "Active",
+    "weight": 1,
+  },
+  "atom2": {
+    "className": "AtomInstance",
+    "observers": {
+      "ion1": {
+        "flags": 9,
+        "operation": "getNode",
+        "p": undefined,
+      },
+    },
+    "sources": {},
+    "state": 2,
+    "status": "Active",
+    "weight": 1,
+  },
+  "ion1": {
+    "className": "AtomInstance",
+    "observers": {},
+    "sources": {
+      "atom1": {
+        "flags": 9,
+        "operation": "getNode",
+        "p": undefined,
+      },
+      "atom2": {
+        "flags": 9,
+        "operation": "getNode",
+        "p": undefined,
+      },
+    },
+    "state": 3,
+    "status": "Active",
+    "weight": 3,
+  },
+}
+`;
+
+exports[`graph on reevaluation, get() updates the graph 1`] = `
+{
+  "a": {
+    "className": "AtomInstance",
+    "observers": {
+      "d": {
+        "flags": 1,
+        "operation": "injectAtomValue",
+        "p": undefined,
+      },
+    },
+    "sources": {},
+    "state": "a",
+    "status": "Active",
+    "weight": 1,
+  },
+  "b-["b"]": {
+    "className": "AtomInstance",
+    "observers": {
+      "d": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "sources": {},
+    "state": "b",
+    "status": "Active",
+    "weight": 1,
+  },
+  "d": {
+    "className": "AtomInstance",
+    "observers": {},
+    "sources": {
+      "a": {
+        "flags": 1,
+        "operation": "injectAtomValue",
+        "p": undefined,
+      },
+      "b-["b"]": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "state": "ab",
+    "status": "Active",
+    "weight": 3,
+  },
+}
+`;
+
+exports[`graph on reevaluation, get() updates the graph 2`] = `
+{
+  "a": {
+    "className": "AtomInstance",
+    "observers": {
+      "d": {
+        "flags": 1,
+        "operation": "injectAtomValue",
+        "p": undefined,
+      },
+    },
+    "sources": {},
+    "state": "a",
+    "status": "Active",
+    "weight": 1,
+  },
+  "b-["b"]": {
+    "className": "AtomInstance",
+    "observers": {},
+    "sources": {},
+    "state": "b",
+    "status": "Stale",
+    "weight": 1,
+  },
+  "c": {
+    "className": "AtomInstance",
+    "observers": {
+      "d": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "sources": {},
+    "state": "c",
+    "status": "Active",
+    "weight": 1,
+  },
+  "d": {
+    "className": "AtomInstance",
+    "observers": {},
+    "sources": {
+      "a": {
+        "flags": 1,
+        "operation": "injectAtomValue",
+        "p": undefined,
+      },
+      "c": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "state": "ac",
+    "status": "Active",
+    "weight": 3,
+  },
+}
+`;

--- a/packages/react/test/integrations/graph.test.tsx
+++ b/packages/react/test/integrations/graph.test.tsx
@@ -1,0 +1,314 @@
+import { fireEvent } from '@testing-library/dom'
+import { act } from '@testing-library/react'
+import {
+  api,
+  atom,
+  Ecosystem,
+  EvaluationReason,
+  injectAtomInstance,
+  injectAtomValue,
+  injectEcosystem,
+  injectMappedSignal,
+  injectRef,
+  injectSignal,
+  ion,
+  NodeOf,
+  useAtomInstance,
+  useAtomValue,
+} from '@zedux/react'
+import React from 'react'
+import { ecosystem, getNodes, snapshotNodes } from '../utils/ecosystem'
+import { renderInEcosystem } from '../utils/renderInEcosystem'
+import { Eventless } from '@zedux/react/utils'
+import { mockConsole } from '../utils/console'
+
+const atom1 = atom('atom1', () => 1)
+const atom2 = atom('atom2', () => 2)
+const atom3 = atom('atom3', () => 3)
+
+const atom4 = atom('atom4', () => {
+  const switchSignal = injectSignal(true)
+  const sumSignal = injectSignal(0)
+  const signal = injectMappedSignal({
+    switch: switchSignal,
+    sum: sumSignal,
+  })
+  const { get } = injectEcosystem()
+
+  const one = get(atom1)
+  const two = switchSignal.get() ? get(atom2) : get(atom3)
+
+  // won't cause a reevaluation loop
+  sumSignal.set(one + two)
+
+  return api(signal).setExports({
+    toggle: () => switchSignal.set(val => !val),
+  })
+})
+
+describe('graph', () => {
+  test('ecosystem getters', async () => {
+    jest.useFakeTimers()
+
+    function Test() {
+      const { sum } = useAtomValue(atom4)
+      const { toggle } = useAtomInstance(atom4).exports
+
+      return (
+        <>
+          <div data-testid="sum">{sum}</div>
+          <button onClick={toggle}>toggle</button>
+        </>
+      )
+    }
+
+    const { findByTestId, findByText } = renderInEcosystem(<Test />)
+
+    const div = await findByTestId('sum')
+    expect(div).toHaveTextContent('3')
+
+    const expectedEdges = {
+      flags: Eventless,
+      operation: 'get',
+    }
+
+    const nodes = getNodes()
+
+    expect(nodes.atom1).toEqual(
+      expect.objectContaining({
+        observers: {
+          atom4: expectedEdges,
+        },
+      })
+    )
+
+    expect(nodes.atom2).toEqual(
+      expect.objectContaining({
+        observers: {
+          atom4: expectedEdges,
+        },
+      })
+    )
+
+    expect(nodes.atom3).toBeUndefined()
+
+    expect(
+      [...ecosystem.n.get('atom4')!.s.keys()].map(node => node.id)
+    ).toEqual([
+      '@signal(atom4)-0',
+      '@signal(atom4)-1',
+      '@signal(atom4)-2',
+      'atom1',
+      'atom2',
+    ])
+
+    const button = await findByText('toggle')
+
+    act(() => {
+      fireEvent.click(button)
+      jest.runAllTimers()
+    })
+
+    const nodes2 = getNodes()
+
+    expect(div).toHaveTextContent('4')
+
+    expect(nodes2.atom1).toEqual(
+      expect.objectContaining({
+        observers: {
+          atom4: expectedEdges,
+        },
+      })
+    )
+
+    expect(nodes2.atom2).toEqual(
+      expect.objectContaining({
+        observers: {},
+      })
+    )
+
+    expect(nodes2.atom3).toEqual(
+      expect.objectContaining({
+        observers: {
+          atom4: expectedEdges,
+        },
+      })
+    )
+
+    expect(nodes2.atom4).toEqual(
+      expect.objectContaining({
+        sources: {
+          '@signal(atom4)-0': expect.any(Object),
+          '@signal(atom4)-1': expect.any(Object),
+          '@signal(atom4)-2': expect.any(Object),
+          atom1: expect.any(Object),
+          atom3: expect.any(Object),
+        },
+      })
+    )
+
+    expect(ecosystem.viewGraph()).toMatchSnapshot()
+    expect(ecosystem.viewGraph('bottom-up')).toMatchSnapshot()
+    expect(ecosystem.viewGraph('top-down')).toMatchSnapshot()
+  })
+
+  test('getNode(atom) returns the instance', () => {
+    const evaluations: number[] = []
+
+    const ion1 = ion('ion1', ({ getNode }) => {
+      const instance1 = getNode(atom1)
+      const instance2 = getNode(atom2)
+
+      evaluations.push(instance1.getOnce())
+
+      return api(instance1.getOnce() + instance2.getOnce()).setExports({
+        set: (val: number) => getNode(atom1).set(val + 1),
+      })
+    })
+
+    const ionInstance = ecosystem.getNode(ion1)
+
+    expect(ecosystem.findAll()).toEqual({
+      atom1: expect.any(Object),
+      atom2: expect.any(Object),
+      ion1: expect.any(Object),
+    })
+
+    snapshotNodes()
+    expect(evaluations).toEqual([1])
+
+    ionInstance.exports.set(11)
+
+    expect(evaluations).toEqual([1])
+    expect(ionInstance.get()).toBe(3)
+    expect(ecosystem.getNode(atom1).get()).toBe(12)
+  })
+
+  test('on reevaluation, get() updates the graph', () => {
+    jest.useFakeTimers()
+    let useB = true
+    const atomA = atom('a', () => 'a')
+    const atomB = atom('b', (param: string) => param)
+    const atomC = atom('c', 'c')
+    const atomD = ion('d', ({ get }) => {
+      const a = injectAtomValue(atomA)
+      const b = useB ? get(atomB, ['b']) : get(atomC)
+
+      return a + b
+    })
+
+    const instance = ecosystem.getInstance(atomD)
+
+    snapshotNodes()
+
+    useB = false
+    instance.invalidate()
+    jest.runAllTimers()
+
+    snapshotNodes()
+  })
+
+  test('atom instances can be passed as atom params', () => {
+    const instance1 = ecosystem.getInstance(atom1)
+
+    const testAtom = atom('test', (instance: NodeOf<typeof atom1>) => {
+      const subRef = injectRef(false)
+      const asDep = injectAtomInstance(instance) // register static dep
+      const { get } = injectEcosystem()
+
+      if (subRef.current) get(asDep)
+
+      return api(asDep.getOnce()).setExports({ subRef })
+    })
+
+    const instance = ecosystem.getInstance(testAtom, [instance1])
+
+    expect(instance.get()).toBe(1)
+
+    instance1.set(2)
+
+    expect(instance.get()).toBe(1)
+
+    instance.exports.subRef.current = true
+    instance.invalidate()
+
+    expect(instance.get()).toBe(2)
+
+    instance1.set(3)
+
+    expect(instance.get()).toBe(3)
+  })
+
+  test('simultaneously-scheduled selector evaluations cause one evaluation', () => {
+    const atom1 = atom('1', 'a')
+    const atom2 = ion('2', ({ get }) => get(atom1) + 'b')
+
+    let why: EvaluationReason[] | undefined
+
+    const selector1 = ({ get }: Ecosystem) => {
+      why = ecosystem.why()
+      return get(atom1) + get(atom2)
+    }
+
+    const selectorInstance = ecosystem.getNode(selector1)
+    const atomInstance = ecosystem.getInstance(atom1)
+
+    expect(selectorInstance.v).toBe('aab')
+    expect(why).toHaveLength(0)
+
+    atomInstance.set('aa')
+
+    expect(selectorInstance.v).toBe('aaaab')
+    expect(why).toHaveLength(2)
+    expect(why).toEqual([
+      {
+        newState: 'aa',
+        oldState: 'a',
+        operation: 'get',
+        reasons: [],
+        source: expect.any(Object),
+        type: 'change',
+      },
+      {
+        newState: 'aab',
+        oldState: 'ab',
+        operation: 'get',
+        reasons: [
+          {
+            newState: 'aa',
+            oldState: 'a',
+            operation: 'get',
+            reasons: [],
+            source: expect.any(Object),
+            type: 'change',
+          },
+        ],
+        source: expect.any(Object),
+        type: 'change',
+      },
+    ])
+  })
+
+  test('signals still propagate to atom observers if atom evaluation errors', () => {
+    const mock = mockConsole('error')
+    const propagatingAtom = atom('propagating', () => {
+      const signal = injectSignal(0)
+
+      if (signal.get() === 1) throw new Error('test')
+
+      return api(signal).setExports({ change: () => signal.set(1) })
+    })
+
+    const receivingAtom = atom('receiving', () =>
+      injectAtomValue(propagatingAtom)
+    )
+
+    const receivingNode = ecosystem.getNode(receivingAtom)
+    const propagatingNode = ecosystem.getNode(propagatingAtom)
+
+    expect(receivingNode.get()).toBe(0)
+    expect(() => propagatingNode.exports.change()).toThrowError(/test/)
+    expect(receivingNode.get()).toBe(1)
+    expect(mock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Description

During some initial playtesting with the new scoped atoms feature, I found one of the primary pain points with it is that exported functions of scoped atoms have to remember to wrap re-getting of atoms they depend on in `ecosystem.withScope`. We can do this automatically.

Wrap exported arrow functions (only arrow functions - functions with a `.prototype` can be constructed with the `new` keyword, we don't want to mess with those) as well as `injectCallback` functions in `ecosystem.withScope` calls _if_ their containing atom is scoped.

Also wrap exports in `ecosystem.batch` while we're at it. We had this before, but the logic was in the AtomInstance class, which was wrong. So we removed it and it's been on my todo list to revisit. Now it's revisited.

Add a `wrap` option as the second argument to `api.addExports` and `api.setExports` to prevent this wrapping. Useful if the exported function has static properties attached to the function object (we could `Object.assign` those into our wrapper function, but that's unnecessary constant overhead for such a rare case).