### PR TITLE
feat(atoms): make wrapper functions reuse wrapped function names

### DIFF
--- a/packages/atoms/src/injectors/injectCallback.ts
+++ b/packages/atoms/src/injectors/injectCallback.ts
@@ -20,14 +20,16 @@ export const injectCallback = <Args extends any[] = [], Ret = any>(
 ) => {
   const self = injectSelf()
 
-  return injectMemo(
-    () =>
-      (...args: Args) =>
-        self.e.batch(() =>
-          self.V
-            ? self.e.withScope(self.V, () => callback(...args))
-            : callback(...args)
-        ),
-    deps
-  )
+  return injectMemo(() => {
+    const wrapperFn = (...args: Args) =>
+      self.e.batch(() =>
+        self.V
+          ? self.e.withScope(self.V, () => callback(...args))
+          : callback(...args)
+      )
+
+    Object.defineProperty(wrapperFn, 'name', { value: callback.name })
+
+    return wrapperFn
+  }, deps)
 }

--- a/packages/react/test/integrations/injectors.test.tsx
+++ b/packages/react/test/integrations/injectors.test.tsx
@@ -374,4 +374,17 @@ describe('injectors', () => {
 
     expect(node1.get()).toBe(0)
   })
+
+  test('injectCallback preserves the callback name', () => {
+    const fn = () => {}
+    let callback: typeof fn | undefined
+
+    const atom1 = atom('1', () => {
+      callback = injectCallback(fn, [])
+    })
+
+    ecosystem.getNode(atom1)
+
+    expect(callback?.name).toBe('fn')
+  })
 })

--- a/packages/react/test/units/AtomApi.test.tsx
+++ b/packages/react/test/units/AtomApi.test.tsx
@@ -1,0 +1,20 @@
+import { api, atom } from '@zedux/atoms'
+import { ecosystem } from '../utils/ecosystem'
+
+describe('AtomApi', () => {
+  test('exports are not wrapped when set outside an atom', () => {
+    const fn = () => {}
+    const testApi = api().setExports({ fn })
+
+    expect(testApi.exports?.fn).toBe(fn)
+  })
+
+  test('wrapped exports have the same name as the wrapped function', () => {
+    const fn = () => {}
+    const atom1 = atom('1', () => api().setExports({ fn }))
+    const node1 = ecosystem.getNode(atom1)
+
+    expect(node1.exports.fn).not.toBe(fn)
+    expect(node1.exports.fn.name).toBe('fn')
+  })
+})


### PR DESCRIPTION
## Description

make `injectCallback` and wrapped exports in AtomAPIs set the wrapping function's name to the name of the wrapped function. Add tests.