### PR TITLE
refactor: micro optimize broad graph updates and node creation

### DIFF
--- a/bench/src/frameworks/zedux.ts
+++ b/bench/src/frameworks/zedux.ts
@@ -10,20 +10,29 @@ import { Computed, ReactiveFramework } from '../util/reactiveFramework'
 let ecosystem: Ecosystem
 let counter = 0
 
-class CustomSelector extends SelectorInstance {
+class BenchmarkableSelector extends SelectorInstance {
   /**
-   * Zedux cleans up graph nodes when it detects they're no longer in use. These
-   * benchmarks don't expect that behavior. Making `node.m`aybeDestroy a noop is
-   * all that's needed to prevent automatic destruction, while still allowing
-   * manual destruction via `node.destroy()`.
+   * Zedux is a cache manager. Unlike other signals-libs, it cleans up graph
+   * nodes when it detects they're no longer in use. These benchmarks don't
+   * expect that behavior. Making `node.m`aybeDestroy a noop is all that's
+   * needed to prevent automatic destruction, while still allowing manual
+   * destruction via `node.destroy()`.
    */
+  m() {}
+}
+
+class BenchmarkableSignal extends Signal {
   m() {}
 }
 
 export const zeduxFramework: ReactiveFramework = {
   name: 'Zedux',
   signal: initialValue => {
-    const s = new Signal(ecosystem, (counter++).toString(), initialValue)
+    const s = new BenchmarkableSignal(
+      ecosystem,
+      (counter++).toString(),
+      initialValue
+    )
 
     return {
       read: () => s.get(),
@@ -31,13 +40,19 @@ export const zeduxFramework: ReactiveFramework = {
     }
   },
   computed: <T>(fn: () => T): Computed<T> => {
-    const s = new CustomSelector(ecosystem, (counter++).toString(), fn, [])
+    const s = new BenchmarkableSelector(
+      ecosystem,
+      (counter++).toString(),
+      fn,
+      []
+    )
 
     return {
       read: () => s.get(),
     }
   },
-  effect: fn => new CustomSelector(ecosystem, (counter++).toString(), fn, []),
+  effect: fn =>
+    new BenchmarkableSelector(ecosystem, (counter++).toString(), fn, []),
   withBatch: fn => ecosystem.batch(fn),
   withBuild: fn => {
     if (ecosystem) ecosystem.reset()

--- a/packages/atoms/src/classes/GraphNode.ts
+++ b/packages/atoms/src/classes/GraphNode.ts
@@ -342,7 +342,7 @@ export abstract class GraphNode<G extends NodeGenerics = AnyNodeGenerics>
    * exact same object reference will also be stored in another node's
    * `s`ources. The only exception is pseudo-nodes.
    */
-  public o = new Map<GraphNode, GraphEdge>()
+  public abstract o: Map<GraphNode, GraphEdge>
 
   /**
    * `p`arams - a reference to the exact params passed to this node. These never
@@ -373,12 +373,12 @@ export abstract class GraphNode<G extends NodeGenerics = AnyNodeGenerics>
   }
 
   /**
-   * `s`ources - a map of the edges drawn between this node and all of its
-   * dependencies, keyed by the GraphNode object reference of the source. Every
+   * `s`ources - a map of the edges drawn between this node and all the nodes it
+   * depends on, keyed by the GraphNode object reference of the source. Every
    * edge stored here is reverse-mapped - the exact same object reference will
    * also be stored in another node's `o`bservers.
    */
-  public s = new Map<GraphNode, GraphEdge>()
+  public abstract s: Map<GraphNode, GraphEdge>
 
   /**
    * `t`emplate - a reference to the template that was used to create this node
@@ -420,9 +420,23 @@ export class ExternalNode<
   public i?: GraphNode
 
   /**
+   * @see GraphNode.o External nodes don't typically have observers. So this
+   * starts off as a getter for efficiency.
+   */
+  public get o(): Map<GraphNode, GraphEdge> {
+    Object.defineProperty(this, 'o', { value: new Map() })
+    return this.o
+  }
+
+  /**
    * @see GraphNode.p external nodes don't have params
    */
   public p: undefined
+
+  /**
+   * @see GraphNode.s
+   */
+  public s = new Map<GraphNode, GraphEdge>()
 
   /**
    * @see GraphNode.t external nodes don't have templates

--- a/packages/atoms/src/classes/MappedSignal.ts
+++ b/packages/atoms/src/classes/MappedSignal.ts
@@ -8,7 +8,7 @@ import {
   Transaction,
   UndefinedEvents,
 } from '../types/index'
-import { flushBuffer, startBuffer } from '../utils/evaluationContext'
+import { flushBuffer } from '../utils/evaluationContext'
 import { Ecosystem } from './Ecosystem'
 import { doMutate, Signal } from './Signal'
 import { ACTIVE, EventSent, INITIALIZING, TopPrio } from '../utils/general'
@@ -248,7 +248,7 @@ export class MappedSignal<
   public u(map: SignalMap) {
     const entries = Object.entries(map)
 
-    const prevNode = startBuffer(this)
+    const prevNode = this.e.cs(this)
 
     // `get` every signal and auto-add each one as a source of the mapped signal
     const edgeConfig = { f: TopPrio }

--- a/packages/atoms/src/classes/SelectorInstance.ts
+++ b/packages/atoms/src/classes/SelectorInstance.ts
@@ -1,4 +1,4 @@
-import { DehydrationFilter, SelectorGenerics } from '../types/index'
+import { DehydrationFilter, GraphEdge, SelectorGenerics } from '../types/index'
 import { prefix } from '../utils/general'
 import { destroyNodeFinish, destroyNodeStart } from '../utils/graph'
 import { runSelector } from '../utils/selectors'
@@ -13,6 +13,18 @@ export class SelectorInstance<
   }
 > extends GraphNode<G & { Events: any }> {
   public static $$typeof = Symbol.for(`${prefix}/SelectorInstance`)
+
+  /**
+   * @see GraphNode.s Selectors typically have observers. So we initialize this
+   * upfront.
+   */
+  public o = new Map<GraphNode, GraphEdge>()
+
+  /**
+   * @see GraphNode.s Selectors typically have sources. So we initialize this
+   * upfront.
+   */
+  public s = new Map<GraphNode, GraphEdge>()
 
   constructor(
     /**

--- a/packages/atoms/src/classes/instances/AtomInstance.ts
+++ b/packages/atoms/src/classes/instances/AtomInstance.ts
@@ -41,7 +41,6 @@ import { AtomTemplateBase } from '../templates/AtomTemplateBase'
 import {
   destroyNodeFinish,
   destroyNodeStart,
-  handleStateChange,
   scheduleEventListeners,
   scheduleStaticDependents,
   setNodeStatus,
@@ -51,7 +50,6 @@ import {
   destroyBuffer,
   flushBuffer,
   getEvaluationContext,
-  startBuffer,
 } from '@zedux/atoms/utils/evaluationContext'
 import { Signal } from '../Signal'
 import {
@@ -397,12 +395,12 @@ export class AtomInstance<
       // observers.
       const oldState = this.v
       this.v = this.S!.v // `this.S`ignal must exist if `this.a`lteredEdge does
-      handleStateChange(this, oldState)
+      this.e.ch(this, oldState)
 
       return
     }
 
-    const prevNode = startBuffer(this)
+    const prevNode = this.e.cs(this)
 
     try {
       const newFactoryResult = evaluate(this)
@@ -430,7 +428,7 @@ export class AtomInstance<
         const oldState = this.v
         this.v = this.S ? newFactoryResult.v : newFactoryResult
 
-        this.v === oldState || handleStateChange(this, oldState)
+        this.v === oldState || this.e.ch(this, oldState)
       }
 
       if (this.S) {
@@ -463,7 +461,7 @@ export class AtomInstance<
         const oldState = this.v
         this.v = this.S.v
 
-        handleStateChange(this, oldState)
+        this.e.ch(this, oldState)
       }
 
       throw err
@@ -564,7 +562,7 @@ export class AtomInstance<
       this.v = reason.s.v
 
       this.v === oldState ||
-        handleStateChange(this, oldState, reason.e as Partial<G['Events']>)
+        this.e.ch(this, oldState, reason.e as Partial<G['Events']>)
     }
   }
 

--- a/packages/atoms/src/classes/schedulers/SchedulerBase.ts
+++ b/packages/atoms/src/classes/schedulers/SchedulerBase.ts
@@ -10,8 +10,8 @@ export const runJobs = (scheduler: SchedulerBase) => {
   let errors: any[] | undefined
 
   scheduler.r = true
-  while (jobs.length) {
-    const job = jobs.shift() as Job
+  while (jobs.length > scheduler.c) {
+    const job = jobs[scheduler.c++] as Job
     try {
       job.j()
     } catch (err) {
@@ -20,11 +20,15 @@ export const runJobs = (scheduler: SchedulerBase) => {
     }
   }
 
+  scheduler.j = []
+  scheduler.c = 0
   scheduler.r = false
   if (errors) throw errors[0]
 }
 
 export abstract class SchedulerBase {
+  public c = 0
+
   /**
    * `r`unning - We set this to true internally when the scheduler starts
    * flushing. We also set it to true when batching updates, to prevent anything
@@ -104,7 +108,7 @@ export abstract class SchedulerBase {
   public abstract schedule(newJob: Job): void
 
   public unschedule(job: Job) {
-    const index = this.j.indexOf(job)
+    const index = this.j.indexOf(job, this.c)
 
     if (index !== -1) this.j.splice(index, 1)
   }

--- a/packages/atoms/src/index.ts
+++ b/packages/atoms/src/index.ts
@@ -9,7 +9,6 @@ import {
   flushBuffer,
   getEvaluationContext,
   setEvaluationContext,
-  startBuffer,
 } from './utils/evaluationContext'
 import { sendImplicitEcosystemEvent } from './utils/events'
 import { DESTROYED, INITIALIZING } from './utils/general'
@@ -53,6 +52,5 @@ export const zi = {
   I: INITIALIZING,
   i: sendImplicitEcosystemEvent,
   f: flushBuffer,
-  s: startBuffer,
   u: scheduleDependents,
 }

--- a/packages/atoms/src/utils/evaluationContext.ts
+++ b/packages/atoms/src/utils/evaluationContext.ts
@@ -71,7 +71,7 @@ export const destroyBuffer = (previousNode: GraphNode | undefined) => {
     sourceEdge.p = undefined
   }
 
-  evaluationContext.n!.e.f(previousNode)
+  evaluationContext.n!.e.cf(previousNode)
 }
 
 /**
@@ -142,7 +142,7 @@ export const flushBuffer = (previousNode: GraphNode | undefined) => {
     source[1].p = undefined
   }
 
-  evaluationContext.n!.e.f(previousNode)
+  evaluationContext.n!.e.cf(previousNode)
 }
 
 export const getEvaluationContext = () => evaluationContext
@@ -164,11 +164,15 @@ export const startBuffer = (node: GraphNode) => {
 
   evaluationContext.n = node
 
+  return prevNode
+}
+
+export const startBufferWithEvent = (node: GraphNode) => {
   if (isListeningTo(node.e, RUN_START)) {
     sendEcosystemEvent(node.e, { source: node, type: RUN_START })
   }
 
-  return prevNode
+  return startBuffer(node)
 }
 
 /**

--- a/packages/atoms/src/utils/graph.ts
+++ b/packages/atoms/src/utils/graph.ts
@@ -162,6 +162,16 @@ export const handleStateChange = <
   oldState: G['State'],
   events?: Partial<SendableEvents<G>>
 ) => {
+  scheduleDependents({ e: events, n: node.v, o: oldState, r: node.w, s: node })
+}
+
+export const handleStateChangeWithEvent = <
+  G extends Pick<AtomGenerics, 'Events' | 'State'>
+>(
+  node: GraphNode<G & { Params: any; Template: any }>,
+  oldState: G['State'],
+  events?: Partial<SendableEvents<G>>
+) => {
   const reason = { e: events, n: node.v, o: oldState, r: node.w, s: node }
 
   if (isListeningTo(node.e, CHANGE)) {

--- a/packages/core/src/utils/types.ts
+++ b/packages/core/src/utils/types.ts
@@ -32,11 +32,6 @@ export interface Hierarchy {
 
 export interface Job {
   /**
-   * `W`eight - the weight of the node (for EvaluateGraphNode jobs).
-   */
-  W?: number
-
-  /**
    * `j`ob - the actual task to run.
    */
   j: () => void
@@ -50,7 +45,7 @@ export interface Job {
    * 2 - EvaluateGraphNode
    * 3 - UpdateExternalDependent
    */
-  T: 0 | 1 | 2 | 3
+  T: 0 | 1
 }
 
 export interface NullNode extends HierarchyNodeBase {

--- a/packages/stores/src/AtomInstance.ts
+++ b/packages/stores/src/AtomInstance.ts
@@ -198,7 +198,7 @@ export class AtomInstance<
   public j() {
     this.N = []
     this._isEvaluating = true
-    const prevNode = zi.s(this)
+    const prevNode = this.e.cs(this)
 
     try {
       const newFactoryResult = this._eval()


### PR DESCRIPTION
@affects atoms, core, stores

## Description

At 1400+ ms, Zedux's `broadPropagation` benchmark score, while >4x faster than Jotai, is still far behind most other signals libraries. This is because Zedux uses a scheduler for everything. At best, this is an O(n log n) algorithm. Most other signals libs use an O(n) (2n to be precise) push-pull algorithm.

The "phase 2" of the graph algorithm change I've been talking about involves switching us to a similar model for normal graph updates. But rather than bail immediately, we should optimize this algorithm first.

The difference between O(n) and O(n log n) shouldn't be as extreme as it looks right now. In fact, we would be able to micro-optimize Zedux so much that the difference is imperceptible. However, our scheduler algorithm must use a dense JS array. And v8 doesn't provide a way to teach the engine how to optimally resize that array.

This means our `splice` and `push` operations are worse than they algorithmically need to be. The good news is that's the only downside. Other than array resizing, we can micro optimize Zedux so much that the difference between O(n) and our O(n log n) is very small.

So do that. Use an offset counter instead of shifting the jobs array when running jobs to cut the amount of array resizing in half. Replace the `findIndex` closure/recursion with a micro optimized `while` loop. Remove several intermediary variables and use bitwise operations for rounding.

Also micro optimize the `createDataSignals` benchmark further. Lazily initialize the GraphNode `o`bservers and `s`ources properties depending on the node type. For example, signals rarely have sources, while external nodes rarely have observers. Don't lazily initialize either map for selectors since they'll rarely benefit from that.

### Bottom Line

These changes improve these benchmarks:

- `avoidablePropagation` from 228 ms to 179 ms
- `broadPropagation` from 1400 ms to 742 ms. For comparison, SolidJS is at 643 ms. We're now where we should be.
- `deepPropagation` from 299 ms to 219 ms
- `diamond` from 505 ms to 385 ms
- `mux` from 434 ms to 291 ms
- `triangle` from 163 ms to 138 ms
- `createDataSignals` from ~28 ms to ~20 ms

All other benchmarks are marginally better.

<details>
  <summary>Full Kairo Bench Comparison</summary>
  <pre>framework        , test                                                         , time     , gcTime
@angular/signals , avoidablePropagation                                         , 640.54   , 121.76
@angular/signals , broadPropagation                                             , 944.50   , 24.01 
@angular/signals , deepPropagation                                              , 282.20   , 8.13  
@angular/signals , diamond                                                      , 483.01   , 56.56 
@angular/signals , mux                                                          , 823.98   , 16.03 
@angular/signals , repeatedObservers                                            , 38.61    , 5.87  
@angular/signals , triangle                                                     , 180.10   , 10.43 
@angular/signals , unstable                                                     , 62.52    , 7.36  
Jotai            , avoidablePropagation                                         , 3142.20  , 563.09
Jotai            , broadPropagation                                             , 6280.17  , 731.89
Jotai            , deepPropagation                                              , 2272.49  , 262.63
Jotai            , diamond                                                      , 3465.44  , 512.21
Jotai            , mux                                                          , 2513.68  , 200.57
Jotai            , repeatedObservers                                            , 408.73   , 56.90 
Jotai            , unstable                                                     , 821.12   , 85.63 
MobX             , avoidablePropagation                                         , 623.04   , 20.07 
MobX             , broadPropagation                                             , 1522.91  , 49.09 
MobX             , deepPropagation                                              , 594.80   , 15.82 
MobX             , diamond                                                      , 781.18   , 20.74 
MobX             , mux                                                          , 688.26   , 14.48 
MobX             , repeatedObservers                                            , 56.85    , 1.74  
MobX             , triangle                                                     , 262.09   , 6.78  
MobX             , unstable                                                     , 109.23   , 2.28  
$mol_wire_atom   , avoidablePropagation                                         , 288.26   , 8.50  
$mol_wire_atom   , broadPropagation                                             , 851.97   , 19.57 
$mol_wire_atom   , deepPropagation                                              , 212.10   , 2.58  
$mol_wire_atom   , diamond                                                      , 368.64   , 10.47 
$mol_wire_atom   , mux                                                          , 619.45   , 13.67 
$mol_wire_atom   , repeatedObservers                                            , 102.80   , 2.31  
$mol_wire_atom   , triangle                                                     , 115.14   , 1.83  
$mol_wire_atom   , unstable                                                     , 181.30   , 2.91  
Preact Signals   , avoidablePropagation                                         , 135.82   , 0.69  
Preact Signals   , broadPropagation                                             , 229.31   , 0.00  
Preact Signals   , deepPropagation                                              , 103.11   , 0.00  
Preact Signals   , diamond                                                      , 170.38   , 0.77  
Preact Signals   , mux                                                          , 241.01   , 1.67  
Preact Signals   , repeatedObservers                                            , 30.87    , 0.00  
Preact Signals   , triangle                                                     , 60.67    , 0.20  
Preact Signals   , unstable                                                     , 50.99    , 0.00  
@reactively      , avoidablePropagation                                         , 186.15   , 1.55  
@reactively      , broadPropagation                                             , 293.15   , 0.77  
@reactively      , deepPropagation                                              , 134.48   , 0.00  
@reactively      , diamond                                                      , 185.86   , 1.18  
@reactively      , mux                                                          , 263.29   , 2.00  
@reactively      , repeatedObservers                                            , 48.45    , 0.17  
@reactively      , triangle                                                     , 61.25    , 0.47  
@reactively      , unstable                                                     , 127.62   , 6.31  
s-js             , avoidablePropagation                                         , 255.20   , 0.73  
s-js             , broadPropagation                                             , 218.72   , 0.00  
s-js             , deepPropagation                                              , 68.07    , 0.00  
s-js             , diamond                                                      , 173.15   , 0.73  
s-js             , mux                                                          , 296.73   , 2.07  
s-js             , repeatedObservers                                            , 83.33    , 0.00  
s-js             , triangle                                                     , 61.31    , 0.18  
s-js             , unstable                                                     , 118.78   , 0.00  
SolidJS          , avoidablePropagation                                         , 294.30   , 4.33  
SolidJS          , broadPropagation                                             , 634.77   , 4.15  
SolidJS          , deepPropagation                                              , 249.49   , 1.92  
SolidJS          , diamond                                                      , 373.04   , 4.65  
SolidJS          , mux                                                          , 427.31   , 3.78  
SolidJS          , repeatedObservers                                            , 123.96   , 1.30  
SolidJS          , triangle                                                     , 145.96   , 2.07  
SolidJS          , unstable                                                     , 169.66   , 1.70  
Zedux            , avoidablePropagation                                         , 177.73   , 6.96  
Zedux            , broadPropagation                                             , 748.41   , 12.38 
Zedux            , deepPropagation                                              , 220.65   , 4.43  
Zedux            , diamond                                                      , 379.48   , 9.15  
Zedux            , mux                                                          , 301.38   , 5.41  
Zedux            , repeatedObservers                                            , 38.64    , 0.50  
Zedux            , triangle                                                     , 137.44   , 2.66  
Zedux            , unstable                                                     , 91.89    , 3.29  </pre>
</details>