### PR TITLE
feat(atoms)!: rename atom flags to tags

### DIFF
--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -91,7 +91,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
    */
   public ecosystem = this
 
-  public flags?: string[]
+  public tags?: string[]
   public hydration?: Record<string, any>
   public id: string
   public onReady: EcosystemConfig<Context>['onReady']
@@ -183,9 +183,9 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
 
   constructor(config: EcosystemConfig<Context>) {
     if (DEV) {
-      if (config.flags && !Array.isArray(config.flags)) {
+      if (config.tags && !Array.isArray(config.tags)) {
         throw new TypeError(
-          "Zedux: The Ecosystem's `flags` property must be an array of strings"
+          "Zedux: The Ecosystem's `tags` property must be an array of strings"
         )
       }
 
@@ -258,12 +258,12 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
    * this.
    *
    * Atoms can be excluded from dehydration by passing `exclude` and/or
-   * `excludeFlags` options:
+   * `excludeTags` options:
    *
    * ```ts
    * myEcosystem.dehydrate({
    *   exclude: [myAtom, 'my-fuzzy-search-string'],
-   *   excludeFlags: ['no-ssr']
+   *   excludeTags: ['no-ssr']
    * })
    * ```
    *
@@ -272,12 +272,12 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
    * string (case-insensitive)
    *
    * You can dehydrate only a subset of all atoms by passing `include` and/or
-   * `includeFlags` options:
+   * `includeTags` options:
    *
    * ```ts
    * myEcosystem.dehydrate({
    *   include: [myAtom, 'my-fuzzy-search-string'],
-   *   includeFlags: ['ssr']
+   *   includeTags: ['ssr']
    * })
    * ```
    *

--- a/packages/atoms/src/classes/GraphNode.ts
+++ b/packages/atoms/src/classes/GraphNode.ts
@@ -264,9 +264,9 @@ export abstract class GraphNode<G extends NodeGenerics = AnyNodeGenerics>
     const lowerCaseId = id.toLowerCase()
     const {
       exclude = [],
-      excludeFlags = [],
+      excludeTags = [],
       include = [],
-      includeFlags = [],
+      includeTags = [],
     } = typeof options === 'object' && !is(options, AtomTemplateBase)
       ? (options as NodeFilterOptions)
       : { include: options ? [options as string | AnyAtomTemplate] : [] }
@@ -277,18 +277,18 @@ export abstract class GraphNode<G extends NodeGenerics = AnyNodeGenerics>
           ? lowerCaseId.includes(templateOrKey.toLowerCase())
           : (t?.key && (templateOrKey as AtomTemplateBase)?.key === t?.key) ||
             templateOrKey === t
-      ) || excludeFlags.some(flag => t.flags?.includes(flag))
+      ) || excludeTags.some(tag => t.tags?.includes(tag))
 
     return (
       !isExcluded &&
-      ((!include.length && !includeFlags.length) ||
+      ((!include.length && !includeTags.length) ||
         include.some(templateOrKey =>
           typeof templateOrKey === 'string'
             ? lowerCaseId.includes(templateOrKey.toLowerCase())
             : (t?.key && (templateOrKey as AtomTemplateBase)?.key === t?.key) ||
               templateOrKey === t
         ) ||
-        includeFlags.some(flag => t.flags?.includes(flag)))
+        includeTags.some(tag => t.tags?.includes(tag)))
     )
   }
 

--- a/packages/atoms/src/classes/templates/AtomTemplateBase.ts
+++ b/packages/atoms/src/classes/templates/AtomTemplateBase.ts
@@ -16,7 +16,7 @@ export abstract class AtomTemplateBase<
   public static $$typeof = Symbol.for(`${prefix}/AtomTemplateBase`)
 
   public readonly dehydrate?: AtomConfig<G['State']>['dehydrate']
