### PR TITLE
feat(react): check for `React.use` before using; partially support React 18

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,7 +51,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=19.0.0"
+    "react": ">=18.0.0"
   },
   "repository": {
     "directory": "packages/react",

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,5 +1,5 @@
 import { AnyAtomTemplate, AtomTemplateBase, Ecosystem, is } from '@zedux/atoms'
-import React, { Context, createContext, use } from 'react'
+import React, { Context, createContext } from 'react'
 
 export const ecosystemContext = createContext<undefined | Ecosystem>(undefined)
 
@@ -43,9 +43,16 @@ export const getReactContext = (
 export const reactContextScope = (
   ecosystem: Ecosystem,
   context: Record<string, any>
-) =>
-  use(
+) => {
+  if (!('use' in React)) {
+    throw new Error(
+      "Using scoped atoms from React requires React 19's new `use` util. Either upgrade React or use `ecosystem.withScope` manually"
+    )
+  }
+
+  return React.use(
     is(context, AtomTemplateBase)
       ? getReactContext(ecosystem, context as AtomTemplateBase)
       : (context as Context<any>)
   )
+}


### PR DESCRIPTION
## Description

We can use React's default export to check if React 19's `use` util exists before using it. Throw an error if it doesn't to let the user know that scoped atoms can only hook into React context in React 19. If you can't upgrade to React 19, you can still use scoped atoms manually via `ecosystem.withScope`.

With this PR, Zedux v2 now works in React 18 non-strict-mode, you just probably won't want to use scoped atoms until upgrading to React 19.