### PR TITLE
feat!: remove atoms package's dependency on core package

### DIFF
--- a/packages/atoms/README.md
+++ b/packages/atoms/README.md
@@ -1,6 +1,6 @@
 # `@zedux/atoms`
 
-The core atomic model of Zedux. This is a standalone package, meaning it's the only package you need to install to use Zedux's atomic model. It includes the Zedux core store package as well as all APIs related to signals, atoms, and ecosystems.
+The core atomic model of Zedux. This is a standalone package, meaning it's the only package you need to install to use Zedux's atomic model. It includes all APIs related to signals, atoms, and ecosystems.
 
 This package is framework-independent, though many of its APIs are heavily inspired by React.
 
@@ -15,8 +15,6 @@ pnpm add @zedux/atoms # pnpm
 ```
 
 If you're using React, you probably want to install the [`@zedux/react` package](https://www.npmjs.com/package/@zedux/react) instead, which includes everything from this package and more.
-
-This package has a direct dependency on the [`@zedux/core` package](https://www.npmjs.com/package/@zedux/core). If you install that directly, ensure its version exactly matches your `@zedux/atoms` version to prevent installing duplicate packages.
 
 ## Usage
 
@@ -41,11 +39,7 @@ instance.destroy()
 
 ## Exports
 
-This package includes and re-exports everything from the following package:
-
-- [`@zedux/core`](https://www.npmjs.com/package/@zedux/core)
-
-On top of this, `@zedux/atoms` exports the following APIs and many helper types for working with them in TypeScript:
+`@zedux/atoms` exports the following APIs and many helper types for working with them in TypeScript:
 
 ### Classes
 
@@ -86,11 +80,10 @@ On top of this, `@zedux/atoms` exports the following APIs and many helper types 
 
 ### Utils
 
-- [`getEcosystem()`](https://omnistac.github.io/zedux/docs/api/utils/internal-utils#getecosystem)
+- [`getDefaultEcosystem()`](https://omnistac.github.io/zedux/docs/api/utils/getDefaultEcosystem)
 - [`getInternals()`](https://omnistac.github.io/zedux/docs/api/utils/internal-utils#getinternals)
 - [`setInternals()`](https://omnistac.github.io/zedux/docs/api/utils/internal-utils#setinternals)
 - [`untrack()`](https://omnistac.github.io/zedux/docs/api/utils/internal-utils#untrack)
-- [`wipe()`](https://omnistac.github.io/zedux/docs/api/utils/internal-utils#wipe)
 
 ## For Authors
 

--- a/packages/atoms/package.json
+++ b/packages/atoms/package.json
@@ -9,9 +9,6 @@
   "bugs": {
     "url": "https://github.com/Omnistac/zedux/issues"
   },
-  "dependencies": {
-    "@zedux/core": "2.0.0-beta.4"
-  },
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",

--- a/packages/atoms/src/classes/AtomApi.ts
+++ b/packages/atoms/src/classes/AtomApi.ts
@@ -1,11 +1,10 @@
-import { is } from '@zedux/core'
 import {
   AtomInstanceTtl,
   AtomApiGenerics,
   Prettify,
   ExportsConfig,
 } from '@zedux/atoms/types/index'
-import { INITIALIZING, prefix } from '@zedux/atoms/utils/general'
+import { INITIALIZING, is, prefix } from '@zedux/atoms/utils/general'
 import { getEvaluationContext } from '../utils/evaluationContext'
 
 const wrapExports = <T extends Record<string, any>>(

--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -1,4 +1,3 @@
-import { is, isPlainObject, Job } from '@zedux/core'
 import {
   AnyAtomInstance,
   AnyAtomTemplate,
@@ -31,6 +30,7 @@ import {
   EcosystemEvents,
   InternalEvaluationReason,
   GetNode,
+  Job,
 } from '../types/index'
 import {
   External,
@@ -48,6 +48,7 @@ import {
   RUN_START,
   RESET_START,
   RUN_END,
+  is,
 } from '../utils/general'
 import { IdGenerator } from './IdGenerator'
 import { Scheduler } from './Scheduler'
@@ -552,10 +553,10 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
     dehydratedState: Record<string, any>,
     config?: { retroactive?: boolean }
   ) {
-    if (DEV && !isPlainObject(dehydratedState)) {
-      throw new TypeError(
-        'Zedux: ecosystem.hydrate() - first parameter must be a plain object'
-      )
+    if (DEV && (!dehydratedState || typeof dehydratedState !== 'object')) {
+      throw new TypeError('Zedux: Expected an object', {
+        cause: dehydratedState,
+      })
     }
 
     this.hydration = { ...this.hydration, ...dehydratedState }

--- a/packages/atoms/src/classes/GraphNode.ts
+++ b/packages/atoms/src/classes/GraphNode.ts
@@ -6,12 +6,12 @@ import {
   GraphEdge,
   GraphEdgeConfig,
   InternalEvaluationReason,
+  Job,
   ListenerConfig,
   NodeFilter,
   NodeFilterOptions,
   NodeGenerics,
 } from '@zedux/atoms/types/index'
-import { is, Job } from '@zedux/core'
 import { Ecosystem } from './Ecosystem'
 import {
   ACTIVE,
@@ -21,6 +21,7 @@ import {
   ExplicitExternal,
   INITIALIZING,
   InternalLifecycleStatus,
+  is,
   statusMap,
 } from '../utils/general'
 import { AtomTemplateBase } from './templates/AtomTemplateBase'

--- a/packages/atoms/src/classes/IdGenerator.ts
+++ b/packages/atoms/src/classes/IdGenerator.ts
@@ -1,4 +1,3 @@
-import { isPlainObject } from '@zedux/core'
 import { GraphNode } from './GraphNode'
 
 /**
@@ -49,7 +48,9 @@ export class IdGenerator {
     return JSON.stringify(params, (_, param) => {
       if (!param) return param
       if (param.izn) return (param as GraphNode).id
-      if (!isPlainObject(param)) {
+
+      // if the prototype has no prototype, it's likely not a plain object:
+      if (Object.getPrototypeOf(param.constructor.prototype)) {
         if (!acceptComplexParams || Array.isArray(param)) return param
         if (typeof param === 'function') return this.cacheFn(param)
         if (typeof param === 'object') return this.cacheClass(param)

--- a/packages/atoms/src/classes/MappedSignal.ts
+++ b/packages/atoms/src/classes/MappedSignal.ts
@@ -1,10 +1,10 @@
-import { Settable } from '@zedux/core'
 import {
   AnyNodeGenerics,
   AtomGenerics,
   InternalEvaluationReason,
   Mutatable,
   SendableEvents,
+  Settable,
   Transaction,
   UndefinedEvents,
 } from '../types/index'

--- a/packages/atoms/src/classes/Scheduler.ts
+++ b/packages/atoms/src/classes/Scheduler.ts
@@ -1,5 +1,10 @@
-import { Job, Scheduler as SchedulerInterface } from '@zedux/core'
+import { Job } from '@zedux/atoms/types/index'
 import { Ecosystem } from './Ecosystem'
+
+// temporarily copied from @zedux/core. TODO: remove
+interface SchedulerInterface {
+  scheduleNow(newJob: Job): void
+}
 
 export class Scheduler implements SchedulerInterface {
   /**

--- a/packages/atoms/src/classes/Signal.ts
+++ b/packages/atoms/src/classes/Signal.ts
@@ -1,9 +1,9 @@
-import { Settable } from '@zedux/core'
 import {
   AtomGenerics,
   Mutatable,
   NodeGenerics,
   SendableEvents,
+  Settable,
   Transaction,
   UndefinedEvents,
 } from '../types/index'

--- a/packages/atoms/src/classes/instances/AtomInstance.ts
+++ b/packages/atoms/src/classes/instances/AtomInstance.ts
@@ -1,4 +1,3 @@
-import { is, Observable, Settable } from '@zedux/core'
 import {
   Mutatable,
   SendableEvents,
@@ -14,6 +13,7 @@ import {
   DehydrationOptions,
   AnyAtomGenerics,
   InternalEvaluationReason,
+  Settable,
 } from '@zedux/atoms/types/index'
 import {
   ACTIVE,
@@ -22,6 +22,7 @@ import {
   INITIALIZING,
   INVALIDATE,
   Invalidate,
+  is,
   prefix,
   PROMISE_CHANGE,
   PromiseChange,
@@ -533,7 +534,9 @@ export class AtomInstance<
     }
 
     // ttl is an observable; destroy as soon as it emits
-    const subscription = (ttl as Observable).subscribe(() => {
+    const subscription = (
+      ttl as { subscribe: (cb: () => void) => { unsubscribe: () => void } }
+    ).subscribe(() => {
       this.c = undefined
       this.destroy()
     })

--- a/packages/atoms/src/classes/proxies.ts
+++ b/packages/atoms/src/classes/proxies.ts
@@ -1,5 +1,4 @@
-import { RecursivePartial } from '@zedux/core'
-import { Transaction, MutatableTypes } from '../types/index'
+import { Transaction, MutatableTypes, RecursivePartial } from '../types/index'
 
 export type ParentProxy<State> = {
   t: Transaction[]

--- a/packages/atoms/src/index.ts
+++ b/packages/atoms/src/index.ts
@@ -20,12 +20,12 @@ import {
   scheduleStaticDependents,
 } from './utils/graph'
 
-export * from '@zedux/core'
 export * from './classes/index'
 export * from './factories/index'
 export * from './injectors/index'
 export * from './types/index'
 export { untrack } from './utils/evaluationContext'
+export { is } from './utils/general'
 
 type Internals = { c: EvaluationContext; g: Ecosystem }
 

--- a/packages/atoms/src/injectors/injectPromise.ts
+++ b/packages/atoms/src/injectors/injectPromise.ts
@@ -1,4 +1,3 @@
-import { detailedTypeof, RecursivePartial } from '@zedux/core'
 import { api } from '../factories/api'
 import {
   getErrorPromiseState,
@@ -13,6 +12,7 @@ import {
   MapEvents,
   None,
   PromiseState,
+  RecursivePartial,
 } from '../types/index'
 import { injectEffect } from './injectEffect'
 import { injectMemo } from './injectMemo'
@@ -134,9 +134,8 @@ export const injectPromise: {
 
     if (DEV && typeof promise?.then !== 'function') {
       throw new TypeError(
-        `Zedux: injectPromise expected callback to return a promise. Received ${detailedTypeof(
-          promise
-        )}`
+        'Zedux: injectPromise expected callback to return a promise',
+        { cause: promise }
       )
     }
 

--- a/packages/atoms/src/injectors/injectSelf.ts
+++ b/packages/atoms/src/injectors/injectSelf.ts
@@ -1,7 +1,7 @@
-import { is } from '@zedux/core'
 import { AnyAtomInstance, PartialAtomInstance } from '../types/index'
 import { getEvaluationContext } from '../utils/evaluationContext'
 import { AtomInstance } from '../classes/instances/AtomInstance'
+import { is } from '../utils/general'
 
 /**
  * An unrestricted injector (can actually be used in loops and if statements).

--- a/packages/atoms/src/types/events.ts
+++ b/packages/atoms/src/types/events.ts
@@ -1,4 +1,3 @@
-import { RecursivePartial } from '@zedux/core'
 import { GraphNode } from '../classes/GraphNode'
 import {
   AnyNodeGenerics,
@@ -8,6 +7,7 @@ import {
   ListenerConfig,
   NodeGenerics,
   Prettify,
+  RecursivePartial,
 } from './index'
 
 export type CatchAllListener<G extends NodeGenerics> = (

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -1,4 +1,3 @@
-import { Observable, Settable } from '@zedux/core'
 import { AtomTemplateBase } from '../classes/templates/AtomTemplateBase'
 import { AtomApi } from '../classes/AtomApi'
 import { Ecosystem } from '../classes/Ecosystem'
@@ -319,6 +318,31 @@ export type IonStateFactory<G extends Omit<AtomGenerics, 'Node' | 'Template'>> =
     ...params: G['Params']
   ) => AtomApi<AtomGenericsToAtomApiGenerics<G>> | Signal<G> | G['State']
 
+export interface Job {
+  /**
+   * `W`eight - the weight of the node (for EvaluateGraphNode jobs).
+   * UpdateExternalDependent jobs also use this to track the order they were
+   * added as dependents, since that's the order they should evaluate in.
+   */
+  W?: number
+
+  /**
+   * `j`ob - the actual task to run.
+   */
+  j: () => void
+
+  /**
+   * `T`ype - the job type. Different types get different priorities in the
+   * scheduler.
+   *
+   * 0 - UpdateStore
+   * 1 - InformSubscribers
+   * 2 - EvaluateGraphNode
+   * 3 - UpdateExternalDependent
+   */
+  T: 0 | 1 | 2 | 3
+}
+
 export type LifecycleStatus = 'Active' | 'Destroyed' | 'Initializing' | 'Stale'
 
 export interface ListenerConfig {
@@ -333,6 +357,10 @@ export type MaybeCleanup = Cleanup | void
 
 export interface MutableRefObject<T = any> {
   current: T
+}
+
+export interface Observable<T = any> {
+  subscribe(subscriber: (value: T) => any): { unsubscribe: () => void }
 }
 
 export interface NodeFilterOptions {
@@ -389,6 +417,10 @@ export interface PromiseState<T> {
 
 export type PromiseStatus = 'error' | 'loading' | 'success'
 
+export type RecursivePartial<T> = T extends Record<string, any>
+  ? { [P in keyof T]?: RecursivePartial<T[P]> }
+  : T
+
 export type Ref<T = any> = MutableRefObject<T>
 
 export interface RefObject<T = any> {
@@ -402,6 +434,10 @@ export type Selectable<State = any, Params extends any[] = any> =
       State: State
       Template: AtomSelectorOrConfig<State, Params>
     }>
+
+export type Settable<State = any, StateIn = State> =
+  | ((state: StateIn) => State)
+  | State
 
 export type StateHookTuple<State, Exports> = [
   State,

--- a/packages/atoms/src/utils/ecosystem.ts
+++ b/packages/atoms/src/utils/ecosystem.ts
@@ -1,4 +1,3 @@
-import { detailedTypeof, is } from '@zedux/core'
 import {
   AnyAtomInstance,
   AnyAtomTemplate,
@@ -13,7 +12,7 @@ import type { Ecosystem } from '../classes/Ecosystem'
 import { GraphNode } from '../classes/GraphNode'
 import { getSelectorKey, SelectorInstance } from '../classes/SelectorInstance'
 import { getEvaluationContext } from './evaluationContext'
-import { DESTROYED } from './general'
+import { DESTROYED, is } from './general'
 
 const getContextualizedId = (
   ecosystem: Ecosystem,
@@ -61,11 +60,9 @@ export const getNode = <G extends AtomGenerics>(
 
   if (DEV) {
     if (typeof params !== 'undefined' && !Array.isArray(params)) {
-      throw new TypeError(
-        `Zedux: Expected atom params to be an array. Received ${detailedTypeof(
-          params
-        )}`
-      )
+      throw new TypeError('Zedux: Expected atom params to be an array', {
+        cause: params,
+      })
     }
   }
 
@@ -165,9 +162,9 @@ export const getNode = <G extends AtomGenerics>(
     }
   }
 
-  throw new TypeError(
-    `Zedux: Expected a template or node. Received ${detailedTypeof(template)}`
-  )
+  throw new TypeError('Zedux: Expected a template, selector, or graph node', {
+    cause: template,
+  })
 }
 
 const resolveAtom = <A extends AnyAtomTemplate>(

--- a/packages/atoms/src/utils/general.ts
+++ b/packages/atoms/src/utils/general.ts
@@ -88,6 +88,27 @@ export const compare = (nextDeps?: any[], prevDeps?: any[]) =>
 
 export const prefix = '@@zedux'
 
+/**
+ * is() - Checks if a value is an instance of a class
+ *
+ * We can't use instanceof 'cause that breaks across realms - e.g. when an atom
+ * instance is shared between a parent and child window, that instance's object
+ * reference will be different in both windows (since each window creates its
+ * own copy of Zedux).
+ *
+ * The classToCheck should have a static $$typeof property whose value is a
+ * symbol created with Symbol.for() (sharing the symbol reference across realms)
+ *
+ * This works no matter how deep the inheritance tree is for either object
+ * passed.
+ *
+ * @param val anything - the thing we're checking
+ * @param classToCheck a class with a static $$typeof property
+ * @returns boolean - whether val is an instanceof classToCheck
+ */
+export const is = (val: any, classToCheck: { $$typeof: symbol }): boolean =>
+  val?.constructor?.$$typeof === classToCheck.$$typeof
+
 export const makeReasonReadable = (
   reason: InternalEvaluationReason,
   node?: GraphNode,

--- a/packages/atoms/vite.config.ts
+++ b/packages/atoms/vite.config.ts
@@ -10,5 +10,6 @@ export default configureVite({
     },
   }),
   moduleName: 'ZeduxAtoms',
-  // don't add `@zedux/core` to globals - @zedux/atoms prod builds bundle it
+  // don't add `@zedux/core` to globals - if we go back to using the core
+  // package here, @zedux/atoms prod builds will bundle it
 })

--- a/packages/core/src/api/createStore.ts
+++ b/packages/core/src/api/createStore.ts
@@ -15,11 +15,10 @@ import {
   Subscriber,
   SubscriberObject,
   Scheduler,
-  Job,
   KnownHierarchyDescriptor,
 } from '../types'
 import { STORE_IDENTIFIER } from '../utils/general'
-import { HierarchyNode } from '../utils/types'
+import { HierarchyNode, Job } from '../utils/types'
 import { detailedTypeof } from './detailedTypeof'
 import { isPlainObject } from './isPlainObject'
 import { removeAllMeta } from './meta'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,5 @@
 import { Store } from './api/createStore'
+import { Job } from './utils/types'
 
 // Same workaround rxjs uses for Symbol.observable:
 declare global {
@@ -128,31 +129,6 @@ export type HierarchyDescriptor<State = any> =
   | Store<State>
   | Reducer<State>
   | null
-
-export interface Job {
-  /**
-   * `W`eight - the weight of the node (for EvaluateGraphNode jobs).
-   * UpdateExternalDependent jobs also use this to track the order they were
-   * added as dependents, since that's the order they should evaluate in.
-   */
-  W?: number
-
-  /**
-   * `j`ob - the actual task to run.
-   */
-  j: () => void
-
-  /**
-   * `T`ype - the job type. Different types get different priorities in the
-   * scheduler.
-   *
-   * 0 - UpdateStore
-   * 1 - InformSubscribers
-   * 2 - EvaluateGraphNode
-   * 3 - UpdateExternalDependent
-   */
-  T: 0 | 1 | 2 | 3
-}
 
 /**
  * After a store is created, TS knows the hierarchy shape and we can be more

--- a/packages/core/src/utils/types.ts
+++ b/packages/core/src/utils/types.ts
@@ -30,6 +30,31 @@ export interface Hierarchy {
   [key: string]: HierarchyNode
 }
 
+export interface Job {
+  /**
+   * `W`eight - the weight of the node (for EvaluateGraphNode jobs).
+   * UpdateExternalDependent jobs also use this to track the order they were
+   * added as dependents, since that's the order they should evaluate in.
+   */
+  W?: number
+
+  /**
+   * `j`ob - the actual task to run.
+   */
+  j: () => void
+
+  /**
+   * `T`ype - the job type. Different types get different priorities in the
+   * scheduler.
+   *
+   * 0 - UpdateStore
+   * 1 - InformSubscribers
+   * 2 - EvaluateGraphNode
+   * 3 - UpdateExternalDependent
+   */
+  T: 0 | 1 | 2 | 3
+}
+
 export interface NullNode extends HierarchyNodeBase {
   reducer?: undefined
   type: NullNodeType

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@zedux/atoms": "2.0.0-beta.4",
+    "@zedux/core": "2.0.0-beta.4",
     "immer": "^10.1.1"
   },
   "exports": {

--- a/packages/immer/src/ImmerStore.ts
+++ b/packages/immer/src/ImmerStore.ts
@@ -1,4 +1,4 @@
-import { Store } from '@zedux/atoms'
+import { Store } from '@zedux/core'
 import { Draft, produce } from 'immer'
 
 export class ImmerStore<State> extends Store<State> {

--- a/packages/immer/src/injectImmerStore.ts
+++ b/packages/immer/src/injectImmerStore.ts
@@ -3,10 +3,9 @@ import {
   injectMemo,
   injectSelf,
   InjectStoreConfig,
-  zeduxTypes,
   PartialAtomInstance,
-  Store,
 } from '@zedux/atoms'
+import { zeduxTypes, Store } from '@zedux/core'
 import { createImmerStore } from './createImmerStore'
 
 const doSubscribe = <State>(

--- a/packages/machines/src/injectMachineStore.ts
+++ b/packages/machines/src/injectMachineStore.ts
@@ -4,8 +4,8 @@ import {
   injectRef,
   injectSelf,
   InjectStoreConfig,
-  zeduxTypes,
 } from '@zedux/atoms'
+import { zeduxTypes } from '@zedux/core'
 import { MachineStore } from './MachineStore'
 import { MachineHook, MachineStateShape } from './types'
 

--- a/packages/machines/src/types.ts
+++ b/packages/machines/src/types.ts
@@ -1,4 +1,4 @@
-import { StoreEffect } from '@zedux/atoms'
+import { StoreEffect } from '@zedux/core'
 import { MachineStore } from './MachineStore'
 
 export type MachineHook<

--- a/packages/react/test/stores/AtomInstance.test.tsx
+++ b/packages/react/test/stores/AtomInstance.test.tsx
@@ -1,4 +1,5 @@
-import { createStore, injectEffect } from '@zedux/atoms'
+import { injectEffect } from '@zedux/atoms'
+import { createStore } from '@zedux/core'
 import { atom, injectStore } from '@zedux/stores'
 import { ecosystem } from '../utils/ecosystem'
 import { mockConsole } from '../utils/console'

--- a/packages/react/test/stores/batching.test.tsx
+++ b/packages/react/test/stores/batching.test.tsx
@@ -1,10 +1,5 @@
-import {
-  injectAtomGetters,
-  injectCallback,
-  injectRef,
-  zeduxTypes,
-} from '@zedux/atoms'
-import { api, atom, injectStore } from '@zedux/stores'
+import { injectAtomGetters, injectCallback, injectRef } from '@zedux/atoms'
+import { api, atom, injectStore, zeduxTypes } from '@zedux/stores'
 import { ecosystem } from '../utils/ecosystem'
 
 describe('batching', () => {

--- a/packages/react/test/stores/dependency-injection.test.tsx
+++ b/packages/react/test/stores/dependency-injection.test.tsx
@@ -2,13 +2,12 @@ import { fireEvent } from '@testing-library/dom'
 import '@testing-library/jest-dom/extend-expect'
 import { act } from '@testing-library/react'
 import {
-  createStore,
   injectEcosystem,
   injectEffect,
   useAtomInstance,
   useAtomValue,
 } from '@zedux/react'
-import { api, atom, injectStore, ion } from '@zedux/stores'
+import { api, atom, createStore, injectStore, ion } from '@zedux/stores'
 import React, { FC } from 'react'
 import { renderInEcosystem } from '../utils/renderInEcosystem'
 import { ecosystem } from '../utils/ecosystem'

--- a/packages/react/test/stores/graph.test.tsx
+++ b/packages/react/test/stores/graph.test.tsx
@@ -1,7 +1,6 @@
 import { fireEvent } from '@testing-library/dom'
 import { act } from '@testing-library/react'
 import {
-  createStore,
   injectAtomGetters,
   injectAtomValue,
   useAtomInstance,
@@ -11,7 +10,14 @@ import {
   AtomGetters,
   EvaluationReason,
 } from '@zedux/react'
-import { api, atom, AtomInstanceType, injectStore, ion } from '@zedux/stores'
+import {
+  api,
+  atom,
+  AtomInstanceType,
+  createStore,
+  injectStore,
+  ion,
+} from '@zedux/stores'
 import React from 'react'
 import { ecosystem, getNodes, snapshotNodes } from '../utils/ecosystem'
 import { renderInEcosystem } from '../utils/renderInEcosystem'

--- a/packages/react/test/stores/ssr.test.tsx
+++ b/packages/react/test/stores/ssr.test.tsx
@@ -4,7 +4,8 @@ import { ecosystem } from '../utils/ecosystem'
 
 describe('ssr', () => {
   test('ecosystem.hydrate() requires a normal object', () => {
-    expect(() => ecosystem.hydrate([])).toThrowError(/plain object/)
+    // @ts-expect-error hydrate requires an object
+    expect(() => ecosystem.hydrate(null)).toThrowError(/Expected an object/)
   })
 
   test('ecosystem.hydrate() hydrates atoms retroactively by default', () => {

--- a/packages/react/test/units/Ecosystem.test.tsx
+++ b/packages/react/test/units/Ecosystem.test.tsx
@@ -142,7 +142,7 @@ describe('Ecosystem', () => {
 
     // @ts-expect-error first param must be an atom template or instance
     expect(() => ecosystem.getInstance({})).toThrowError(
-      /Expected a template or node. Received object/i
+      /Expected a template, selector, or graph node/i
     )
 
     // @ts-expect-error first param must be an atom template or instance
@@ -152,7 +152,7 @@ describe('Ecosystem', () => {
 
     // @ts-expect-error second param must be an array or undefined
     expect(() => ecosystem.getInstance(atom1, 'a')).toThrowError(
-      /Expected atom params to be an array. Received string/i
+      /Expected atom params to be an array/i
     )
   })
 
@@ -161,7 +161,7 @@ describe('Ecosystem', () => {
 
     // @ts-expect-error first param must be an atom template or instance
     expect(() => ecosystem.getNode({})).toThrowError(
-      /Expected a template or node. Received object/i
+      /Expected a template, selector, or graph node/i
     )
 
     // @ts-expect-error first param must be an atom template or instance
@@ -171,7 +171,7 @@ describe('Ecosystem', () => {
 
     // @ts-expect-error second param must be an array or undefined
     expect(() => ecosystem.getNode(atom1, 'a')).toThrowError(
-      /Expected atom params to be an array. Received string/i
+      /Expected atom params to be an array/i
     )
   })
 


### PR DESCRIPTION
@affects atoms, core, immer, machines, react

## Description

With the `@zedux/atoms` package converted to using signals, the core package is now 6+kb of cruft. Remove the atoms package's dependency on the core package.

Copy some types to the atoms package. Refactor some usages of core utils we didn't really need to be using like `detailedTypeof`. Copy the `is` util over.

We will probably rework the core package in the future to make it a lightweight signals implementation. All store-related APIs will live in the `@zedux/stores` package. When we do, we can use its `is` util again the atoms package, removing that little bit of duplication.

### Breaking Changes

The `@zedux/atoms` package now does not use the `@zedux/core` package at all. This means it doesn't re-export `@zedux/core`'s exports anymore. This indirectly impacts the `@zedux/atoms` package too, since that in turn re-exports everything from the `@zedux/atoms` package.

All core APIs need to be imported either from `@zedux/core` itself (not recommended) or via the new `@zedux/stores` package, which does still re-export everything from `@zedux/core`.

The affected APIs are listed in the [core package README](https://github.com/Omnistac/zedux/tree/master/packages/core)