### PR TITLE
feat!: rename `getInstanceId` to `getNodeId` and add a `scope` option

### DIFF
--- a/docs/docs/migrations/v2.mdx
+++ b/docs/docs/migrations/v2.mdx
@@ -660,6 +660,7 @@ This section is a work in progress
 - `atomInstance._promiseError` -> `atomInstance.promiseError`
 - `{ flags }` -> `{ tags }` (in atom config objects)
 - `{ includeFlags, excludeFlags }` -> `{ includeTags, excludeTags }` (in the object passed to `ecosystem.dehydrate`)
+- `atomTemplate.getInstanceId` -> `atomTemplate.getNodeId`
 
 For mods (previously added to `ZeduxPlugin`s, now "ecosystem events" registered with `ecosystem.on`), replace:
 
@@ -804,3 +805,6 @@ Some public-but-underscore-prefixed properties changed. Most apps shouldn't have
 
 - `ecosystem._consumeHydration`. Removed. The `cycle` ecosystem event can be used to delete `ecosystem.hydration` entries yourself when hydrated nodes become `Active`.
 - `_createdAt` (the property on atom and selector instances). Removed. Plugins can track time created themselves if needed.
+- `atomTemplate._createInstance`. Renamed to `atomTemplate._instantiate`. Zedux uses this internally. You shouldn't use it manually.
+- `atomTemplate._config`. Renamed to `atomTemplate.c` (short for `config`). This is for internal use so it's obfuscated
+- `atomTemplate._value`. Renamed to `atomTemplate.v` (short for `valueOrFactory`). This is for internal use.

