### PR TITLE
fix(atoms): unschedule effects from the right scheduler

### DIFF
--- a/packages/atoms/src/injectors/injectEffect.ts
+++ b/packages/atoms/src/injectors/injectEffect.ts
@@ -51,9 +51,13 @@ export const injectEffect = (
   }
 
   const { e } = injectSelf()
+  const isUsingAsyncScheduler = e.S?.t === 'react'
 
   const nextDescriptor: InjectorDescriptor<InjectorDeps> = {
-    c: () => e.asyncScheduler.unschedule(job),
+    c: () =>
+      (isUsingAsyncScheduler ? e.asyncScheduler : e.syncScheduler).unschedule(
+        job
+      ),
     t: TYPE,
     v: deps,
   }


### PR DESCRIPTION
## Description

`injectEffect` schedules async jobs that can be upgraded to sync jobs. But it currently only tries to unschedule jobs from the async scheduler. This means that when atoms are created outside React and throw on initial evaluation, the effects remain scheduled in the syncScheduler and will run later, when something flushes that scheduler.

Detect which scheduler will be used in `injectEffect` and unschedule from the correct scheduler.