### PR TITLE
feat(atoms)!: support `@atom` node type filter in `findAll` and `dehydrate`

### DIFF
--- a/packages/atoms/src/classes/GraphNode.ts
+++ b/packages/atoms/src/classes/GraphNode.ts
@@ -259,7 +259,12 @@ export abstract class GraphNode<G extends NodeGenerics = AnyNodeGenerics>
    * typically called by `node.d`ehydrate to perform its filtering logic.
    *
    * This is made to be universally compatible with all Zedux's built-in node
-   * classes. Custom nodes (e.g. that extend `Signal`) may need to override it
+   * classes. Custom nodes (e.g. that extend `Signal`) may need to override it.
+   *
+   * NOTE: This is only designed to work with Zedux's default id structure
+   * (where every node except atoms has an `@` prefix). When supplying a custom
+   * `makeId` function, you should call `ecosystem.findAll()` (with no
+   * arguments) and filter/dehydrate the list of nodes yourself.
    */
   public f(options?: NodeFilter): boolean | undefined | void {
     const { id, t } = this
@@ -276,7 +281,9 @@ export abstract class GraphNode<G extends NodeGenerics = AnyNodeGenerics>
     const isExcluded =
       exclude.some(templateOrKey =>
         typeof templateOrKey === 'string'
-          ? lowerCaseId.includes(templateOrKey.toLowerCase())
+          ? templateOrKey === '@atom'
+            ? !lowerCaseId.startsWith('@')
+            : lowerCaseId.includes(templateOrKey.toLowerCase())
           : (t?.key && (templateOrKey as AtomTemplateBase)?.key === t?.key) ||
             templateOrKey === t
       ) || excludeTags.some(tag => t.tags?.includes(tag))
@@ -286,7 +293,9 @@ export abstract class GraphNode<G extends NodeGenerics = AnyNodeGenerics>
       ((!include.length && !includeTags.length) ||
         include.some(templateOrKey =>
           typeof templateOrKey === 'string'
-            ? lowerCaseId.includes(templateOrKey.toLowerCase())
+            ? templateOrKey === '@atom'
+              ? !lowerCaseId.startsWith('@')
+              : lowerCaseId.includes(templateOrKey.toLowerCase())
             : (t?.key && (templateOrKey as AtomTemplateBase)?.key === t?.key) ||
               templateOrKey === t
         ) ||

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -103,7 +103,11 @@ export interface DehydrationOptions extends NodeFilterOptions {
   transform?: boolean
 }
 
-export type DehydrationFilter = string | AnyAtomTemplate | DehydrationOptions
+export type DehydrationFilter =
+  | string
+  | NodeType
+  | AnyAtomTemplate
+  | DehydrationOptions
 
 export interface EcosystemConfig<
   Context extends Record<string, any> | undefined = any
@@ -382,17 +386,26 @@ export interface Observable<T = any> {
 }
 
 export interface NodeFilterOptions {
-  exclude?: (AnyAtomTemplate | AtomSelectorOrConfig | string)[]
+  exclude?: (AnyAtomTemplate | AtomSelectorOrConfig | NodeType | string)[]
   excludeTags?: string[]
-  include?: (AnyAtomTemplate | AtomSelectorOrConfig | string)[]
+  include?: (AnyAtomTemplate | AtomSelectorOrConfig | NodeType | string)[]
   includeTags?: string[]
 }
 
 export type NodeFilter =
   | string
+  | NodeType
   | AnyAtomTemplate
   | AtomSelectorOrConfig
   | NodeFilterOptions
+
+export type NodeType =
+  | '@atom'
+  | '@component'
+  | '@listener'
+  | '@memo'
+  | '@selector'
+  | '@signal'
 
 /**
  * Reads better than `Record<never, never>` in atom generics

--- a/packages/react/test/integrations/ecosystem.test.tsx
+++ b/packages/react/test/integrations/ecosystem.test.tsx
@@ -257,15 +257,21 @@ describe('ecosystem', () => {
     ecosystem.getInstance(atomA, ['aa'])
     ecosystem.getInstance(atomB)
 
-    expect(ecosystem.findAll(atomA)).toEqual({
-      'a-["a"]': expect.objectContaining({ params: ['a'] }),
-      'a-["aa"]': expect.objectContaining({ params: ['aa'] }),
-    })
+    expect(ecosystem.findAll(atomA)).toEqual([
+      expect.objectContaining({ id: 'a-["a"]', params: ['a'] }),
+      expect.objectContaining({ id: 'a-["aa"]', params: ['aa'] }),
+    ])
 
-    expect(ecosystem.findAll('a')).toEqual({
-      'a-["a"]': expect.objectContaining({ params: ['a'] }),
-      'a-["aa"]': expect.objectContaining({ params: ['aa'] }),
-    })
+    expect(ecosystem.findAll('a')).toEqual([
+      expect.objectContaining({ id: 'a-["a"]', params: ['a'] }),
+      expect.objectContaining({ id: 'a-["aa"]', params: ['aa'] }),
+    ])
+
+    expect(ecosystem.findAll('@atom').map(({ id }) => id)).toEqual([
+      'a-["a"]',
+      'a-["aa"]',
+      'b',
+    ])
 
     ecosystem.reset({ listeners: true })
   })

--- a/packages/react/test/integrations/graph.test.tsx
+++ b/packages/react/test/integrations/graph.test.tsx
@@ -168,11 +168,11 @@ describe('graph', () => {
 
     const ionInstance = ecosystem.getNode(ion1)
 
-    expect(ecosystem.findAll()).toEqual({
-      atom1: expect.any(Object),
-      atom2: expect.any(Object),
-      ion1: expect.any(Object),
-    })
+    expect(ecosystem.findAll().map(({ id }) => id)).toEqual([
+      'atom1',
+      'atom2',
+      'ion1',
+    ])
 
     snapshotNodes()
     expect(evaluations).toEqual([1])

--- a/packages/react/test/integrations/scoped-atoms.test.tsx
+++ b/packages/react/test/integrations/scoped-atoms.test.tsx
@@ -180,7 +180,7 @@ describe('scoped atoms', () => {
     // 2 parents, 4 children, 2 nested, 6 external
     expect(ecosystem.n.size).toBe(14)
 
-    expect(Object.keys(ecosystem.findAll())).toEqual([
+    expect(ecosystem.findAll().map(({ id }) => id)).toEqual([
       'child-@scope("a",parent-[1])',
       'child-@scope("a",parent-[2])',
       'child-@scope("b",parent-[1])',
@@ -205,7 +205,7 @@ describe('scoped atoms', () => {
 
     expect(ecosystem.n.size).toBe(14) // 2 new children, 2 destroyed
 
-    expect(Object.keys(ecosystem.findAll())).toEqual([
+    expect(ecosystem.findAll().map(({ id }) => id)).toEqual([
       'child-@scope("aa",parent-[1])',
       'child-@scope("aa",parent-[2])',
       'child-@scope("b",parent-[1])',
@@ -231,7 +231,7 @@ describe('scoped atoms', () => {
 
     expect(ecosystem.n.size).toBe(14) // no changes
 
-    expect(Object.keys(ecosystem.findAll())).toEqual([
+    expect(ecosystem.findAll().map(({ id }) => id)).toEqual([
       'child-@scope("aa",parent-[1])',
       'child-@scope("aa",parent-[2])',
       'child-@scope("b",parent-[1])',
@@ -340,7 +340,7 @@ describe('scoped atoms', () => {
     // 4 parents, 4 children, 4 nested, 4 middle, 4 top, 8 external
     expect(ecosystem.n.size).toBe(28)
 
-    expect(Object.keys(ecosystem.findAll())).toMatchSnapshot()
+    expect(ecosystem.findAll().map(({ id }) => id)).toMatchSnapshot()
 
     act(() => {
       button1.click()
@@ -357,7 +357,7 @@ describe('scoped atoms', () => {
     // 4 parents, 4 children, 4 nested, 4 middle, 4 top, 8 external
     expect(ecosystem.n.size).toBe(28)
 
-    expect(Object.keys(ecosystem.findAll())).toMatchSnapshot()
+    expect(ecosystem.findAll().map(({ id }) => id)).toMatchSnapshot()
 
     const scope = new Map<Record<string, any>, any>([
       [context, 'b'],
@@ -379,7 +379,7 @@ describe('scoped atoms', () => {
     // 4 parents, 4 children, 4 nested, 4 middle, 4 top, 8 external
     expect(ecosystem.n.size).toBe(28)
 
-    expect(Object.keys(ecosystem.findAll())).toMatchSnapshot()
+    expect(ecosystem.findAll().map(({ id }) => id)).toMatchSnapshot()
 
     act(() => {
       childInstance.destroy(true)
@@ -391,7 +391,7 @@ describe('scoped atoms', () => {
     // 4 parents, 4 children, 4 nested, 4 middle, 4 top, 8 external
     expect(ecosystem.n.size).toBe(28)
 
-    expect(Object.keys(ecosystem.findAll())).toMatchSnapshot()
+    expect(ecosystem.findAll().map(({ id }) => id)).toMatchSnapshot()
   })
 
   test('React context reference changes create new scopes', async () => {
@@ -437,7 +437,7 @@ describe('scoped atoms', () => {
     expect(calls).toEqual([{ a: { b: 1 } }])
     calls.splice(0, calls.length)
 
-    expect(Object.keys(ecosystem.findAll())).toEqual([
+    expect(ecosystem.findAll().map(({ id }) => id)).toEqual([
       '@selector(unknown)-1-@scope({"a":{"b":1}})',
       'child-@scope({"a":{"b":1}})',
     ])
@@ -449,7 +449,7 @@ describe('scoped atoms', () => {
     expect(child).toHaveTextContent('2')
     expect(calls).toEqual([{ a: { b: 2 } }])
 
-    expect(Object.keys(ecosystem.findAll())).toEqual([
+    expect(ecosystem.findAll().map(({ id }) => id)).toEqual([
       '@selector(unknown)-1-@scope({"a":{"b":1}})',
       'child-@scope({"a":{"b":1}})',
       'child-@scope({"a":{"b":2}})',

--- a/packages/react/test/stores/graph.test.tsx
+++ b/packages/react/test/stores/graph.test.tsx
@@ -161,11 +161,11 @@ describe('graph', () => {
 
     const ionInstance = ecosystem.getInstance(ion1)
 
-    expect(ecosystem.findAll()).toEqual({
-      atom1: expect.any(Object),
-      atom2: expect.any(Object),
-      ion1: expect.any(Object),
-    })
+    expect(ecosystem.findAll().map(({ id }) => id)).toEqual([
+      'atom1',
+      'atom2',
+      'ion1',
+    ])
 
     snapshotNodes()
     expect(evaluations).toEqual([1])

--- a/packages/react/test/stores/ssr.test.tsx
+++ b/packages/react/test/stores/ssr.test.tsx
@@ -273,4 +273,18 @@ describe('ssr', () => {
       b: 'ab',
     })
   })
+
+  test('dehydrate only atoms with "@atom"', () => {
+    const atom1 = atom('1', 1)
+    const atom2 = atom('2', 2)
+    const atom3 = ion('3', ({ get }) => get(atom1) + get(atom2))
+
+    ecosystem.getNode(atom3)
+
+    expect(ecosystem.dehydrate('@atom')).toEqual({
+      1: 1,
+      2: 2,
+      3: 3,
+    })
+  })
 })

--- a/packages/react/test/units/Ecosystem.test.tsx
+++ b/packages/react/test/units/Ecosystem.test.tsx
@@ -127,12 +127,9 @@ describe('Ecosystem', () => {
   test('findAll() with no params returns all atom instances', () => {
     const atom1 = atom('1', (id: number) => id)
 
-    const instances = Array(10)
+    const expected = Array(10)
       .fill(null)
       .map((_, i) => ecosystem.getInstance(atom1, [i]))
-    const expected = Object.fromEntries(
-      instances.map(instance => [instance.id, instance])
-    )
 
     expect(ecosystem.findAll()).toEqual(expected)
   })

--- a/packages/react/test/units/SelectorInstance.test.tsx
+++ b/packages/react/test/units/SelectorInstance.test.tsx
@@ -118,32 +118,37 @@ describe('the SelectorInstance class', () => {
 
   test('ecosystem.findAll() accepts selector refs or string ids', () => {
     const instance = ecosystem.getNode(selector3)
-    const allNodes = ecosystem.findAll()
 
-    expect(Object.keys(allNodes)).toEqual([
-      '1',
+    expect(ecosystem.findAll().map(({ id }) => id)).toEqual([
       '@selector(selector1)-3',
       '@selector(selector2)-2',
       '@selector(selector3)-1', // the id for selector3 is generated first
+      '1',
     ])
 
-    const instances1 = ecosystem.findAll('selector2')
+    expect(ecosystem.findAll('selector2')).toEqual([
+      ecosystem.getNode(selector2),
+    ])
 
-    expect(instances1).toEqual({
-      '@selector(selector2)-2': ecosystem.getNode(selector2),
-    })
+    expect(ecosystem.findAll(selector3)).toEqual([instance])
 
-    const instances2 = ecosystem.findAll(selector3)
+    expect(ecosystem.findAll('@selector').map(({ id }) => id)).toEqual([
+      '@selector(selector1)-3',
+      '@selector(selector2)-2',
+      '@selector(selector3)-1',
+    ])
 
-    expect(instances2).toEqual({
-      '@selector(selector3)-1': instance,
-    })
+    expect(ecosystem.findAll('@atom').map(({ id }) => id)).toEqual(['1'])
+
+    expect(
+      ecosystem.findAll({ include: ['@atom'] }).map(({ id }) => id)
+    ).toEqual(['1'])
   })
 
   test("ecosystem.findAll() returns an empty object if the selector hasn't been cached", () => {
     ecosystem.getNode(selector2)
 
-    expect(ecosystem.findAll(selector3)).toEqual({})
+    expect(ecosystem.findAll(selector3)).toEqual([])
   })
 
   test('getNode(instance) returns the passed instance', () => {


### PR DESCRIPTION
## Description

Zedux's "built-in devtools", `ecosystem.findAll` and `ecosystem.dehydrate` received some upgrades for v2. But hitherto, there was still no good way to make them return only atoms.

While #201 made all other node types easier to search for by simply passing an `@` prefix, it did not give atoms an `@atom` prefix. I think it still makes sense that these methods should accept `@atom` specifically.

So: Give both `findAll` and `dehydrate` an overload for TS auto completion of the node types. Handle the `@atom` string specifically.

```ts
ecosystem.findAll('@atom') // get a list of all atom nodes
ecosystem.findAll('@selector') // get a list of all selector nodes
ecosystem.findAll('@component') // get a list of all React component nodes
ecosystem.findAll({ include: ['@atom', '@signal'] }) // get a list of all atom or signal nodes
ecosystem.findAll({ exclude: ['@component', '@selector'] }) // get all nodes but components/selectors
```

`ecosystem.dehydrate` works exactly the same (but returning an object with dehydrated state values).

### Breaking Changes

To better support custom ids where you might have to manually filter nodes yourself, `ecosystem.findAll` now returns an array instead of an object keyed by node id.

Before, you'd have to use `Object.values` to get the list of returned nodes for manually iterating. That was annoying. Now this API more closely aligns to `document.querySelectorAll` which is probably where the `*All` namesake came from.

```ts
// before:
const nodes = Object.values(ecosystem.findAll('my/atom/key')).filter(myCustomFilter)
// after:
const nodes = ecosystem.findAll('my/atom/key').filter(myCustomFilter)
```

In particular, I did this all the time:

```ts
console.log(Object.values(ecosystem.findAll('my/namespace')).map(({ id }) => id))
// now it's:
console.log(ecosystem.findAll('my/namespace').map(({ id }) => id))
```

Additonally, making the `@atom` string filter by all atoms is technically a breaking change. It's a best practice to not use the `@` character in atom keys/manual id strings so Zedux can add features like this.