### PR TITLE
feat(atoms)!: use consistent terminology for observers and sources

### DIFF
--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -636,7 +636,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
    * nothing for passed atoms that aren't currently in the overrides list.
    *
    * Force destroys all instances of all removed atoms. This forced destruction
-   * will cause dependents of those instances to recreate their dependency atom
+   * will cause observers of those instances to recreate their observed atom
    * instance without using an override.
    */
   public removeOverrides(overrides: (AnyAtomTemplate | string)[]) {
@@ -704,8 +704,8 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
     const pre = _scheduler.pre()
 
     // TODO: Delete nodes in an optimal order, starting with nodes with no
-    // internal dependents. This is different from highest-weighted nodes since
-    // static dependents don't affect weight. This should make sure no internal
+    // internal observers. This is different from highest-weighted nodes since
+    // static observers don't affect weight. This should make sure no internal
     // nodes schedule unnecessary reevaaluations to recreate force-destroyed
     // nodes
     ;[...n.values()].forEach(node => {
@@ -763,8 +763,8 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
    * new list.
    *
    * Force destroys all instances of all previously- and newly-overridden atoms.
-   * This forced destruction will cause dependents of those instances to
-   * recreate their dependency atom instance.
+   * This forced destruction will cause observers of those instances to recreate
+   * their observed atom instance.
    */
   public setOverrides(newOverrides: AnyAtomTemplate[]) {
     const oldOverrides = this.overrides
@@ -810,8 +810,8 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
   public viewGraph(view?: 'flat'): Record<
     string,
     {
-      dependencies: { key: string; operation: string }[]
-      dependents: { key: string; operation: string }[]
+      observers: { key: string; operation: string }[]
+      sources: { key: string; operation: string }[]
       weight: number
     }
   >
@@ -821,35 +821,35 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
    * Get the current graph of this ecosystem. There are 3 views:
    *
    * Flat (default). Returns an object with all graph nodes on the top layer,
-   * each node pointing to its dependencies and dependents. No nesting.
+   * each node pointing to its sources and observers. No nesting.
    *
    * Bottom-Up. Returns an object containing all the leaf nodes of the graph
-   * (nodes that have no internal dependents), each node containing an object of
+   * (nodes that have no internal observers), each node containing an object of
    * its parent nodes, recursively.
    *
    * Top-Down. Returns an object containing all the root nodes of the graph
-   * (nodes that have no dependencies), each node containing an object of its
-   * child nodes, recursively.
+   * (nodes that have no sources), each node containing an object of its child
+   * nodes, recursively.
    */
   public viewGraph(view?: string) {
     if (view !== 'top-down' && view !== 'bottom-up') {
       const hash: Record<
         string,
         {
-          dependencies: { key: string; operation: string }[]
-          dependents: { key: string; operation: string }[]
+          sources: { key: string; operation: string }[]
+          observers: { key: string; operation: string }[]
           weight: number
         }
       > = {}
 
       for (const [id, node] of this.n) {
         hash[id] = {
-          dependencies: [...node.s].map(([source, edge]) => ({
-            key: source.id,
+          observers: [...node.o].map(([observer, edge]) => ({
+            key: observer.id,
             operation: edge.operation,
           })),
-          dependents: [...node.o].map(([observer, edge]) => ({
-            key: observer.id,
+          sources: [...node.s].map(([source, edge]) => ({
+            key: source.id,
             operation: edge.operation,
           })),
           weight: node.W,

--- a/packages/atoms/src/classes/GraphNode.ts
+++ b/packages/atoms/src/classes/GraphNode.ts
@@ -92,16 +92,19 @@ export abstract class GraphNode<G extends NodeGenerics = AnyNodeGenerics>
    */
   public W = 1
 
+  public P = 1
+
   /**
    * Detach this node from the ecosystem and clean up all graph edges and other
    * subscriptions/effects created by this node.
    *
    * Destruction will bail out if this node still has non-passive observers
-   * (`node.o.size - node.P !== 0`). Pass `true` to force-destroy the node
+   * (`node.o.size - (node.L ? 1 : 0)`). Pass `true` to force-destroy the node
    * anyway.
    *
-   * When force-destroying a node that still has dependents, the node will be
-   * immediately recreated and all dependents notified of the destruction.
+   * When force-destroying a node that still has observers, the node will be
+   * immediately recreated and all observers will be notified of the
+   * destruction.
    */
   public abstract destroy(force?: boolean): void
 

--- a/packages/atoms/src/classes/instances/AtomInstance.ts
+++ b/packages/atoms/src/classes/instances/AtomInstance.ts
@@ -460,7 +460,7 @@ export class AtomInstance<
       destroyBuffer(prevNode)
 
       // even if evaluation errored, we need to keep this atom in sync with its
-      // signal (and update dependents if the `S`ignal's state changed).
+      // signal and update transitive observers if the `S`ignal's state changed.
       if (this.S && this.S.v !== this.v) {
         const oldState = this.v
         this.v = this.S.v
@@ -568,7 +568,7 @@ export class AtomInstance<
     if (reason.s && reason.s === this.S && reason.e) {
       // when `this.S`ignal gives us events along with a state update, subsume
       // it as this atom's own state update. This atom will reevaluate before
-      // any scheduled dependents, giving the state factory an opportunity to
+      // any scheduled observers, giving the state factory an opportunity to
       // change the signal's state again, resulting in an additional event.
       const oldState = this.v
       this.v = reason.s.v

--- a/packages/atoms/src/factories/api.ts
+++ b/packages/atoms/src/factories/api.ts
@@ -14,7 +14,8 @@ import { Signal } from '../classes/Signal'
  *   - Any exports on the AtomApi are set as the atom instance's exports on
  *     initial evaluation (and ignored on all subsequent evaluations).
  *   - If promise or state references change on subsequent evaluations, it
- *     triggers the appropriate updates in all the atom's dynamic dependents.
+ *     triggers the appropriate updates in all the atom's dynamic observers.
+ *     Promise reference changes also notify static observers.
  */
 export const api: {
   // Signals (AtomApi cloning)

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -321,8 +321,6 @@ export type IonStateFactory<G extends Omit<AtomGenerics, 'Node' | 'Template'>> =
 export interface Job {
   /**
    * `W`eight - the weight of the node (for EvaluateGraphNode jobs).
-   * UpdateExternalDependent jobs also use this to track the order they were
-   * added as dependents, since that's the order they should evaluate in.
    */
   W?: number
 

--- a/packages/atoms/src/utils/evaluationContext.ts
+++ b/packages/atoms/src/utils/evaluationContext.ts
@@ -56,7 +56,7 @@ export const bufferEdge = (
 
 /**
  * If a node errors during evaluation, we need to destroy any nodes created
- * during that evaluation that now have no dependents.
+ * during that evaluation that now have no observers.
  *
  * Always pass the previously captured node/startTime (undefined if this is the
  * last item in the stack)

--- a/packages/atoms/src/utils/graph.ts
+++ b/packages/atoms/src/utils/graph.ts
@@ -94,7 +94,7 @@ export const addEdge = (
 }
 
 export const destroyNodeStart = (node: GraphNode, force?: boolean) => {
-  // If we're not force-destroying, don't destroy if there are dependents. Also
+  // If we're not force-destroying, don't destroy if there are observers. Also
   // don't destroy if `node.K`eep is set
   if (node.l === DESTROYED || (!force && node.o.size - (node.L ? 1 : 0))) {
     return
@@ -110,12 +110,12 @@ export const destroyNodeStart = (node: GraphNode, force?: boolean) => {
 
 // TODO: merge this into destroyNodeStart. We should be able to
 export const destroyNodeFinish = (node: GraphNode) => {
-  // first remove all edges between this node and its dependencies
+  // first remove all edges between this node and its sources
   for (const dependency of node.s.keys()) {
     removeEdge(node, dependency)
   }
 
-  // now remove all edges between this node and its dependents
+  // now remove all edges between this node and its observers
   for (const [observer, edge] of node.o) {
     if (!(edge.flags & Static)) {
       recalculateNodeWeight(-node.W, observer)

--- a/packages/core/src/utils/types.ts
+++ b/packages/core/src/utils/types.ts
@@ -33,8 +33,6 @@ export interface Hierarchy {
 export interface Job {
   /**
    * `W`eight - the weight of the node (for EvaluateGraphNode jobs).
-   * UpdateExternalDependent jobs also use this to track the order they were
-   * added as dependents, since that's the order they should evaluate in.
    */
   W?: number
 

--- a/packages/react/src/hooks/useAtomSelector.ts
+++ b/packages/react/src/hooks/useAtomSelector.ts
@@ -89,9 +89,9 @@ export const useAtomSelector = <S extends Selectable>(
     render.m = true
 
     // an unmounting component's effect cleanup can force-destroy the selector
-    // or update the state of its dependencies (causing it to rerun) before we
-    // set `render.m`ounted. If that happened, trigger a rerender to recreate
-    // the selector and/or get its new state
+    // or update the state of its sources (causing it to rerun) before we set
+    // `render.m`ounted. If that happened, trigger a rerender to recreate the
+    // selector and/or get its new state
     if (instance.v !== renderedValue || instance.l === zi.D) {
       render({})
     }
@@ -99,9 +99,9 @@ export const useAtomSelector = <S extends Selectable>(
     return () => {
       // remove the edge immediately - no need for a delay here. When StrictMode
       // double-invokes (invokes, then cleans up, then re-invokes) this effect,
-      // it's expected that selectors and `ttl: 0` atoms with no other
-      // dependents get destroyed and recreated - that's part of what StrictMode
-      // is ensuring
+      // it's expected that selectors and `ttl: 0` atoms with no other observers
+      // get destroyed and recreated - that's part of what StrictMode is
+      // ensuring
       node.k(instance)
       // don't set `render.m = false` here
     }

--- a/packages/react/test/integrations/__snapshots__/ecosystem.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/ecosystem.test.tsx.snap
@@ -3,73 +3,67 @@
 exports[`ecosystem big graph 1`] = `
 {
   "@signal(atom1)-0": {
-    "dependencies": [],
-    "dependents": [
+    "observers": [
       {
         "key": "atom1",
         "operation": "injectSignal",
       },
     ],
+    "sources": [],
     "weight": 1,
   },
   "Child-:r0:": {
-    "dependencies": [
+    "observers": [],
+    "sources": [
       {
         "key": "atom5",
         "operation": "useAtomValue",
       },
     ],
-    "dependents": [],
     "weight": 16,
   },
   "Child-:r1:": {
-    "dependencies": [
+    "observers": [],
+    "sources": [
       {
         "key": "atom4",
         "operation": "useAtomState",
       },
     ],
-    "dependents": [],
     "weight": 10,
   },
   "Child-:r2:": {
-    "dependencies": [
+    "observers": [],
+    "sources": [
       {
         "key": "atom3-["1"]",
         "operation": "useAtomValue",
       },
     ],
-    "dependents": [],
     "weight": 7,
   },
   "Child-:r3:": {
-    "dependencies": [
+    "observers": [],
+    "sources": [
       {
         "key": "atom2",
         "operation": "useAtomValue",
       },
     ],
-    "dependents": [],
     "weight": 4,
   },
   "Child-:r4:": {
-    "dependencies": [
+    "observers": [],
+    "sources": [
       {
         "key": "atom1",
         "operation": "useAtomValue",
       },
     ],
-    "dependents": [],
     "weight": 3,
   },
   "atom1": {
-    "dependencies": [
-      {
-        "key": "@signal(atom1)-0",
-        "operation": "injectSignal",
-      },
-    ],
-    "dependents": [
+    "observers": [
       {
         "key": "atom2",
         "operation": "injectAtomValue",
@@ -91,16 +85,16 @@ exports[`ecosystem big graph 1`] = `
         "operation": "useAtomValue",
       },
     ],
+    "sources": [
+      {
+        "key": "@signal(atom1)-0",
+        "operation": "injectSignal",
+      },
+    ],
     "weight": 2,
   },
   "atom2": {
-    "dependencies": [
-      {
-        "key": "atom1",
-        "operation": "injectAtomValue",
-      },
-    ],
-    "dependents": [
+    "observers": [
       {
         "key": "atom3-["1"]",
         "operation": "injectAtomValue",
@@ -114,20 +108,16 @@ exports[`ecosystem big graph 1`] = `
         "operation": "useAtomValue",
       },
     ],
-    "weight": 3,
-  },
-  "atom3-["1"]": {
-    "dependencies": [
+    "sources": [
       {
         "key": "atom1",
         "operation": "injectAtomValue",
       },
-      {
-        "key": "atom2",
-        "operation": "injectAtomValue",
-      },
     ],
-    "dependents": [
+    "weight": 3,
+  },
+  "atom3-["1"]": {
+    "observers": [
       {
         "key": "atom4",
         "operation": "injectAtomValue",
@@ -137,20 +127,20 @@ exports[`ecosystem big graph 1`] = `
         "operation": "useAtomValue",
       },
     ],
-    "weight": 6,
-  },
-  "atom4": {
-    "dependencies": [
-      {
-        "key": "atom3-["1"]",
-        "operation": "injectAtomValue",
-      },
+    "sources": [
       {
         "key": "atom1",
         "operation": "injectAtomValue",
       },
+      {
+        "key": "atom2",
+        "operation": "injectAtomValue",
+      },
     ],
-    "dependents": [
+    "weight": 6,
+  },
+  "atom4": {
+    "observers": [
       {
         "key": "atom5",
         "operation": "injectAtomValue",
@@ -160,10 +150,26 @@ exports[`ecosystem big graph 1`] = `
         "operation": "useAtomState",
       },
     ],
+    "sources": [
+      {
+        "key": "atom3-["1"]",
+        "operation": "injectAtomValue",
+      },
+      {
+        "key": "atom1",
+        "operation": "injectAtomValue",
+      },
+    ],
     "weight": 9,
   },
   "atom5": {
-    "dependencies": [
+    "observers": [
+      {
+        "key": "Child-:r0:",
+        "operation": "useAtomValue",
+      },
+    ],
+    "sources": [
       {
         "key": "atom2",
         "operation": "injectAtomValue",
@@ -175,12 +181,6 @@ exports[`ecosystem big graph 1`] = `
       {
         "key": "atom1",
         "operation": "injectAtomValue",
-      },
-    ],
-    "dependents": [
-      {
-        "key": "Child-:r0:",
-        "operation": "useAtomValue",
       },
     ],
     "weight": 15,

--- a/packages/react/test/integrations/__snapshots__/graph.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/graph.test.tsx.snap
@@ -3,8 +3,7 @@
 exports[`graph ecosystem getters 1`] = `
 {
   "@signal(atom4)-0": {
-    "dependencies": [],
-    "dependents": [
+    "observers": [
       {
         "key": "@signal(atom4)-2",
         "operation": "get",
@@ -14,11 +13,11 @@ exports[`graph ecosystem getters 1`] = `
         "operation": "injectSignal",
       },
     ],
+    "sources": [],
     "weight": 1,
   },
   "@signal(atom4)-1": {
-    "dependencies": [],
-    "dependents": [
+    "observers": [
       {
         "key": "@signal(atom4)-2",
         "operation": "get",
@@ -28,55 +27,66 @@ exports[`graph ecosystem getters 1`] = `
         "operation": "injectSignal",
       },
     ],
+    "sources": [],
     "weight": 1,
   },
   "Test-:r0:": {
-    "dependencies": [
+    "observers": [],
+    "sources": [
       {
         "key": "atom4",
         "operation": "useAtomValue",
       },
     ],
-    "dependents": [],
     "weight": 9,
   },
   "Test-:r1:": {
-    "dependencies": [
+    "observers": [],
+    "sources": [
       {
         "key": "atom4",
         "operation": "useAtomInstance",
       },
     ],
-    "dependents": [],
     "weight": 1,
   },
   "atom1": {
-    "dependencies": [],
-    "dependents": [
+    "observers": [
       {
         "key": "atom4",
         "operation": "get",
       },
     ],
+    "sources": [],
     "weight": 1,
   },
   "atom2": {
-    "dependencies": [],
-    "dependents": [],
+    "observers": [],
+    "sources": [],
     "weight": 1,
   },
   "atom3": {
-    "dependencies": [],
-    "dependents": [
+    "observers": [
       {
         "key": "atom4",
         "operation": "get",
       },
     ],
+    "sources": [],
     "weight": 1,
   },
   "atom4": {
-    "dependencies": [
+    "observers": [
+      {
+        "key": "Test-:r0:",
+        "operation": "useAtomValue",
+      },
+      {
+        "key": "Test-:r1:",
+        "operation": "useAtomInstance",
+      },
+    ],
+    "sources": [
       {
         "key": "@signal(atom4)-0",
         "operation": "injectSignal",
@@ -96,16 +106,6 @@ exports[`graph ecosystem getters 1`] = `
       {
         "key": "atom3",
         "operation": "get",
-      },
-    ],
-    "dependents": [
-      {
-        "key": "Test-:r0:",
-        "operation": "useAtomValue",
-      },
-      {
-        "key": "Test-:r1:",
-        "operation": "useAtomInstance",
       },
     ],
     "weight": 8,

--- a/packages/react/test/integrations/injectors.test.tsx
+++ b/packages/react/test/integrations/injectors.test.tsx
@@ -243,13 +243,13 @@ describe('injectors', () => {
     expect(selectValue).toBe(1)
     expect(ecosystem.viewGraph()).toEqual({
       1: {
-        dependencies: [],
-        dependents: [],
+        observers: [],
+        sources: [],
         weight: 1,
       },
       '@@selector-selector1-0': {
-        dependencies: [],
-        dependents: [],
+        observers: [],
+        sources: [],
         weight: 1,
       },
     })

--- a/packages/react/test/integrations/selection.test.tsx
+++ b/packages/react/test/integrations/selection.test.tsx
@@ -67,7 +67,7 @@ describe('selection', () => {
     expect(await findByTestId('text')).toHaveTextContent('b')
   })
 
-  test("a state change from an unmounting component's effect cleanup triggers rerenders in newly-created components that use the updated atom or its dependents", async () => {
+  test("a state change from an unmounting component's effect cleanup triggers rerenders in newly-created components that use the updated atom or its observers", async () => {
     jest.useFakeTimers()
     const selector = jest.fn(({ get }: AtomGetters) => get(testAtom, ['a']))
 
@@ -120,7 +120,7 @@ describe('selection', () => {
   test('selectors are recreated when necessary on component remount', async () => {
     jest.useFakeTimers()
     let b = 2
-    const selector1 = jest.fn(() => ({ a: 1 })) // two dependents; shouldn't rerun
+    const selector1 = jest.fn(() => ({ a: 1 })) // two observers; shouldn't rerun
     const selector2 = jest.fn(() => ({ b: b++ })) // one dependent; should rerun
     const selector3 = jest.fn((_: AtomGetters, arg: number) => 'c' + arg) // args change; should run with 2 different args
 

--- a/packages/react/test/stores/__snapshots__/graph.test.tsx.snap
+++ b/packages/react/test/stores/__snapshots__/graph.test.tsx.snap
@@ -55,62 +55,52 @@ exports[`graph getInstance(atom) returns the instance 1`] = `
 exports[`graph injectAtomGetters 1`] = `
 {
   "Test-:r0:": {
-    "dependencies": [
+    "observers": [],
+    "sources": [
       {
         "key": "atom4",
         "operation": "useAtomValue",
       },
     ],
-    "dependents": [],
     "weight": 4,
   },
   "Test-:r1:": {
-    "dependencies": [
+    "observers": [],
+    "sources": [
       {
         "key": "atom4",
         "operation": "useAtomInstance",
       },
     ],
-    "dependents": [],
     "weight": 1,
   },
   "atom1": {
-    "dependencies": [],
-    "dependents": [
+    "observers": [
       {
         "key": "atom4",
         "operation": "get",
       },
     ],
+    "sources": [],
     "weight": 1,
   },
   "atom2": {
-    "dependencies": [],
-    "dependents": [],
+    "observers": [],
+    "sources": [],
     "weight": 1,
   },
   "atom3": {
-    "dependencies": [],
-    "dependents": [
+    "observers": [
       {
         "key": "atom4",
         "operation": "get",
       },
     ],
+    "sources": [],
     "weight": 1,
   },
   "atom4": {
-    "dependencies": [
-      {
-        "key": "atom1",
-        "operation": "get",
-      },
-      {
-        "key": "atom3",
-        "operation": "get",
-      },
-    ],
-    "dependents": [
+    "observers": [
       {
         "key": "Test-:r0:",
         "operation": "useAtomValue",
@@ -118,6 +108,16 @@ exports[`graph injectAtomGetters 1`] = `
       {
         "key": "Test-:r1:",
         "operation": "useAtomInstance",
+      },
+    ],
+    "sources": [
+      {
+        "key": "atom1",
+        "operation": "get",
+      },
+      {
+        "key": "atom3",
+        "operation": "get",
       },
     ],
     "weight": 3,

--- a/packages/react/test/stores/injectors.test.tsx
+++ b/packages/react/test/stores/injectors.test.tsx
@@ -229,13 +229,13 @@ describe('injectors', () => {
     expect(selectValue).toBe(1)
     expect(ecosystem.viewGraph()).toEqual({
       1: {
-        dependencies: [],
-        dependents: [],
+        observers: [],
+        sources: [],
         weight: 1,
       },
       '@@selector-selector1-0': {
-        dependencies: [],
-        dependents: [],
+        observers: [],
+        sources: [],
         weight: 1,
       },
     })
@@ -260,13 +260,13 @@ describe('injectors', () => {
     expect(selectValue).toBe(1)
     expect(ecosystem.viewGraph()).toEqual({
       1: {
-        dependencies: [],
-        dependents: [],
+        observers: [],
+        sources: [],
         weight: 1,
       },
       '@@selector-selector1-0': {
-        dependencies: [],
-        dependents: [],
+        observers: [],
+        sources: [],
         weight: 1,
       },
     })

--- a/packages/react/test/units/SelectorInstance.test.tsx
+++ b/packages/react/test/units/SelectorInstance.test.tsx
@@ -26,7 +26,7 @@ describe('the SelectorInstance class', () => {
     snapshotSelectorNodes()
   })
 
-  test('on() adds and removes dependents', () => {
+  test('on() adds and removes observers', () => {
     const instance2a = ecosystem.getNode(selector2)
 
     expect(getSelectorNodes()).toEqual({
@@ -77,7 +77,7 @@ describe('the SelectorInstance class', () => {
     expect(() => ecosystem.getNode(selector2).destroy()).not.toThrow()
   })
 
-  test('if the selector has dependents, `destroyCache()` bails out unless `force` is passed', () => {
+  test('if the selector has observers, `destroyCache()` bails out unless `force` is passed', () => {
     jest.useFakeTimers()
     ecosystem.getNode(selector3)
     const instance1 = ecosystem.getNode(selector1)

--- a/packages/react/test/units/useAtomSelector.test.tsx
+++ b/packages/react/test/units/useAtomSelector.test.tsx
@@ -365,7 +365,7 @@ describe('useAtomSelector', () => {
     expect(renders).toBe(2)
   })
 
-  test('selector is not considered inline if it has multiple dependents', async () => {
+  test('selector is not considered inline if it has multiple observers', async () => {
     jest.useFakeTimers()
     const selector1 = jest.fn(() => 1)
     const selector2 = jest.fn(() => 2)

--- a/packages/stores/src/AtomInstance.ts
+++ b/packages/stores/src/AtomInstance.ts
@@ -270,7 +270,7 @@ export class AtomInstance<
       // scheduler
       if (!prevNode) Store._scheduler = undefined
 
-      // even if evaluation errored, we need to update dependents if the store's
+      // even if evaluation errored, we need to update observers if the store's
       // state changed
       if (this._bufferedUpdate) {
         this._handleStateChange(

--- a/packages/stores/src/api.ts
+++ b/packages/stores/src/api.ts
@@ -14,7 +14,8 @@ import { AtomApi } from './AtomApi'
  *   - Any exports on the AtomApi are set as the atom instance's exports on
  *     initial evaluation and ignored forever after.
  *   - If promise or state references change on subsequent evaluations, it
- *     triggers the appropriate updates in all the atom's dynamic dependents.
+ *     triggers the appropriate updates in all the atom's dynamic observers.
+ *     Promise reference changes also notify static observers.
  */
 export const api: {
   // Custom Stores (AtomApi cloning)


### PR DESCRIPTION
## Description

In v2, a graph node's "dependencies" are called "sources" and "dependents" are called "observers". This is consistent with other signals libs and I find it clearer. Reword mostly code comments to reflect this.

### Breaking Change

The only non-code-comment affected by this is the objects returned by `ecosystem.viewGraph`. Those had `dependencies` and `dependents` keys. Rename those to `sources` and `observers` respectively.