### PR TITLE
feat!: de-underscore-prefix atom promise properties; move `_isEvaluating` to store atoms

### DIFF
--- a/packages/atoms/src/classes/instances/AtomInstance.ts
+++ b/packages/atoms/src/classes/instances/AtomInstance.ts
@@ -164,7 +164,7 @@ const setPromise = <G extends Omit<AtomGenerics, 'Node'>>(
     .then(data => {
       if (instance.promise !== promise) return
 
-      instance._promiseStatus = 'success'
+      instance.promiseStatus = 'success'
       if (!isStateUpdater) return
 
       instance.set(getSuccessPromiseState(data) as unknown as G['State'])
@@ -176,15 +176,15 @@ const setPromise = <G extends Omit<AtomGenerics, 'Node'>>(
         sendEcosystemErrorEvent(instance, error)
       }
 
-      instance._promiseStatus = 'error'
-      instance._promiseError = error
+      instance.promiseStatus = 'error'
+      instance.promiseError = error
       if (!isStateUpdater) return
 
       instance.set(getErrorPromiseState(error) as unknown as G['State'])
     })
 
   const state: PromiseState<any> = getInitialPromiseState(currentState?.data)
-  instance._promiseStatus = state.status
+  instance.promiseStatus = state.status
 
   const reason = { r: instance.w, s: instance, t: PromiseChange } as const
 
@@ -239,9 +239,8 @@ export class AtomInstance<
    */
   public S: Signal<G> | undefined = undefined
 
-  public _isEvaluating = false
-  public _promiseError: Error | undefined = undefined
-  public _promiseStatus: PromiseStatus | undefined = undefined
+  public promiseError: Error | undefined = undefined
+  public promiseStatus: PromiseStatus | undefined = undefined
 
   constructor(
     /**
@@ -403,7 +402,6 @@ export class AtomInstance<
       return
     }
 
-    this._isEvaluating = true
     const prevNode = startBuffer(this)
 
     try {
@@ -470,8 +468,6 @@ export class AtomInstance<
 
       throw err
     } finally {
-      this._isEvaluating = false
-
       this.w = []
     }
 

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -9,6 +9,9 @@
   "bugs": {
     "url": "https://github.com/Omnistac/zedux/issues"
   },
+  "dependencies": {
+    "@zedux/stores": "2.0.0-beta.4"
+  },
   "devDependencies": {
     "@zedux/atoms": "2.0.0-beta.4",
     "@zedux/core": "2.0.0-beta.4",

--- a/packages/immer/src/injectImmerStore.ts
+++ b/packages/immer/src/injectImmerStore.ts
@@ -3,13 +3,13 @@ import {
   injectMemo,
   injectSelf,
   InjectStoreConfig,
-  PartialAtomInstance,
 } from '@zedux/atoms'
 import { zeduxTypes, Store } from '@zedux/core'
+import { PartialStoreAtomInstance } from '@zedux/stores'
 import { createImmerStore } from './createImmerStore'
 
 const doSubscribe = <State>(
-  instance: PartialAtomInstance,
+  instance: PartialStoreAtomInstance,
   store: Store<State>
 ) =>
   store.subscribe((newState, oldState, action) => {
@@ -35,7 +35,7 @@ export const injectImmerStore: {
   <State = any>(state: State, config?: InjectStoreConfig): Store<State>
   <State = undefined>(): Store<State>
 } = <State = any>(state?: State, config?: InjectStoreConfig) => {
-  const instance = injectSelf()
+  const instance = injectSelf() as PartialStoreAtomInstance
   const subscribe = config?.subscribe ?? true
 
   const store = injectMemo(() => {

--- a/packages/machines/package.json
+++ b/packages/machines/package.json
@@ -9,6 +9,9 @@
   "bugs": {
     "url": "https://github.com/Omnistac/zedux/issues"
   },
+  "dependencies": {
+    "@zedux/stores": "2.0.0-beta.4"
+  },
   "devDependencies": {
     "@zedux/atoms": "2.0.0-beta.4",
     "@zedux/core": "2.0.0-beta.4"

--- a/packages/machines/src/injectMachineStore.ts
+++ b/packages/machines/src/injectMachineStore.ts
@@ -8,6 +8,7 @@ import {
 import { zeduxTypes } from '@zedux/core'
 import { MachineStore } from './MachineStore'
 import { MachineHook, MachineStateShape } from './types'
+import { PartialStoreAtomInstance } from '@zedux/stores'
 
 type ArrToUnion<S extends string[]> = S extends [infer K, ...infer Rest]
   ? Rest extends string[]
@@ -168,7 +169,7 @@ export const injectMachineStore: <
   type EventNames = MapStatesToEvents<States, Context>
   type StateNames = MapStatesToStateNames<States, Context>
 
-  const instance = injectSelf()
+  const instance = injectSelf() as PartialStoreAtomInstance
 
   const { enterHooks, leaveHooks, store } = injectMemo(() => {
     const enterHooks: Record<

--- a/packages/react/src/hooks/useAtomInstance.ts
+++ b/packages/react/src/hooks/useAtomInstance.ts
@@ -169,12 +169,12 @@ export const useAtomInstance: {
   }, [instance.id])
 
   if (suspend !== false) {
-    const status = (instance as AtomInstance)._promiseStatus
+    const status = (instance as AtomInstance).promiseStatus
 
     if (status === 'loading') {
       throw (instance as AtomInstance).promise
     } else if (status === 'error') {
-      throw (instance as AtomInstance)._promiseError
+      throw (instance as AtomInstance).promiseError
     }
   }
 

--- a/packages/stores/src/AtomInstance.ts
+++ b/packages/stores/src/AtomInstance.ts
@@ -80,6 +80,7 @@ export class AtomInstance<
   // @ts-expect-error same as exports
   public store: G['Store']
 
+  public _isEvaluating = false
   public _stateType?: typeof StoreState | typeof RawState
 
   private _bufferedUpdate?: {
@@ -383,7 +384,7 @@ export class AtomInstance<
       .then(data => {
         if (this.promise !== promise) return
 
-        this._promiseStatus = 'success'
+        this.promiseStatus = 'success'
         if (!isStateUpdater) return
 
         this.store.setState(
@@ -393,8 +394,8 @@ export class AtomInstance<
       .catch(error => {
         if (this.promise !== promise) return
 
-        this._promiseStatus = 'error'
-        this._promiseError = error
+        this.promiseStatus = 'error'
+        this.promiseError = error
         if (!isStateUpdater) return
 
         this.store.setState(
@@ -403,7 +404,7 @@ export class AtomInstance<
       })
 
     const state: PromiseState<any> = getInitialPromiseState(currentState?.data)
-    this._promiseStatus = state.status
+    this.promiseStatus = state.status
 
     zi.a({ s: this, t: PromiseChange })
 

--- a/packages/stores/src/injectStore.ts
+++ b/packages/stores/src/injectStore.ts
@@ -4,11 +4,11 @@ import {
   injectRef,
   injectSelf,
   InjectStoreConfig,
-  PartialAtomInstance,
 } from '@zedux/atoms'
+import { PartialStoreAtomInstance } from '@zedux/stores'
 
 export const doSubscribe = <State>(
-  instance: PartialAtomInstance,
+  instance: PartialStoreAtomInstance,
   store: Store<State>
 ) =>
   store.subscribe((n, o, action) => {
@@ -96,7 +96,7 @@ export const injectStore: {
   storeFactory?: State | ((hydration?: State) => Store<State>),
   config?: InjectStoreConfig
 ) => {
-  const instance = injectSelf()
+  const instance = injectSelf() as PartialStoreAtomInstance
   const subscribe = config?.subscribe ?? true
 
   const ref = injectRef<Store<State>>()

--- a/packages/stores/src/injectStore.ts
+++ b/packages/stores/src/injectStore.ts
@@ -5,7 +5,7 @@ import {
   injectSelf,
   InjectStoreConfig,
 } from '@zedux/atoms'
-import { PartialStoreAtomInstance } from '@zedux/stores'
+import { PartialStoreAtomInstance } from './types'
 
 export const doSubscribe = <State>(
   instance: PartialStoreAtomInstance,

--- a/packages/stores/src/types.ts
+++ b/packages/stores/src/types.ts
@@ -185,6 +185,16 @@ export type IonStateFactory<G extends Omit<AtomGenerics, 'Node' | 'Template'>> =
     ...params: G['Params']
   ) => AtomApi<AtomGenericsToAtomApiGenerics<G>> | G['Store'] | G['State']
 
+/**
+ * Part of the atom instance can be accessed during initial evaluation. The only
+ * fields that are inaccessible are those that don't exist yet 'cause the
+ * initial evaluation is supposed to create them.
+ */
+export type PartialStoreAtomInstance = Omit<
+  AnyStoreAtomInstance,
+  'api' | 'exports' | 'promise' | 'S'
+>
+
 export type SelectorGenerics = Pick<AtomGenerics, 'State'> & {
   Params: any[]
   Template: AtomSelectorOrConfig


### PR DESCRIPTION
@affects atoms, immer, machines, react, stores

## Description

The atom instance `._promiseStatus` and `._promiseError` properties are meant to be read by users. They shouldn't be underscore-prefixed.

Also the `._isEvaluating` property is only relevant for store atoms - signals-based atoms don't need to buffer store updates during evaluation. Move that to the store-based `AtomInstance` class.

### Breaking Changes

`AtomInstance#_promiseStatus` is renamed to `AtomInstance#promiseStatus`

`AtomInstance#_promiseError` is renamed to `AtomInstance#promiseError`

`AtomInstance#_isEvaluating` is gone on the signals-based `AtomInstance` class (in the `@zedux/atoms` and therefore `@zedux/react` packages). It's moved to the store-based `AtomInstance` class in the `@zedux/stores` package.

The `@zedux/stores` package also exports a new type, `PartialStoreAtomInstance` which should be used instead of `PartialAtomInstance` when using `injectSelf` in store atoms:

```ts
const self = injectSelf() as PartialStoreAtomInstance // only use if you're guaranteeing this is only run in store atoms.
```