--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -414,7 +414,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
 
     if (!isString) {
       const id = isTemplate
-        ? (template as AnyAtomTemplate).getInstanceId(this, params)
+        ? (template as AnyAtomTemplate).getNodeId(this, params)
         : getSelectorKey(this, template as AtomSelectorOrConfig)
 
       // try to find an existing instance

--- a/packages/atoms/src/classes/ZeduxNode.ts
+++ b/packages/atoms/src/classes/ZeduxNode.ts
@@ -11,6 +11,7 @@ import {
   NodeFilter,
   NodeFilterOptions,
   NodeGenerics,
+  Scope,
 } from '@zedux/atoms/types/index'
 import { Ecosystem } from './Ecosystem'
 import {
@@ -80,12 +81,7 @@ export abstract class ZeduxNode<G extends NodeGenerics = AnyNodeGenerics>
    * provided. If the values have changed, a new atom instance is created with
    * the new scope.
    */
-  public V:
-    | Map<
-        Record<string, any>,
-        WeakRef<any> | number | string | boolean | null | undefined
-      >
-    | undefined = undefined
+  public V: Scope | undefined = undefined
 
   /**
    * @see Job.W

--- a/packages/atoms/src/classes/instances/AtomInstance.ts
+++ b/packages/atoms/src/classes/instances/AtomInstance.ts
@@ -92,15 +92,15 @@ export type InjectorDescriptor<T = any> = {
 const evaluate = <G extends Omit<AtomGenerics, 'Node'>>(
   instance: AtomInstance<G>
 ) => {
-  const { _value } = instance.t
+  const { v } = instance.t
 
-  if (typeof _value !== 'function') {
-    return _value
+  if (typeof v !== 'function') {
+    return v
   }
 
   try {
     const val = (
-      _value as (
+      v as (
         ...params: G['Params']
       ) => Signal<G> | G['State'] | AtomApi<AtomGenericsToAtomApiGenerics<G>>
     )(...instance.p)

--- a/packages/atoms/src/classes/templates/AtomTemplate.ts
+++ b/packages/atoms/src/classes/templates/AtomTemplate.ts
@@ -31,11 +31,9 @@ export class AtomTemplate<
   G extends AtomGenerics = AnyAtomGenerics
 > extends AtomTemplateBase<G> {
   /**
-   * This method should be overridden when creating custom atom classes that
-   * create a custom atom instance class. Return a new instance of your atom
-   * instance class.
+   * @see AtomTemplateBase._instantiate
    */
-  public _createInstance(
+  public _instantiate(
     ecosystem: Ecosystem,
     id: string,
     params: G['Params']
@@ -50,7 +48,7 @@ export class AtomTemplate<
       }
     >
   ): AtomTemplate<G> {
-    const newAtom = atom(this.key, newValue, this._config)
+    const newAtom = atom(this.key, newValue, this.c)
     newAtom._isOverride = true
     return newAtom as any
   }

--- a/packages/atoms/src/classes/templates/IonTemplate.ts
+++ b/packages/atoms/src/classes/templates/IonTemplate.ts
@@ -32,12 +32,12 @@ export class IonTemplate<
   constructor(
     key: string,
     stateFactory: IonStateFactory<Omit<G, 'Node' | 'Template'>>,
-    _config?: AtomConfig<G['State']>
+    config?: AtomConfig<G['State']>
   ) {
     super(
       key,
       (...params: G['Params']) => stateFactory(injectEcosystem(), ...params),
-      _config
+      config
     )
   }
 }

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -457,6 +457,11 @@ export interface RefObject<T = any> {
   readonly current: T | null
 }
 
+export type Scope = Map<
+  Record<string, any>,
+  WeakRef<any> | number | string | boolean | null | undefined
+>
+
 export type Selectable<State = any, Params extends any[] = any> =
   | AtomSelectorOrConfig<State, Params>
   | SelectorInstance<{

--- a/packages/atoms/src/utils/ecosystem.ts
+++ b/packages/atoms/src/utils/ecosystem.ts
@@ -102,7 +102,7 @@ export const getNode = <G extends AtomGenerics>(
   }
 
   if (is(template, AtomTemplateBase)) {
-    const id = (template as AtomTemplate).getInstanceId(ecosystem, params)
+    const id = (template as AtomTemplate).getNodeId(ecosystem, params)
 
     // try to find an existing instance
     let instance = ecosystem.n.get(id) as AtomInstance
@@ -128,7 +128,7 @@ export const getNode = <G extends AtomGenerics>(
     }
 
     // create a new instance
-    instance = resolveAtom(ecosystem, template as AtomTemplate)._createInstance(
+    instance = resolveAtom(ecosystem, template as AtomTemplate)._instantiate(
       ecosystem,
       id,
       (params || []) as G['Params']

--- a/packages/react/test/integrations/scoped-atoms.test.tsx
+++ b/packages/react/test/integrations/scoped-atoms.test.tsx
@@ -670,4 +670,22 @@ describe('scoped atoms', () => {
     )
     expect(mock).toHaveBeenCalledTimes(1)
   })
+
+  test('`AtomTemplate#getNodeId` can return scoped strings', () => {
+    const template = atom('1', (id?: string) => id)
+
+    const scope = new Map<Record<string, any>, any>([[template, 'b']])
+
+    expect(template.getNodeId(ecosystem, [], { scope })).toBe('1-@scope("b")')
+
+    expect(template.getNodeId(ecosystem, ['a'], { scope })).toBe(
+      '1-["a"]-@scope("b")'
+    )
+
+    scope.set({}, 'c')
+
+    expect(template.getNodeId(ecosystem, ['a'], { scope })).toBe(
+      '1-["a"]-@scope("b","c")'
+    )
+  })
 })

--- a/packages/react/test/legacy-types.test.tsx
+++ b/packages/react/test/legacy-types.test.tsx
@@ -741,10 +741,10 @@ describe('react types', () => {
   })
 
   test('recursive templates and nodes', () => {
-    const instanceA = exampleAtom._createInstance(ecosystem, 'a', ['b'])
-    const instanceB = instanceA.t._createInstance(ecosystem, '', ['b'])
-    const instanceC = instanceB.t._createInstance(ecosystem, '', ['b'])
-    const instanceD = instanceC.t._createInstance(ecosystem, '', ['b'])
+    const instanceA = exampleAtom._instantiate(ecosystem, 'a', ['b'])
+    const instanceB = instanceA.t._instantiate(ecosystem, '', ['b'])
+    const instanceC = instanceB.t._instantiate(ecosystem, '', ['b'])
+    const instanceD = instanceC.t._instantiate(ecosystem, '', ['b'])
 
     expectTypeOf<AtomParamsType<typeof instanceD.t>>().toEqualTypeOf<
       [p: string]

--- a/packages/react/test/types.test.tsx
+++ b/packages/react/test/types.test.tsx
@@ -698,10 +698,10 @@ describe('react types', () => {
   })
 
   test('recursive templates and nodes', () => {
-    const instanceA = exampleAtom._createInstance(ecosystem, 'a', ['b'])
-    const instanceB = instanceA.t._createInstance(ecosystem, '', ['b'])
-    const instanceC = instanceB.t._createInstance(ecosystem, '', ['b'])
-    const instanceD = instanceC.t._createInstance(ecosystem, '', ['b'])
+    const instanceA = exampleAtom._instantiate(ecosystem, 'a', ['b'])
+    const instanceB = instanceA.t._instantiate(ecosystem, '', ['b'])
+    const instanceC = instanceB.t._instantiate(ecosystem, '', ['b'])
+    const instanceD = instanceC.t._instantiate(ecosystem, '', ['b'])
 
     expectTypeOf<ParamsOf<typeof instanceD.t>>().toEqualTypeOf<[p: string]>()
 

--- a/packages/stores/src/AtomInstance.ts
+++ b/packages/stores/src/AtomInstance.ts
@@ -295,15 +295,15 @@ export class AtomInstance<
    * - A function that returns an AtomApi
    */
   private _eval(): G['Store'] | G['State'] {
-    const { _value } = this.t
+    const { v } = this.t
 
-    if (typeof _value !== 'function') {
-      return _value
+    if (typeof v !== 'function') {
+      return v
     }
 
     try {
       const val = (
-        _value as (
+        v as (
           ...params: G['Params']
         ) => G['Store'] | G['State'] | AtomApi<AtomGenericsToAtomApiGenerics<G>>
       )(...this.p)

--- a/packages/stores/src/AtomTemplate.ts
+++ b/packages/stores/src/AtomTemplate.ts
@@ -26,10 +26,10 @@ export class AtomTemplate<
 > extends AtomTemplateBase<G> {
   constructor(
     key: string,
-    _value: AtomValueOrFactory<G>,
-    _config?: AtomConfig<G['State']> | undefined
+    valueOrFactory: AtomValueOrFactory<G>,
+    config?: AtomConfig<G['State']> | undefined
   ) {
-    super(key, _value, _config)
+    super(key, valueOrFactory, config)
   }
 
   /**
@@ -37,7 +37,7 @@ export class AtomTemplate<
    * create a custom atom instance class. Return a new instance of your atom
    * instance class.
    */
-  public _createInstance(
+  public _instantiate(
     ecosystem: Ecosystem,
     id: string,
     params: G['Params']
@@ -46,7 +46,7 @@ export class AtomTemplate<
   }
 
   public override(newValue: AtomValueOrFactory<G>): AtomTemplate<G> {
-    const newAtom = atom(this.key, newValue, this._config)
+    const newAtom = atom(this.key, newValue, this.c)
     newAtom._isOverride = true
     return newAtom as any
   }

--- a/packages/stores/src/IonTemplate.ts
+++ b/packages/stores/src/IonTemplate.ts
@@ -27,12 +27,12 @@ export class IonTemplate<
   constructor(
     key: string,
     stateFactory: IonStateFactory<Omit<G, 'Node' | 'Template'>>,
-    _config?: AtomConfig<G['State']>
+    config?: AtomConfig<G['State']>
   ) {
     super(
       key,
       (...params: G['Params']) => stateFactory(injectEcosystem(), ...params),
-      _config
+      config
     )
   }
 }


### PR DESCRIPTION
@affects atoms, stores

## Description

With the introduction of scoped atoms came the concept of scoped ids. These `@scope()`-suffixed ids can currently only be generated automatically by Zedux internals.

Expose a way to create scoped ids via the existing `getInstanceId` method on `AtomTemplateBase`. Pass an optional third object parameter with a `scope` map pointing contexts to their contextual values that should be added to the id. Also rename `getInstanceId` to `getNodeId` to match the new nomenclature.

```ts
import { atom, createEcosystem } from '@zedux/react'

const ecosystem = createEcosystem()
const contextAtom = atom('context', 'example state')

const scopedAtom = atom('scoped', () => {
  inject(contextAtom)
})

const scope = new Map([
  [contextAtom, ecosystem.getNode(contextAtom)]
])

const id = scopedAtom.getNodeId(ecosystem, [], { scope })

id // 'scoped-@scope("context")'
```

### Breaking Changes

The `AtomTemplateBase` class is the last thing that needs some love for Zedux v2. Rename:

- `getInstanceId`  -> `getNodeId`
- `_createInstance` -> `_instantiate`
- `_config` -> `c` (short for `config`)
- `_value` -> `v` (short for `valueOrFactory`)