### PR TITLE
release: v2.0.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v2.0.0-beta.6 (Mar 11, 2025)
+
+### New Features:
+
+- **Breaking Change** `atoms`: support `@atom` node type filter in `findAll` and `dehydrate` (#204)
+- **Breaking Change** `atoms`, `stores`: use a singly-linked list for evaluation reasons (#202)
+- **Breaking Change** `atoms`, `react`, `stores`: standardize id generation (#201)
+- **Breaking Change** `atoms`, `core`, `immer`, `machines`, `react`, `stores`: separate sync and async schedulers (#200)
+
 ## v2.0.0-beta.5 (Feb 28, 2025)
 
 ### New Features:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zedux",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "A Molecular State Engine for React",
   "type": "module",
   "author": "Joshua Claunch (bowheart <bowheart31@gmail.com>)",

--- a/packages/atoms/package.json
+++ b/packages/atoms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/atoms",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/core",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "A high-level, declarative, composable form of Redux",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/immer",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "Official Immer integration for Zedux's store and atomic APIs",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,11 +10,11 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/stores": "2.0.0-beta.5"
+    "@zedux/stores": "2.0.0-beta.6"
   },
   "devDependencies": {
-    "@zedux/atoms": "2.0.0-beta.5",
-    "@zedux/core": "2.0.0-beta.5",
+    "@zedux/atoms": "2.0.0-beta.6",
+    "@zedux/core": "2.0.0-beta.6",
     "immer": "^10.1.1"
   },
   "exports": {
@@ -39,7 +39,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/atoms": "2.0.0-beta.5",
+    "@zedux/atoms": "2.0.0-beta.6",
     "immer": ">=9.0.19"
   },
   "repository": {

--- a/packages/machines/package.json
+++ b/packages/machines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/machines",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "Simple native state machine implementation for Zedux atoms",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,11 +10,11 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/stores": "2.0.0-beta.5"
+    "@zedux/stores": "2.0.0-beta.6"
   },
   "devDependencies": {
-    "@zedux/atoms": "2.0.0-beta.5",
-    "@zedux/core": "2.0.0-beta.5"
+    "@zedux/atoms": "2.0.0-beta.6",
+    "@zedux/core": "2.0.0-beta.6"
   },
   "exports": {
     ".": {
@@ -39,8 +39,8 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/atoms": "2.0.0-beta.5",
-    "@zedux/core": "2.0.0-beta.5"
+    "@zedux/atoms": "2.0.0-beta.6",
+    "@zedux/core": "2.0.0-beta.6"
   },
   "repository": {
     "directory": "packages/machines",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/react",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/atoms": "2.0.0-beta.5"
+    "@zedux/atoms": "2.0.0-beta.6"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/stores",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "The legacy composable store model of Zedux",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,8 +10,8 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/atoms": "2.0.0-beta.5",
-    "@zedux/core": "2.0.0-beta.5"
+    "@zedux/atoms": "2.0.0-beta.6",
+    "@zedux/core": "2.0.0-beta.6"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
## Description

Increment monorepo package versions and update the CHANGELOG for version 2.0.0-beta.6.

This PR was generated by the release script at https://github.com/Omnistac/zedux/tree/master/scripts/release.js

The packages will be published to npm and a GitHub release will be created after this PR merges.