### PR TITLE
fix: rename core package `Settable` to `StoreSettable`

### DIFF
--- a/docs/docs/migrations/v2.mdx
+++ b/docs/docs/migrations/v2.mdx
@@ -210,12 +210,13 @@ function Child() {
 
 function App() {
   const ecosystem = useEcosystem()
-  const cleanupRef = useRef()
 
-  if (!cleanupRef.current) {
+  useEffect(() => {
     // uncomment this and open browser console:
-    // cleanupRef.current = ecosystem.on(event => console.log(event))
-  }
+    // const cleanup = ecosystem.on(event => console.log(event))
+    // return () => cleanup()
+  }, [ecosystem])
+  const cleanupRef = useRef()
 
   const [count, setCount] = useAtomState(parentCountAtom)
 
@@ -669,6 +670,7 @@ This section is a work in progress
 - `{ flags }` -> `{ tags }` (in atom config objects)
 - `{ includeFlags, excludeFlags }` -> `{ includeTags, excludeTags }` (in the object passed to `ecosystem.dehydrate`)
 - `atomTemplate.getInstanceId` -> `atomTemplate.getNodeId`
+- `ecosystem._idGenerator.generateId` -> `ecosystem.makeId`. Use the new `makeId` ecosystem config option in tests instead of mocking Zedux APIs.
 - `AtomSelectorOrConfig` -> `SelectorTemplate`
 
 For mods (previously added to `ZeduxPlugin`s, now "ecosystem events" registered with `ecosystem.on`), replace:
@@ -710,53 +712,112 @@ Also optionally replace some deprecated and/or "legacy" types:
 - reading `sourceType` field on evaluation reasons.
 - `internalStore` usages. Zedux no longer stores ecosystems in module-level state. Pass them around yourself as needed.
 - `wipe` usages (the top-level export). Zedux no longer has internal state to clear.
+- any other usages of `ecosystem._idGenerator`.
 
 ### Keeping Stores
 
 If you're using stores extensively, especially with lots of advanced features, it may be easier to keep using stores for now and migrate incrementally to signals.
 
-To do this, replace any store-atom-related imports from `@zedux/atoms` or `@zedux/react` with imports from `@zedux/stores`. Refer to this for the full list:
+To do this, replace any store-atom-related imports from `@zedux/atoms` or `@zedux/react` with the relevant imports from `@zedux/stores`. It may be easier to use import aliases to map the new names to the old. Refer to this for the full list:
 
 ```ts
 import {
-  // APIs:
+  // APIs that need aliasing for migrating from Zedux v1:
+  injectStorePromise as injectPromise,
   storeApi as api,
   storeAtom as atom,
   StoreAtomApi as AtomApi,
   StoreAtomInstance as AtomInstance,
-  StoreAtomInstanceRecursive as AtomInstanceRecursive,
   StoreAtomTemplate as AtomTemplate,
-  StoreAtomTemplateRecursive as AtomTemplateRecursive,
-  injectStorePromise as injectPromise,
-  injectStore,
   storeIon as ion,
   StoreIonTemplate as IonTemplate,
 
-  // types:
+  // APIs that don't need aliasing:
+  actionFactory,
+  createReducer,
+  createStore,
+  detailedTypeof,
+  doSubscribe,
+  getMetaData,
+  getStoreInternals,
+  injectStore,
+  is,
+  isPlainObject,
+  removeAllMeta,
+  removeMeta,
+  setStoreInternals,
+  Store,
+  zeduxTypes,
+} from '@zedux/stores'
+
+import type {
+  // Types that need aliasing for migrating from Zedux v1:
+  AnyStoreAtomApi as AnyAtomApi,
   AnyStoreAtomApiGenerics as AnyAtomApiGenerics,
   AnyStoreAtomGenerics as AnyAtomGenerics,
-  AnyStoreAtomApi as AnyAtomApi,
   AnyStoreAtomInstance as AnyAtomInstance,
   AnyStoreAtomTemplate as AnyAtomTemplate,
+  PartialStoreAtomInstance as PartialAtomInstance,
   StoreAtomApiGenerics as AtomApiGenerics,
   StoreAtomApiGenericsPartial as AtomApiGenericsPartial,
   StoreAtomApiPromise as AtomApiPromise,
-  AtomEventsType,
-  AtomExportsType,
   StoreAtomGenerics as AtomGenerics,
   StoreAtomGenericsToStoreAtomApiGenerics as AtomGenericsToAtomApiGenerics,
-  AtomInstanceType,
-  AtomParamsType,
-  AtomPromiseType,
+  StoreAtomInstanceRecursive as AtomInstanceRecursive,
   StoreAtomStateFactory as AtomStateFactory,
-  AtomStateType,
-  AtomStoreType,
+  StoreAtomTemplateRecursive as AtomTemplateRecursive,
   StoreAtomValueOrFactory as AtomValueOrFactory,
-  AtomTemplateType,
   StoreIonInstanceRecursive as IonInstanceRecursive,
   StoreIonStateFactory as IonStateFactory,
   StoreIonTemplateRecursive as IonTemplateRecursive,
-  PartialStoreAtomInstance as PartialAtomInstance,
+  StoreSettable as Settable,
+
+  // types that don't need aliasing:
+  AtomTemplateType,
+  AtomStateType,
+  AtomStoreType,
+  AtomInstanceType,
+  AtomParamsType,
+  AtomPromiseType,
+  AtomEventsType,
+  AtomExportsType,
+  Action,
+  ActionChain,
+  ActionCreator,
+  ActionFactory,
+  ActionFactoryActionType,
+  ActionFactoryPayloadType,
+  ActionFactoryTypeType,
+  ActionMeta,
+  ActionMetaType,
+  ActionPayloadType,
+  ActionType,
+  ActionTypeType,
+  Branch,
+  Composable,
+  Dispatchable,
+  Dispatcher,
+  EffectType,
+  EffectsSubscriber,
+  ErrorSubscriber,
+  HierarchyDescriptor,
+  KnownHierarchyDescriptor,
+  NextSubscriber,
+  Observable,
+  Reactable,
+  RecursivePartial,
+  Reducer,
+  ReducerBuilder,
+  Scheduler,
+  Selector,
+  SetState,
+  StateSetter,
+  StoreEffect,
+  StoreStateType,
+  SubReducer,
+  Subscriber,
+  SubscriberObject,
+  Subscription,
 } from '@zedux/stores'
 ```
 

--- a/packages/core/src/api/createStore.ts
+++ b/packages/core/src/api/createStore.ts
@@ -11,7 +11,7 @@ import {
   SetState,
   RecursivePartial,
   Reducer,
-  Settable,
+  StoreSettable,
   Subscriber,
   SubscriberObject,
   KnownHierarchyDescriptor,
@@ -161,10 +161,10 @@ export class Store<State = any> {
     recreates this small function. But it's always bound and can be passed
     around easily.
   */
-  public setState = (settable: Settable<State>, meta?: any) => {
+  public setState = (settable: StoreSettable<State>, meta?: any) => {
     if (this._isSolo) {
       return this._setState(
-        settable as Settable<RecursivePartial<State>, State>,
+        settable as StoreSettable<RecursivePartial<State>, State>,
         meta
       )
     }
@@ -172,7 +172,7 @@ export class Store<State = any> {
     getScheduler().s({
       j: () =>
         this._setState(
-          settable as Settable<RecursivePartial<State>, State>,
+          settable as StoreSettable<RecursivePartial<State>, State>,
           meta
         ),
       T: 0, // UpdateStore (0)
@@ -206,12 +206,12 @@ export class Store<State = any> {
     e.g. by using dot-notation: `store.setStateDeep(...)`
   */
   public setStateDeep(
-    settable: Settable<RecursivePartial<State>, State>,
+    settable: StoreSettable<RecursivePartial<State>, State>,
     meta?: any
   ) {
     if (this._isSolo) {
       return this._setState(
-        settable as Settable<RecursivePartial<State>, State>,
+        settable as StoreSettable<RecursivePartial<State>, State>,
         meta,
         true
       )
@@ -220,7 +220,7 @@ export class Store<State = any> {
     getScheduler().s({
       j: () =>
         this._setState(
-          settable as Settable<RecursivePartial<State>, State>,
+          settable as StoreSettable<RecursivePartial<State>, State>,
           meta,
           true
         ),
@@ -559,7 +559,7 @@ export class Store<State = any> {
   }
 
   private _setState(
-    settable: Settable<RecursivePartial<State>, State>,
+    settable: StoreSettable<RecursivePartial<State>, State>,
     meta?: any,
     deep = false
   ) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -179,11 +179,11 @@ export type SetState<State = any, PartialState extends Partial<State> = any> = (
   state: State
 ) => PartialState
 
-export type Settable<State = any, StateIn = State> =
+export type StoreSettable<State = any, StateIn = State> =
   | ((state: StateIn) => State)
   | State
 
-export type StateSetter<State = any> = (settable: Settable<State>) => State
+export type StateSetter<State = any> = (settable: StoreSettable<State>) => State
 
 export type StoreStateType<S extends Store> = S extends Store<infer T>
   ? T

--- a/packages/core/src/utils/scheduler.ts
+++ b/packages/core/src/utils/scheduler.ts
@@ -40,7 +40,7 @@ export class Scheduler {
   public j: Job[] = []
 
   /**
-   * `s`cheduler - add a job to the queue. Starts running jobs if we're not
+   * `s`chedule - add a job to the queue. Starts running jobs if we're not
    * already running.
    *
    * UpdateStore (0) jobs must run immediately but also need the scheduler to be

--- a/packages/machines/src/MachineStore.ts
+++ b/packages/machines/src/MachineStore.ts
@@ -1,4 +1,4 @@
-import { RecursivePartial, Settable, Store } from '@zedux/core'
+import { RecursivePartial, StoreSettable, Store } from '@zedux/core'
 import { MachineStateShape } from './types'
 
 /**
@@ -53,7 +53,7 @@ export class MachineStore<
       return { context: currentState.context, value: nextValue.name }
     }, meta)
 
-  public setContext = (context: Settable<Context>, meta?: any) =>
+  public setContext = (context: StoreSettable<Context>, meta?: any) =>
     this.setState(
       state => ({
         context:
@@ -64,7 +64,7 @@ export class MachineStore<
     )
 
   public setContextDeep = (
-    partialContext: Settable<RecursivePartial<Context>, Context>,
+    partialContext: StoreSettable<RecursivePartial<Context>, Context>,
     meta?: any
   ) =>
     this.setStateDeep(

--- a/packages/stores/src/StoreAtomInstance.ts
+++ b/packages/stores/src/StoreAtomInstance.ts
@@ -5,7 +5,7 @@ import {
   zeduxTypes,
   is,
   RecursivePartial,
-  Settable,
+  StoreSettable,
   Store,
   Subscription,
 } from '@zedux/core'
@@ -172,7 +172,7 @@ export class StoreAtomInstance<
   }
 
   public set(
-    settable: Settable<G['State']>,
+    settable: StoreSettable<G['State']>,
     events?: Partial<SendableEvents<G>>
   ) {
     return this.setState(settable, events && Object.keys(events)[0])
@@ -185,14 +185,16 @@ export class StoreAtomInstance<
    * is compatible with the new signals-based atoms. Using `.set` will make it
    * easier to migrate to signals.
    */
-  public setState = (settable: Settable<G['State']>, meta?: any): G['State'] =>
-    this.store.setState(settable, meta)
+  public setState = (
+    settable: StoreSettable<G['State']>,
+    meta?: any
+  ): G['State'] => this.store.setState(settable, meta)
 
   /**
    * An alias for `.store.setStateDeep()`
    */
   public setStateDeep = (
-    settable: Settable<RecursivePartial<G['State']>, G['State']>,
+    settable: StoreSettable<RecursivePartial<G['State']>, G['State']>,
     meta?: any
   ): G['State'] => this.store.setStateDeep(settable, meta)
 


### PR DESCRIPTION
@affects core, machines, stores

## Description

One more type from the `@zedux/core` package needs to be renamed for full interoperability with the `@zedux/atoms` package.

Rename the core package's `Settable` type to `StoreSettable`. The `Settable` type in the `@zedux/atoms` package is unchanged.

This is technically a breaking change for TS users, but I'm classifying it as a bug since it caused problems for us.