-  public readonly flags?: string[]
+  public readonly tags?: string[]
   public readonly hydrate?: AtomConfig<G['State']>['hydrate']
   public readonly manualHydration?: boolean
   public readonly ttl?: number

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -28,7 +28,7 @@ export type AnyNonNullishValue = {}
 
 export interface AtomConfig<State = any> {
   dehydrate?: (state: State) => any
-  flags?: string[]
+  tags?: string[]
   hydrate?: (dehydratedState: unknown) => State
   manualHydration?: boolean
   ttl?: number
@@ -116,7 +116,7 @@ export interface EcosystemConfig<
   complexParams?: boolean
   context?: Context
   destroyOnUnmount?: boolean
-  flags?: string[]
+  tags?: string[]
   id?: string
   onReady?: (
     ecosystem: Ecosystem<Context>,
@@ -338,9 +338,9 @@ export interface MutableRefObject<T = any> {
 
 export interface NodeFilterOptions {
   exclude?: (AnyAtomTemplate | AtomSelectorOrConfig | string)[]
-  excludeFlags?: string[]
+  excludeTags?: string[]
   include?: (AnyAtomTemplate | AtomSelectorOrConfig | string)[]
-  includeFlags?: string[]
+  includeTags?: string[]
 }
 
 export type NodeFilter =

--- a/packages/atoms/src/utils/ecosystem.ts
+++ b/packages/atoms/src/utils/ecosystem.ts
@@ -171,21 +171,19 @@ export const getNode = <G extends AtomGenerics>(
 }
 
 const resolveAtom = <A extends AnyAtomTemplate>(
-  { flags, overrides }: Ecosystem,
+  { tags, overrides }: Ecosystem,
   template: A
 ) => {
   const override = overrides[template.key]
   const maybeOverriddenAtom = (override || template) as A
 
-  // to turn off flag checking, just don't pass a `flags` prop
-  if (flags) {
-    const badFlag = maybeOverriddenAtom.flags?.find(
-      flag => !flags.includes(flag)
-    )
+  // to turn off tag checking, just don't pass a `tags` prop
+  if (tags) {
+    const badTag = maybeOverriddenAtom.tags?.find(tag => !tags.includes(tag))
 
-    if (DEV && badFlag) {
+    if (DEV && badTag) {
       console.error(
-        `Zedux: encountered unsafe atom template "${template.key}" with flag "${badFlag}". This should be overridden in the current environment.`
+        `Zedux: encountered unsafe atom template "${template.key}" with tag "${badTag}". This should be overridden in the current environment.`
       )
     }
   }

--- a/packages/react/test/integrations/ecosystem.test.tsx
+++ b/packages/react/test/integrations/ecosystem.test.tsx
@@ -298,12 +298,12 @@ describe('ecosystem', () => {
     ecosystem.destroy(true)
   })
 
-  test('flags', () => {
+  test('tags', () => {
     const mock = mockConsole('error')
-    const atomA = atom('a', () => 1, { flags: ['a'] })
+    const atomA = atom('a', () => 1, { tags: ['a'] })
     const atomB = atom('b', () => 2)
 
-    const ecosystem = createEcosystem({ flags: ['b'], id: 'flags' })
+    const ecosystem = createEcosystem({ tags: ['b'], id: 'tags' })
     ecosystem.getInstance(atomA)
 
     expect(mock).toHaveBeenCalledTimes(1)

--- a/packages/react/test/stores/ssr.test.tsx
+++ b/packages/react/test/stores/ssr.test.tsx
@@ -145,8 +145,8 @@ describe('ssr', () => {
     expect(ecosystem.dehydrate({ exclude: ['1', atom2] })).toEqual({})
   })
 
-  test('`ecosystem.dehydrate({ excludeFlags })` excludes atoms from dehydration', () => {
-    const atom1 = atom('1', 'a', { flags: ['exclude-me'] })
+  test('`ecosystem.dehydrate({ excludeTags })` excludes atoms from dehydration', () => {
+    const atom1 = atom('1', 'a', { tags: ['exclude-me'] })
     const atom2 = ion('2', ({ get }) => get(atom1) + 'b')
 
     ecosystem.getInstance(atom2)
@@ -156,16 +156,14 @@ describe('ssr', () => {
       2: 'ab',
     })
 
-    expect(ecosystem.dehydrate({ excludeFlags: ['exclude-me'] })).toEqual({
+    expect(ecosystem.dehydrate({ excludeTags: ['exclude-me'] })).toEqual({
       2: 'ab',
     })
 
-    expect(ecosystem.dehydrate({ excludeFlags: ['nonexistent-flag'] })).toEqual(
-      {
-        1: 'a',
-        2: 'ab',
-      }
-    )
+    expect(ecosystem.dehydrate({ excludeTags: ['nonexistent-tag'] })).toEqual({
+      1: 'a',
+      2: 'ab',
+    })
   })
 
   test('`ecosystem.dehydrate({ include })` includes atoms in dehydration', () => {
@@ -201,8 +199,8 @@ describe('ssr', () => {
     })
   })
 
-  test('`ecosystem.dehydrate({ includeFlags })` includes atoms in dehydration', () => {
-    const atom1 = atom('1', 'a', { flags: ['include-me'] })
+  test('`ecosystem.dehydrate({ includeTags })` includes atoms in dehydration', () => {
+    const atom1 = atom('1', 'a', { tags: ['include-me'] })
     const atom2 = ion('2', ({ get }) => get(atom1) + 'b')
 
     ecosystem.getInstance(atom2)
@@ -212,23 +210,23 @@ describe('ssr', () => {
       2: 'ab',
     })
 
-    expect(ecosystem.dehydrate({ includeFlags: ['include-me'] })).toEqual({
+    expect(ecosystem.dehydrate({ includeTags: ['include-me'] })).toEqual({
       1: 'a',
     })
 
-    expect(ecosystem.dehydrate({ includeFlags: ['nonexistent-flag'] })).toEqual(
+    expect(ecosystem.dehydrate({ includeTags: ['nonexistent-tag'] })).toEqual(
       {}
     )
   })
 
   test('excludes take precedence over includes', () => {
-    const atom1 = atom('1', 'a', { flags: ['include-me', 'exclude-me'] })
+    const atom1 = atom('1', 'a', { tags: ['include-me', 'exclude-me'] })
     const atom2 = ion('2', ({ get }) => get(atom1) + 'b')
 
     ecosystem.getInstance(atom2)
 
     expect(
-      ecosystem.dehydrate({ excludeFlags: ['exclude-me'], include: [atom1] })
+      ecosystem.dehydrate({ excludeTags: ['exclude-me'], include: [atom1] })
     ).toEqual({})
 
     expect(ecosystem.dehydrate({ exclude: [atom2], include: [atom2] })).toEqual(
@@ -239,7 +237,7 @@ describe('ssr', () => {
       ecosystem.dehydrate({
         exclude: [atom2],
         include: [atom2],
-        includeFlags: ['include-me'],
+        includeTags: ['include-me'],
       })
     ).toEqual({
       1: 'a',
@@ -248,9 +246,9 @@ describe('ssr', () => {
     expect(
       ecosystem.dehydrate({
         exclude: [atom2],
-        excludeFlags: ['exclude-me'],
+        excludeTags: ['exclude-me'],
         include: [atom2],
-        includeFlags: ['include-me'],
+        includeTags: ['include-me'],
       })
     ).toEqual({})
   })

--- a/packages/react/test/units/Ecosystem.test.tsx
+++ b/packages/react/test/units/Ecosystem.test.tsx
@@ -16,9 +16,9 @@ describe('Ecosystem', () => {
     expect(instance.v).toBe(getValue)
   })
 
-  test('flags must be an array', () => {
-    // @ts-expect-error flags must be an array
-    expect(() => createEcosystem({ flags: { a: true } })).toThrowError(
+  test('tags must be an array', () => {
+    // @ts-expect-error tags must be an array
+    expect(() => createEcosystem({ tags: { a: true } })).toThrowError(
       /must be an array/i
     )
   })
@@ -30,13 +30,13 @@ describe('Ecosystem', () => {
     )
   })
 
-  test('atom override flags are also respected', () => {
+  test('atom override tags are also respected', () => {
     const mock = mockConsole('error')
-    const atom1 = atom('1', 'a', { flags: ['test-flag'] })
+    const atom1 = atom('1', 'a', { tags: ['test-tag'] })
     const atom1Override = atom1.override('aa')
 
     const testEcosystem = createEcosystem({
-      flags: [],
+      tags: [],
       overrides: [atom1Override],
     })
 


### PR DESCRIPTION
## Description

Atoms have a feature called "flags". These are arbitrary strings that add a list of searchable attributes to an atom. In other words, tags.

I'm not sure why this feature was ever called "flags". Possibly 'cause I created them around the same time I added the bitwise edge flags. Or maybe 'cause one of their purposes is to raise a warning ("flag") for unsafe atoms.

Regardless, tags is a more appropriate name for them.

### Breaking Change

This feature is probably not used much, but renaming the config option is still, of course, a breaking change.

```ts
- atom('myAtomKey', myStateFactory, { flags: ['browser-only'] }) // before
+ atom('myAtomKey', myStateFactory, { tags: ['browser-only'] }) // after
```