### PR TITLE
fix(react): use scope in `useAtomContext` when using default params

### DIFF
--- a/packages/react/src/hooks/useAtomContext.ts
+++ b/packages/react/src/hooks/useAtomContext.ts
@@ -9,7 +9,7 @@ import {
 } from '@zedux/atoms'
 import { useContext } from 'react'
 import { useEcosystem } from './useEcosystem'
-import { getReactContext } from '../utils'
+import { getReactContext, reactContextScope } from '../utils'
 
 /**
  * A React hook that accepts an atom template and returns an atom instance of
@@ -78,5 +78,13 @@ export const useAtomContext: {
     return instance
   }
 
-  return ecosystem.getInstance(template, defaultParams)
+  ecosystem.S = reactContextScope
+
+  try {
+    return ecosystem.getNode(template, defaultParams)
+  } finally {
+    // We shouldn't need to capture/restore previous `S`cope. There should be no
+    // way for React to be rendering inside another scope.
+    ecosystem.S = undefined
+  }
 }

--- a/packages/react/test/integrations/react-context.test.tsx
+++ b/packages/react/test/integrations/react-context.test.tsx
@@ -1,6 +1,7 @@
 import {
   atom,
   AtomProvider,
+  injectEffect,
   useAtomContext,
   useAtomInstance,
   useAtomValue,
@@ -220,5 +221,32 @@ describe('React context', () => {
     const pattern = /no atom instance was provided/i
 
     expect(() => renderInEcosystem(<Test />)).toThrowError(pattern)
+  })
+
+  test('useAtomContext with default params flags the context as unsafe before getting the instance', () => {
+    const calls: any[] = []
+
+    const atom1 = atom('1', (id: string) => {
+      injectEffect(() => {
+        calls.push(id)
+      })
+
+      return id
+    })
+
+    function Test() {
+      const instance = useAtomContext(atom1, ['a'])
+
+      return instance.get()
+    }
+
+    renderInEcosystem(<Test />)
+
+    expect(calls).toEqual([])
+    expect(ecosystem.asyncScheduler.j.length).toEqual(1)
+
+    ecosystem.asyncScheduler.flush()
+
+    expect(calls).toEqual(['a'])
   })
 })


### PR DESCRIPTION
## Description

When passing default params to `useAtomContext`, Zedux gets or creates the instance for those params if no instance is provided. This operation currently happens without access to scope and without flagging the current context as unsafe for effects to run immediately.

So provide the react context scope to the `ecosystem.getInstance` call in `useAtomContext`. Also switch to `getNode`. The react context scope also automatically (currently) flags the context as unsafe for effects. Add a test for that.