### PR TITLE
feat!: improve `findAll`, ions, and clean up types, properties, and deprecations

### DIFF
--- a/docs/docs/migrations/v2.mdx
+++ b/docs/docs/migrations/v2.mdx
@@ -331,6 +331,10 @@ function App() {
 
 ## Other New Features
 
+- `ecosystem.findAll` now accepts all the same filtering parameters as `ecosystem.dehydrate` and then some:
+  - Pass an `@`-prefixed string like `@atom` or `@selector` to only return nodes of that type.
+  - The types have been improved to make editors autocomplete those `@`-prefixed strings, leading to some slick DX.
+  - Pass an array of filters (`.findAll([...myFilters])`) as a shorthand for `.findAll({ include: [...myFilters] })`
 - `untrack` - A new top-level export for bumping out of a reactive context.
 - When called with no deps, `injectMemo` now automatically tracks any signal usages in the callback and reactively updates when they change, causing the injecting atom to reevaluate.
 - `ecosystem.withScope` - Runs a callback in a scoped context with the passed scope.
@@ -510,7 +514,7 @@ const ecosystem = createEcosystem({
 
 `ecosystem.findAll` now returns an array instead of an object keyed by node id. This is to make it easier to sort/filter/map/reduce the returned list yourself.
 
-In particular, the default filtering logic is only designed for the default id generation. Now that you can easily customize ids with `makeId`, we need an API that lends itself to custom filtering of those ids better. Simply adding the ability to chain array operations directly off the `.findAll()` call is really all we need. It also makes manual dehydration easier:
+The default filtering logic is only designed for the default id generation. Now that you can easily customize ids with `makeId`, we need an API that lends itself to custom filtering of those ids better. Simply adding the ability to chain array operations directly off the `.findAll()` call is really all we need. It also makes manual dehydration easier:
 
 ```ts
 // custom dehydration example
@@ -519,6 +523,8 @@ ecosystem
   .filter(myCustomFilter)
   .reduce((obj, node) => ({ ...obj, [node.id]: node.get() }), {})
 ```
+
+The new signals-based ions now set `ttl: 0` by default. This reflects their primary purpose - to derive state. Derivations are usually transient and should be cleaned up (by default!) when no longer in use.
 
 ## Migrating to Signals
 
@@ -661,6 +667,7 @@ This section is a work in progress
 - `{ flags }` -> `{ tags }` (in atom config objects)
 - `{ includeFlags, excludeFlags }` -> `{ includeTags, excludeTags }` (in the object passed to `ecosystem.dehydrate`)
 - `atomTemplate.getInstanceId` -> `atomTemplate.getNodeId`
+- `AtomSelectorOrConfig` -> `SelectorTemplate`
 
 For mods (previously added to `ZeduxPlugin`s, now "ecosystem events" registered with `ecosystem.on`), replace:
 
@@ -675,6 +682,7 @@ Note that the `instanceReused` mod is removed with no equivalent (see below). Al
 
 Optionally replace deprecated APIs. May be needed for TS support in rare cases. These will be required in Zedux v3:
 
+- `atomInstance.setState` -> `atomInstance.set`
 - `atomGetters.select(selector, arg1, arg2)` -> `atomGetters.get(selector, [arg1, arg2])`
 - `useAtomSelector(selector, arg1, arg2)` -> `useAtomValue(selector, [arg1, arg2])`
 - `injectAtomSelector(selector, arg1, arg2)` -> `injectAtomValue(selector, [arg1, arg2])`
@@ -694,6 +702,7 @@ Also optionally replace some deprecated and/or "legacy" types:
 
 - `manualHydration` atom config option.
 - `AtomInstanceBase` usages. This was an unnecessary superclass. The `AtomInstance` class itself now handles everything this class did.
+- `atomDefaults` ecosystem config options. Use custom atom factories to share atom behaviors. Or use `ion`s to create `ttl: 0` atoms easily.
 - `ZeduxPlugin` usages. Use [ecosystem events](#feature-ecosystem-events) instead.
 - `instanceReused` mods. No replacement. We're working on build tool plugins to do what this mod was trying to do. Those will be released later.
 - reading `sourceType` field on evaluation reasons.
@@ -789,6 +798,7 @@ Replace:
 
 Remove:
 
+- `ttl: 0` in ions. This is the default for signals-based ions. That also means you may need to add `ttl: -1` (infinity) to ions that you don't want to give `ttl: 0` (tip: If you're unsure, leave the new default alone).
 - `createStore`. Use mapped signals instead for composing state primitives. Use `ecosystem.signal` instead for creating state containers on the fly.
 - `atomInstance.store`. Signal-based atoms don't expose the underlying signal. Use the atom instance itself; it forwards all state updates and sent events to wrapped signals
   - `atomInstance.store.getState` -> `atomInstance.getOnce` (but prefer `.get` for automatic reactivity)

--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -5,7 +5,7 @@ import {
   NodeOf,
   ParamsOf,
   AtomSelectorConfig,
-  AtomSelectorOrConfig,
+  SelectorTemplate,
   StateOf,
   Cleanup,
   DehydrationFilter,
@@ -85,7 +85,6 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
   implements EventEmitter, Job
 {
   public asyncScheduler = new AsyncScheduler(this)
-  public atomDefaults: EcosystemConfig['atomDefaults'] | undefined = undefined
   public complexParams = false
 
   // @ts-expect-error context can be specifically undefined, and that's its type
@@ -168,7 +167,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
    * selectorKey that can be used to predictably create selectorKey+params ids
    * to look up the cached selector instance in `this.n`odes.
    */
-  public b = new WeakMap<AtomSelectorOrConfig, string>()
+  public b = new WeakMap<SelectorTemplate, string>()
 
   /**
    * `c`urrent `f`inishBuffer - the currently-used `finishBuffer`
@@ -383,30 +382,28 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
   >(
     template: G extends AtomGenerics
       ? AtomTemplateBase<G>
-      : AtomSelectorOrConfig<G>,
+      : SelectorTemplate<G>,
     params: G['Params']
   ): G['Node'] | undefined
 
   public find<
     G extends Pick<AtomGenerics, 'Node' | 'State' | 'Template'> & { Params: [] }
   >(
-    template: G extends AtomGenerics
-      ? AtomTemplateBase<G>
-      : AtomSelectorOrConfig<G>
+    template: G extends AtomGenerics ? AtomTemplateBase<G> : SelectorTemplate<G>
   ): G['Node'] | undefined
 
   public find<
     G extends Pick<AtomGenerics, 'Node' | 'Params' | 'State' | 'Template'>
   >(
     template: ParamlessTemplate<
-      G extends AtomGenerics ? AtomTemplateBase<G> : AtomSelectorOrConfig<G>
+      G extends AtomGenerics ? AtomTemplateBase<G> : SelectorTemplate<G>
     >
   ): G['Node'] | undefined
 
   public find(searchStr: string, params?: []): ZeduxNode | undefined
 
   public find<G extends AtomGenerics>(
-    template: AtomTemplateBase<G> | AtomSelectorOrConfig<G> | string,
+    template: AtomTemplateBase<G> | SelectorTemplate<G> | string,
     params?: G['Params']
   ) {
     const isString = typeof template === 'string'
@@ -415,7 +412,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
     if (!isString) {
       const id = isTemplate
         ? (template as AnyAtomTemplate).getNodeId(this, params)
-        : getSelectorKey(this, template as AtomSelectorOrConfig)
+        : getSelectorKey(this, template as SelectorTemplate)
 
       // try to find an existing instance
       const instance = this.n.get(id)
@@ -430,7 +427,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
           : `${
               isTemplate
                 ? (template as AnyAtomTemplate).key
-                : getSelectorKey(this, template as AtomSelectorOrConfig)
+                : getSelectorKey(this, template as SelectorTemplate)
             }-${this.hash(params)}`
       )
     }
@@ -444,6 +441,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
   }
 
   public findAll(type?: NodeType): ZeduxNode[]
+  public findAll(type?: NodeType[]): ZeduxNode[]
   public findAll(options?: NodeFilter): ZeduxNode[]
 
   /**
@@ -543,7 +541,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
    * without registering dependencies, @see Ecosystem.getNodeOnce
    */
   public getNode: GetNode = <G extends AtomGenerics>(
-    template: AtomTemplateBase<G> | ZeduxNode<G> | AtomSelectorOrConfig<G>,
+    template: AtomTemplateBase<G> | ZeduxNode<G> | SelectorTemplate<G>,
     params?: G['Params'],
     edgeConfig?: GraphEdgeConfig
   ) => {
@@ -570,7 +568,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
    * even when called in reactive contexts.
    */
   public getNodeOnce: GetNode = <G extends AtomGenerics>(
-    template: AtomTemplateBase<G> | ZeduxNode<G> | AtomSelectorOrConfig<G>,
+    template: AtomTemplateBase<G> | ZeduxNode<G> | SelectorTemplate<G>,
     params?: G['Params']
   ) => getNode(this, template, params)
 
@@ -582,7 +580,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
    * even when called in reactive contexts.
    */
   public getOnce: GetNode = <G extends AtomGenerics>(
-    template: AtomTemplateBase<G> | ZeduxNode<G> | AtomSelectorOrConfig<G>,
+    template: AtomTemplateBase<G> | ZeduxNode<G> | SelectorTemplate<G>,
     params?: G['Params']
   ) => getNode(this, template, params).getOnce()
 

--- a/packages/atoms/src/classes/ZeduxNode.ts
+++ b/packages/atoms/src/classes/ZeduxNode.ts
@@ -269,7 +269,9 @@ export abstract class ZeduxNode<G extends NodeGenerics = AnyNodeGenerics>
       excludeTags = [],
       include = [],
       includeTags = [],
-    } = typeof options === 'object' && !is(options, AtomTemplateBase)
+    } = Array.isArray(options)
+      ? { include: options }
+      : options && typeof options === 'object' && !is(options, AtomTemplateBase)
       ? (options as NodeFilterOptions)
       : { include: options ? [options as string | AnyAtomTemplate] : [] }
 
@@ -380,9 +382,9 @@ export abstract class ZeduxNode<G extends NodeGenerics = AnyNodeGenerics>
   public abstract s: Map<ZeduxNode, GraphEdge>
 
   /**
-   * `t`emplate - a reference to the template that was used to create this node
-   * - e.g. an `AtomTemplate` instance for atom instances or an
-   * AtomSelectorOrConfig function or object for selector instances.
+   * `t`emplate - a reference to the template that was used to create this node.
+   * e.g. an `AtomTemplate` instance for atom instances or a SelectorTemplate
+   * function or object for selector instances.
    */
   public abstract t: G['Template']
 
@@ -494,11 +496,6 @@ export class ExternalNode<
    * @see ZeduxNode.d can't dehydrate external nodes
    */
   public d() {}
-
-  /**
-   * @see ZeduxNode.f `ecosystem.findAll()` never returns external nodes
-   */
-  public f() {}
 
   /**
    * @see ZeduxNode.j can't hydrate external nodes

--- a/packages/atoms/src/classes/templates/IonTemplate.ts
+++ b/packages/atoms/src/classes/templates/IonTemplate.ts
@@ -32,12 +32,12 @@ export class IonTemplate<
   constructor(
     key: string,
     stateFactory: IonStateFactory<Omit<G, 'Node' | 'Template'>>,
-    config?: AtomConfig<G['State']>
+    config: AtomConfig<G['State']> = {}
   ) {
     super(
       key,
       (...params: G['Params']) => stateFactory(injectEcosystem(), ...params),
-      config
+      { ttl: 0, ...config }
     )
   }
 }

--- a/packages/atoms/src/factories/ion.ts
+++ b/packages/atoms/src/factories/ion.ts
@@ -15,6 +15,14 @@ import {
   None,
 } from '../types/index'
 
+/**
+ * Creates an atom template that's specifically geared toward derivations:
+ *
+ * - The first parameter of the state factory will be the `ecosystem`, so you
+ *   can easily `get(otherAtom)`
+ * - The atom's `ttl` will be set to `0` by default, destroying instances of
+ *   this atom as soon as they're no longer used.
+ */
 export const ion: {
   // Query Atoms
   <

--- a/packages/atoms/src/injectors/injectAtomState.ts
+++ b/packages/atoms/src/injectors/injectAtomState.ts
@@ -41,5 +41,5 @@ export const injectAtomState: {
     subscribe: true,
   })
 
-  return [instance.v, instance._infusedSetter]
+  return [instance.v, instance.x]
 }

--- a/packages/atoms/src/types/atoms.ts
+++ b/packages/atoms/src/types/atoms.ts
@@ -4,7 +4,7 @@ import { AtomApi } from '../classes/AtomApi'
 import { ZeduxNode } from '../classes/ZeduxNode'
 import {
   AnyNonNullishValue,
-  AtomSelectorOrConfig,
+  SelectorTemplate,
   Prettify,
   Selectable,
 } from './index'
@@ -85,7 +85,7 @@ export type EventsOf<A extends AnyAtomApi | AnyAtomTemplate | ZeduxNode> =
     ? G['Signal'] extends Signal
       ? EventsOf<G['Signal']>
       : never
-    : A extends AtomSelectorOrConfig<infer Events>
+    : A extends SelectorTemplate<infer Events>
     ? Events
     : never
 
@@ -123,21 +123,20 @@ export type NodeOf<A extends AnyAtomTemplate | Selectable<any, any>> =
     ? SelectorInstance<{
         Params: Params
         State: State
-        Template: AtomSelectorOrConfig<State, Params>
+        Template: SelectorTemplate<State, Params>
       }>
     : never
 
-export type ParamsOf<
-  A extends AnyAtomTemplate | ZeduxNode | AtomSelectorOrConfig
-> = A extends AtomTemplateBase<infer G>
-  ? G['Params']
-  : A extends ZeduxNode<infer G>
-  ? G extends { Params: infer Params }
+export type ParamsOf<A extends AnyAtomTemplate | ZeduxNode | SelectorTemplate> =
+  A extends AtomTemplateBase<infer G>
+    ? G['Params']
+    : A extends ZeduxNode<infer G>
+    ? G extends { Params: infer Params }
+      ? Params
+      : never
+    : A extends SelectorTemplate<any, infer Params>
     ? Params
     : never
-  : A extends AtomSelectorOrConfig<any, infer Params>
-  ? Params
-  : never
 
 export type PromiseOf<A extends AnyAtomApi | AnyAtomTemplate | ZeduxNode> =
   A extends AtomTemplateBase<infer G>
@@ -152,11 +151,11 @@ export type PromiseOf<A extends AnyAtomApi | AnyAtomTemplate | ZeduxNode> =
 
 export type SelectorGenerics = Pick<AtomGenerics, 'State'> & {
   Params: any[]
-  Template: AtomSelectorOrConfig
+  Template: SelectorTemplate
 }
 
 export type StateOf<
-  A extends AnyAtomApi | AnyAtomTemplate | AtomSelectorOrConfig | ZeduxNode
+  A extends AnyAtomApi | AnyAtomTemplate | SelectorTemplate | ZeduxNode
 > = A extends AtomTemplateBase<infer G>
   ? G['State']
   : A extends ZeduxNode<infer G>
@@ -167,7 +166,7 @@ export type StateOf<
   ? G['State']
   : A extends AtomApi<infer G>
   ? G['State']
-  : A extends AtomSelectorOrConfig<infer State>
+  : A extends SelectorTemplate<infer State>
   ? State
   : never
 

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -73,8 +73,7 @@ export interface AtomSelectorConfig<State = any, Params extends any[] = any> {
   selector: AtomSelector<State, Params>
 }
 
-// TODO: rename to SelectorTemplate
-export type AtomSelectorOrConfig<State = any, Params extends any[] = any> =
+export type SelectorTemplate<State = any, Params extends any[] = any> =
   | AtomSelector<State, Params>
   | AtomSelectorConfig<State, Params>
 
@@ -112,9 +111,6 @@ export type DehydrationFilter =
 export interface EcosystemConfig<
   Context extends Record<string, any> | undefined = any
 > {
-  atomDefaults?: {
-    ttl?: number
-  }
   complexParams?: boolean
   context?: Context
   makeId?: (
@@ -183,7 +179,7 @@ export interface GetNode {
     template: S,
     params: ParamsOf<S>,
     edgeConfig?: GraphEdgeConfig
-  ): S extends AtomSelectorOrConfig
+  ): S extends SelectorTemplate
     ? SelectorInstance<{
         Params: ParamsOf<S>
         State: StateOf<S>
@@ -191,7 +187,7 @@ export interface GetNode {
       }>
     : S
 
-  <S extends Selectable<any, []>>(template: S): S extends AtomSelectorOrConfig
+  <S extends Selectable<any, []>>(template: S): S extends SelectorTemplate
     ? SelectorInstance<{
         Params: ParamsOf<S>
         State: StateOf<S>
@@ -201,7 +197,7 @@ export interface GetNode {
 
   <S extends Selectable>(
     template: ParamlessTemplate<S>
-  ): S extends AtomSelectorOrConfig
+  ): S extends SelectorTemplate
     ? SelectorInstance<{
         Params: ParamsOf<S>
         State: StateOf<S>
@@ -213,7 +209,7 @@ export interface GetNode {
 
   // catch-all
   <G extends AtomGenerics>(
-    template: AtomTemplateBase<G> | ZeduxNode<G> | AtomSelectorOrConfig<G>,
+    template: AtomTemplateBase<G> | ZeduxNode<G> | SelectorTemplate<G>,
     params: G['Params'],
     edgeConfig?: GraphEdgeConfig
   ): G['Node']
@@ -385,9 +381,9 @@ export interface Observable<T = any> {
 }
 
 export interface NodeFilterOptions {
-  exclude?: (AnyAtomTemplate | AtomSelectorOrConfig | NodeType | string)[]
+  exclude?: (AnyAtomTemplate | SelectorTemplate | NodeType | string)[]
   excludeTags?: string[]
-  include?: (AnyAtomTemplate | AtomSelectorOrConfig | NodeType | string)[]
+  include?: (AnyAtomTemplate | SelectorTemplate | NodeType | string)[]
   includeTags?: string[]
 }
 
@@ -395,8 +391,9 @@ export type NodeFilter =
   | string
   | NodeType
   | AnyAtomTemplate
-  | AtomSelectorOrConfig
+  | SelectorTemplate
   | NodeFilterOptions
+  | NodeFilter[]
 
 export type NodeType =
   | '@atom'
@@ -416,7 +413,7 @@ export type None = Prettify<Record<never, never>>
  * params or has only optional params.
  */
 export type ParamlessTemplate<
-  A extends AnyAtomTemplate | AtomSelectorOrConfig | ZeduxNode
+  A extends AnyAtomTemplate | SelectorTemplate | ZeduxNode
 > = ParamsOf<A> extends [AnyNonNullishValue | undefined | null, ...any[]]
   ? never
   : A
@@ -463,11 +460,11 @@ export type Scope = Map<
 >
 
 export type Selectable<State = any, Params extends any[] = any> =
-  | AtomSelectorOrConfig<State, Params>
+  | SelectorTemplate<State, Params>
   | SelectorInstance<{
       Params: Params
       State: State
-      Template: AtomSelectorOrConfig<State, Params>
+      Template: SelectorTemplate<State, Params>
     }>
 
 export type Settable<State = any, StateIn = State> =

--- a/packages/atoms/src/utils/ecosystem.ts
+++ b/packages/atoms/src/utils/ecosystem.ts
@@ -3,7 +3,7 @@ import {
   AnyAtomTemplate,
   AtomGenerics,
   AtomSelectorConfig,
-  AtomSelectorOrConfig,
+  SelectorTemplate,
   Job,
 } from '../types'
 import { AtomInstance } from '../classes/instances/AtomInstance'
@@ -84,7 +84,7 @@ export const mapRefToId = (ecosystem: Ecosystem, obj: any, name: string) => {
  */
 export const getNode = <G extends AtomGenerics>(
   ecosystem: Ecosystem,
-  template: AtomTemplateBase<G> | ZeduxNode<G> | AtomSelectorOrConfig<G>,
+  template: AtomTemplateBase<G> | ZeduxNode<G> | SelectorTemplate<G>,
   params?: G['Params']
 ): ZeduxNode => {
   if ((template as ZeduxNode).izn) {
@@ -150,7 +150,7 @@ export const getNode = <G extends AtomGenerics>(
     typeof template === 'function' ||
     (template && (template as AtomSelectorConfig).selector)
   ) {
-    const selectorOrConfig = template as AtomSelectorOrConfig<G>
+    const selectorOrConfig = template as SelectorTemplate<G>
     const id = getInstanceId(ecosystem, selectorOrConfig, params)
     let instance = ecosystem.n.get(id) as SelectorInstance<G>
 

--- a/packages/atoms/src/utils/selectors.ts
+++ b/packages/atoms/src/utils/selectors.ts
@@ -1,7 +1,7 @@
 import {
   AtomSelector,
   AtomSelectorConfig,
-  AtomSelectorOrConfig,
+  SelectorTemplate,
   SelectorGenerics,
 } from '../types/index'
 import { schedulerPost, schedulerPre } from './ecosystem'
@@ -19,7 +19,7 @@ const defaultResultsComparator = (a: any, b: any) => a === b
  */
 export const getInstanceId = (
   ecosystem: Ecosystem,
-  selectorOrConfig: AtomSelectorOrConfig,
+  selectorOrConfig: SelectorTemplate,
   params?: any[]
 ) => {
   const baseKey = getSelectorKey(ecosystem, selectorOrConfig)
@@ -29,7 +29,7 @@ export const getInstanceId = (
 
 export const getSelectorKey = (
   ecosystem: Ecosystem,
-  template: AtomSelectorOrConfig
+  template: SelectorTemplate
 ) => {
   const existingKey = ecosystem.b.get(template)
 
@@ -42,7 +42,7 @@ export const getSelectorKey = (
   return key
 }
 
-export const getSelectorName = (template: AtomSelectorOrConfig) =>
+export const getSelectorName = (template: SelectorTemplate) =>
   template.name || (template as AtomSelectorConfig).selector?.name || 'unknown'
 
 /**

--- a/packages/react/src/hooks/useAtomSelector.ts
+++ b/packages/react/src/hooks/useAtomSelector.ts
@@ -1,15 +1,5 @@
-import {
-  ExternalNode,
-  ParamsOf,
-  Selectable,
-  SelectorInstance,
-  StateOf,
-  zi,
-} from '@zedux/atoms'
-import { Dispatch, SetStateAction, useEffect, useState } from 'react'
-import { Eventless, External, reactContextScope } from '../utils'
-import { useEcosystem } from './useEcosystem'
-import { useReactComponentId } from './useReactComponentId'
+import { ParamsOf, Selectable, StateOf } from '@zedux/atoms'
+import { useAtomValue } from './useAtomValue'
 
 /**
  * Get the result of running a selector in the current ecosystem.
@@ -31,81 +21,4 @@ import { useReactComponentId } from './useReactComponentId'
 export const useAtomSelector = <S extends Selectable>(
   template: S,
   ...args: ParamsOf<S>
-): StateOf<S> => {
-  const ecosystem = useEcosystem()
-  ecosystem.S = reactContextScope
-  const observerId = useReactComponentId(ecosystem)
-
-  // use this referentially stable setState function as a ref. We lazily add
-  // `i`nstance and `m`ounted properties
-  const [, render] = useState<undefined | object>() as [
-    any,
-    Dispatch<SetStateAction<object | undefined>> & {
-      m: boolean
-      i?: SelectorInstance
-    }
-  ]
-
-  let instance: SelectorInstance
-
-  try {
-    instance = render.i
-      ? ecosystem.u(render.i, template, args, render)
-      : ecosystem.getNode(template, args)
-  } finally {
-    // we shouldn't need to capture/restore previous `S`cope. There should be no
-    // way for React to be rendering while another scope was active
-    ecosystem.S = undefined
-  }
-
-  const renderedValue = instance.v
-  render.i = instance
-
-  let node =
-    (ecosystem.n.get(observerId) as ExternalNode) ??
-    new ExternalNode(ecosystem, observerId, render)
-
-  const addEdge = () => {
-    node.l === zi.D && (node = new ExternalNode(ecosystem, observerId, render))
-    node.i === instance ||
-      node.u(instance, 'useAtomSelector', Eventless | External)
-  }
-
-  // Yes, subscribe during render. This operation is idempotent.
-  addEdge()
-
-  useEffect(() => {
-    instance = instance.V
-      ? ecosystem.withScope(instance.V!, () =>
-          ecosystem.getNode(template, args)
-        )
-      : ecosystem.getNode(template, args)
-
-    render.i = instance
-
-    // Try adding the edge again (will be a no-op unless React's StrictMode ran
-    // this effect's cleanup unnecessarily)
-    addEdge()
-    render.m = true
-
-    // an unmounting component's effect cleanup can force-destroy the selector
-    // or update the state of its sources (causing it to rerun) before we set
-    // `render.m`ounted. If that happened, trigger a rerender to recreate the
-    // selector and/or get its new state
-    if (instance.v !== renderedValue || instance.l === zi.D) {
-      render({})
-    }
-
-    return () => {
-      // remove the edge immediately - no need for a delay here. When StrictMode
-      // double-invokes (invokes, then cleans up, then re-invokes) this effect,
-      // it's expected that selectors and `ttl: 0` atoms with no other observers
-      // get destroyed and recreated - that's part of what StrictMode is
-      // ensuring
-      node.k(instance)
-      // don't set `render.m = false` here
-    }
-  }, [instance.id])
-
-  return renderedValue
-}
+): StateOf<S> => useAtomValue(template, args, { operation: 'useAtomSelector' })

--- a/packages/react/src/hooks/useAtomState.ts
+++ b/packages/react/src/hooks/useAtomState.ts
@@ -74,5 +74,5 @@ export const useAtomState: {
     subscribe: true,
   })
 
-  return [instance.v, instance._infusedSetter]
+  return [instance.v, instance.x]
 }

--- a/packages/react/test/integrations/ecosystem.test.tsx
+++ b/packages/react/test/integrations/ecosystem.test.tsx
@@ -10,6 +10,7 @@ import {
   EcosystemProvider,
   useEcosystem,
   getDefaultEcosystem,
+  useAtomInstance,
 } from '@zedux/react'
 import React, { useEffect, useState } from 'react'
 import { act } from '@testing-library/react'
@@ -270,6 +271,28 @@ describe('ecosystem', () => {
     expect(ecosystem.findAll('@atom').map(({ id }) => id)).toEqual([
       'a-["a"]',
       'a-["aa"]',
+      'b',
+    ])
+
+    function Test() {
+      useAtomValue(atomA, ['aaa'])
+      useAtomInstance(atomA, ['aaa'])
+
+      return null
+    }
+
+    renderInEcosystem(<Test />)
+
+    expect(
+      ecosystem
+        .findAll(['@atom', '@component'])
+        .map(({ id }) => id.replace(/-:.*:/, ''))
+    ).toEqual([
+      '@component(Test)',
+      '@component(Test)',
+      'a-["a"]',
+      'a-["aa"]',
+      'a-["aaa"]',
       'b',
     ])
 

--- a/packages/react/test/integrations/lifecycle.test.tsx
+++ b/packages/react/test/integrations/lifecycle.test.tsx
@@ -2,7 +2,6 @@ import { act, fireEvent } from '@testing-library/react'
 import {
   api,
   atom,
-  createEcosystem,
   injectAtomValue,
   injectEffect,
   injectSignal,
@@ -265,22 +264,5 @@ describe('ttl', () => {
     jest.runAllTimers()
 
     expect(instance1.status).toBe('Destroyed')
-  })
-
-  test('ecosystem `atomDefaults.ttl` is used as a default', () => {
-    const testEcosystem = createEcosystem({ atomDefaults: { ttl: 0 } })
-    const atom1 = atom('1', () => 'a')
-
-    const instance1 = testEcosystem.getInstance(atom1)
-    const cleanup = instance1.on(() => {}, { active: true })
-    const keys = [...testEcosystem.n.keys()]
-
-    expect(keys).toHaveLength(2)
-    expect(keys[0]).toBe('1')
-    expect(keys[1]).toBe('@listener(1)-1')
-
-    cleanup()
-
-    expect([...testEcosystem.n.keys()]).toEqual([])
   })
 })

--- a/packages/react/test/integrations/scoped-atoms.test.tsx
+++ b/packages/react/test/integrations/scoped-atoms.test.tsx
@@ -180,7 +180,7 @@ describe('scoped atoms', () => {
     // 2 parents, 4 children, 2 nested, 6 external
     expect(ecosystem.n.size).toBe(14)
 
-    expect(ecosystem.findAll().map(({ id }) => id)).toEqual([
+    expect(ecosystem.findAll('@atom').map(({ id }) => id)).toEqual([
       'child-@scope("a",parent-[1])',
       'child-@scope("a",parent-[2])',
       'child-@scope("b",parent-[1])',
@@ -205,7 +205,7 @@ describe('scoped atoms', () => {
 
     expect(ecosystem.n.size).toBe(14) // 2 new children, 2 destroyed
 
-    expect(ecosystem.findAll().map(({ id }) => id)).toEqual([
+    expect(ecosystem.findAll('@atom').map(({ id }) => id)).toEqual([
       'child-@scope("aa",parent-[1])',
       'child-@scope("aa",parent-[2])',
       'child-@scope("b",parent-[1])',
@@ -231,7 +231,7 @@ describe('scoped atoms', () => {
 
     expect(ecosystem.n.size).toBe(14) // no changes
 
-    expect(ecosystem.findAll().map(({ id }) => id)).toEqual([
+    expect(ecosystem.findAll('@atom').map(({ id }) => id)).toEqual([
       'child-@scope("aa",parent-[1])',
       'child-@scope("aa",parent-[2])',
       'child-@scope("b",parent-[1])',
@@ -298,7 +298,14 @@ describe('scoped atoms', () => {
       const instance2 = useAtomInstance(parentAtom2, [2])
       const instance200 = useAtomInstance(parentAtom2, [200])
 
-      // 8 pairs
+      /**
+       * 4 triplets:
+       *
+       * - contextA+instance1+instance2
+       * - contextA+instance100+instance200
+       * - contextB+instance1+instance2
+       * - contextB+instance100+instance200
+       */
       return (
         <>
           {[state1, 'b'].map((value, index) => (
@@ -340,7 +347,9 @@ describe('scoped atoms', () => {
     // 4 parents, 4 children, 4 nested, 4 middle, 4 top, 8 external
     expect(ecosystem.n.size).toBe(28)
 
-    expect(ecosystem.findAll().map(({ id }) => id)).toMatchSnapshot()
+    expect(
+      ecosystem.findAll(['@atom', '@selector']).map(({ id }) => id)
+    ).toMatchSnapshot()
 
     act(() => {
       button1.click()
@@ -357,7 +366,9 @@ describe('scoped atoms', () => {
     // 4 parents, 4 children, 4 nested, 4 middle, 4 top, 8 external
     expect(ecosystem.n.size).toBe(28)
 
-    expect(ecosystem.findAll().map(({ id }) => id)).toMatchSnapshot()
+    expect(
+      ecosystem.findAll(['@atom', '@selector']).map(({ id }) => id)
+    ).toMatchSnapshot()
 
     const scope = new Map<Record<string, any>, any>([
       [context, 'b'],
@@ -379,7 +390,9 @@ describe('scoped atoms', () => {
     // 4 parents, 4 children, 4 nested, 4 middle, 4 top, 8 external
     expect(ecosystem.n.size).toBe(28)
 
-    expect(ecosystem.findAll().map(({ id }) => id)).toMatchSnapshot()
+    expect(
+      ecosystem.findAll(['@atom', '@selector']).map(({ id }) => id)
+    ).toMatchSnapshot()
 
     act(() => {
       childInstance.destroy(true)
@@ -391,7 +404,9 @@ describe('scoped atoms', () => {
     // 4 parents, 4 children, 4 nested, 4 middle, 4 top, 8 external
     expect(ecosystem.n.size).toBe(28)
 
-    expect(ecosystem.findAll().map(({ id }) => id)).toMatchSnapshot()
+    expect(
+      ecosystem.findAll(['@atom', '@selector']).map(({ id }) => id)
+    ).toMatchSnapshot()
   })
 
   test('React context reference changes create new scopes', async () => {
@@ -438,6 +453,7 @@ describe('scoped atoms', () => {
     calls.splice(0, calls.length)
 
     expect(ecosystem.findAll().map(({ id }) => id)).toEqual([
+      '@component(Child)-:rh:',
       '@selector(unknown)-1-@scope({"a":{"b":1}})',
       'child-@scope({"a":{"b":1}})',
     ])
@@ -450,6 +466,7 @@ describe('scoped atoms', () => {
     expect(calls).toEqual([{ a: { b: 2 } }])
 
     expect(ecosystem.findAll().map(({ id }) => id)).toEqual([
+      '@component(Child)-:rh:',
       '@selector(unknown)-1-@scope({"a":{"b":1}})',
       'child-@scope({"a":{"b":1}})',
       'child-@scope({"a":{"b":2}})',

--- a/packages/react/test/integrations/selection.test.tsx
+++ b/packages/react/test/integrations/selection.test.tsx
@@ -336,4 +336,20 @@ describe('selection', () => {
 
     expect(node2.get()).toBe('aab')
   })
+
+  test('ions have ttl: 0 by default', () => {
+    const atom1 = atom('1', () => 'a', { ttl: 0 })
+    const atom2 = ion('2', ({ get }) => get(atom1))
+
+    const node2 = ecosystem.getNode(atom2)
+    const node1 = ecosystem.getNode(atom1)
+
+    expect(node2.status).toBe('Active')
+
+    node2.on(() => {}, { active: true })() // add a dep and immediately remove
+
+    expect(node2.status).toBe('Destroyed')
+    expect(node1.status).toBe('Destroyed')
+    expect(ecosystem.n.size).toBe(0)
+  })
 })

--- a/packages/react/test/units/useAtomState.test.tsx
+++ b/packages/react/test/units/useAtomState.test.tsx
@@ -1,0 +1,34 @@
+import { api, atom } from '@zedux/atoms'
+import { useAtomState } from '@zedux/react'
+import React, { act } from 'react'
+import { renderInEcosystem } from '../utils/renderInEcosystem'
+
+describe('useAtomState', () => {
+  test('returns an exports-infused setter', () => {
+    const atom1 = atom('1', () => {
+      return api(1).setExports({
+        test: 2,
+      })
+    })
+
+    let state: any
+    let setState: any
+
+    function Test() {
+      ;[state, setState] = useAtomState(atom1)
+
+      return null
+    }
+
+    renderInEcosystem(<Test />)
+
+    expect(state).toBe(1)
+    expect(setState.test).toBe(2)
+
+    act(() => {
+      setState(3)
+    })
+
+    expect(state).toBe(3)
+  })
+})

--- a/packages/stores/src/AtomInstance.ts
+++ b/packages/stores/src/AtomInstance.ts
@@ -180,6 +180,10 @@ export class AtomInstance<
 
   /**
    * An alias for `.store.setState()`
+   *
+   * @deprecated prefer `.set`, which is a thin wrapper around this method but
+   * is compatible with the new signals-based atoms. Using `.set` will make it
+   * easier to migrate to signals.
    */
   public setState = (settable: Settable<G['State']>, meta?: any): G['State'] =>
     this.store.setState(settable, meta)

--- a/packages/stores/src/types.ts
+++ b/packages/stores/src/types.ts
@@ -2,7 +2,7 @@ import {
   AnyNonNullishValue,
   AtomGenerics as NewAtomGenerics,
   AtomGetters,
-  AtomSelectorOrConfig,
+  SelectorTemplate,
   AtomTemplateBase,
   ZeduxNode,
   Prettify,
@@ -104,14 +104,14 @@ export type AtomInstanceType<A extends AnyStoreAtomTemplate> =
     : never
 
 export type AtomParamsType<
-  A extends AnyStoreAtomTemplate | ZeduxNode | AtomSelectorOrConfig
+  A extends AnyStoreAtomTemplate | ZeduxNode | SelectorTemplate
 > = A extends AtomTemplateBase<infer G>
   ? G['Params']
   : A extends ZeduxNode<infer G>
   ? G extends { Params: infer Params }
     ? Params
     : never
-  : A extends AtomSelectorOrConfig<any, infer Params>
+  : A extends SelectorTemplate<any, infer Params>
   ? Params
   : never
 
@@ -144,14 +144,14 @@ export type AtomValueOrFactory<
 > = AtomStateFactory<G> | G['Store'] | G['State']
 
 export type AtomStateType<
-  A extends AnyAtomApi | AnyStoreAtomTemplate | AtomSelectorOrConfig | ZeduxNode
+  A extends AnyAtomApi | AnyStoreAtomTemplate | SelectorTemplate | ZeduxNode
 > = A extends AtomTemplateBase<infer G>
   ? G['State']
   : A extends ZeduxNode<infer G>
   ? G['State']
   : A extends AtomApi<infer G>
   ? G['State']
-  : A extends AtomSelectorOrConfig<infer State>
+  : A extends SelectorTemplate<infer State>
   ? State
   : never
 
@@ -197,5 +197,5 @@ export type PartialStoreAtomInstance = Omit<
 
 export type SelectorGenerics = Pick<AtomGenerics, 'State'> & {
   Params: any[]
-  Template: AtomSelectorOrConfig
+  Template: SelectorTemplate
 }


### PR DESCRIPTION
@affects atoms, stores

## Description

There are just a few last things to round up for Zedux v2. Knock them all out.

Add an array overload to `ecosystem.findAll` that's a shorthand for `.findAll({ include: [...mySearchList] })`. This is especially useful now that all node types can be returned.

Add a type overload to `ecosystem.findAll` so editors autocomplete with the new `@`-prefixed strings by default. This gives some very sleek DX - type `ecosystem.findAll('` and you'll see `@atom` as the first suggestion, which should be the most common. Same goes for the new array overload.

Deprecate the old store-based AtomInstance `.setState` function property. Prefer `.set` instead - it does the same thing for store-based atoms, but will make it easier to migrate to signals-based atoms.

Remove the implementation of `useAtomSelector`. Make it an alias for `useAtomValue` which now fully supports selectors.

### Breaking Changes

Signals-based ions (created via the `@zedux/atoms` or `@zedux/react` package's `ion` factory) now set `ttl` to zero by default. This was something we almost did years ago with the original spec. I wasn't sure if it was a good default at the time. Now I'm sure. And with the new signals-based `ion` factory being completely distinct from the old store-based ions, we get a free opportunity to reset. So do it.

The `atomDefaults` ecosystem config option is gone. The only supported default was `ttl` and the only other default that made sense was `0`. That should no longer be useful since ions are now a built-in way to create `ttl: 0` atoms.

The `AtomSelectorOrConfig` type is renamed to `SelectorTemplate`.

Stop preventing external nodes (components and event listeners) from being returned by `ecosystem.findAll`. I've been caught off guard by that behavior multiple times already. So it's bad. `ecosystem.findAll` can now return every node in the ecosystem.

Rework the AtomInstance `_infusedSetter` and `_set` properties to a new `x` property (short for e`x`portsInfusedSetter). Users shouldn't be using that directly, so obfuscate it. Make it a single getter property that overwrites itself when first used.