### PR TITLE
feat(react): add function overloads to `AtomProvider` props

### DIFF
--- a/packages/react/test/integrations/scoped-atoms.test.tsx
+++ b/packages/react/test/integrations/scoped-atoms.test.tsx
@@ -177,8 +177,8 @@ describe('scoped atoms', () => {
     expect(calls).toEqual(['a1 1', 'a2 2', 'b1 1', 'b2 2'])
     calls.splice(0, calls.length)
 
-    // 2 parents, 4 children, 2 nested, 6 external
-    expect(ecosystem.n.size).toBe(14)
+    // 2 parents, 4 providers, 4 children, 2 nested, 6 external
+    expect(ecosystem.n.size).toBe(18)
 
     expect(ecosystem.findAll('@atom').map(({ id }) => id)).toEqual([
       'child-@scope("a",parent-[1])',
@@ -203,7 +203,7 @@ describe('scoped atoms', () => {
     expect(calls).toEqual(['aa1 1', 'aa2 2', 'b1 1', 'b2 2'])
     calls.splice(0, calls.length)
 
-    expect(ecosystem.n.size).toBe(14) // 2 new children, 2 destroyed
+    expect(ecosystem.n.size).toBe(18) // 2 new children, 2 destroyed
 
     expect(ecosystem.findAll('@atom').map(({ id }) => id)).toEqual([
       'child-@scope("aa",parent-[1])',
@@ -229,7 +229,7 @@ describe('scoped atoms', () => {
     expect(calls).toEqual(['aa11 11', 'b11 11'])
     calls.splice(0, calls.length)
 
-    expect(ecosystem.n.size).toBe(14) // no changes
+    expect(ecosystem.n.size).toBe(18) // no changes
 
     expect(ecosystem.findAll('@atom').map(({ id }) => id)).toEqual([
       'child-@scope("aa",parent-[1])',
@@ -344,8 +344,8 @@ describe('scoped atoms', () => {
     expect(calls).toEqual(['a1 2', 'a100 200', 'b1 2', 'b100 200'])
     calls.splice(0, calls.length)
 
-    // 4 parents, 4 children, 4 nested, 4 middle, 4 top, 8 external
-    expect(ecosystem.n.size).toBe(28)
+    // 4 parents, 8 providers, 4 children, 4 nested, 4 middle, 4 top, 8 external
+    expect(ecosystem.n.size).toBe(36)
 
     expect(
       ecosystem.findAll(['@atom', '@selector']).map(({ id }) => id)
@@ -363,8 +363,8 @@ describe('scoped atoms', () => {
     expect(calls).toEqual(['aa1 2', 'aa100 200'])
     calls.splice(0, calls.length)
 
-    // 4 parents, 4 children, 4 nested, 4 middle, 4 top, 8 external
-    expect(ecosystem.n.size).toBe(28)
+    // 4 parents, 8 providers, 4 children, 4 nested, 4 middle, 4 top, 8 external
+    expect(ecosystem.n.size).toBe(36)
 
     expect(
       ecosystem.findAll(['@atom', '@selector']).map(({ id }) => id)
@@ -387,8 +387,8 @@ describe('scoped atoms', () => {
     expect(calls).toEqual(['b1 2'])
     calls.splice(0, calls.length)
 
-    // 4 parents, 4 children, 4 nested, 4 middle, 4 top, 8 external
-    expect(ecosystem.n.size).toBe(28)
+    // 4 parents, 8 providers, 4 children, 4 nested, 4 middle, 4 top, 8 external
+    expect(ecosystem.n.size).toBe(36)
 
     expect(
       ecosystem.findAll(['@atom', '@selector']).map(({ id }) => id)
@@ -401,8 +401,8 @@ describe('scoped atoms', () => {
     expect(calls).toEqual(['b1 2'])
     calls.splice(0, calls.length)
 
-    // 4 parents, 4 children, 4 nested, 4 middle, 4 top, 8 external
-    expect(ecosystem.n.size).toBe(28)
+    // 4 parents, 8 providers, 4 children, 4 nested, 4 middle, 4 top, 8 external
+    expect(ecosystem.n.size).toBe(36)
 
     expect(
       ecosystem.findAll(['@atom', '@selector']).map(({ id }) => id)
@@ -453,7 +453,7 @@ describe('scoped atoms', () => {
     calls.splice(0, calls.length)
 
     expect(ecosystem.findAll().map(({ id }) => id)).toEqual([
-      '@component(Child)-:rh:',
+      expect.stringContaining('@component(Child)'),
       '@selector(unknown)-1-@scope({"a":{"b":1}})',
       'child-@scope({"a":{"b":1}})',
     ])
@@ -466,7 +466,7 @@ describe('scoped atoms', () => {
     expect(calls).toEqual([{ a: { b: 2 } }])
 
     expect(ecosystem.findAll().map(({ id }) => id)).toEqual([
-      '@component(Child)-:rh:',
+      expect.stringContaining('@component(Child)'),
       '@selector(unknown)-1-@scope({"a":{"b":1}})',
       'child-@scope({"a":{"b":1}})',
       'child-@scope({"a":{"b":2}})',


### PR DESCRIPTION
## Description

In tests, `AtomProvider` is often rendered at the top-level, e.g. in a storybook setup function. Currently, this means you have to either create a wrapper component for each test or use a global ecosystem to get an instance statically - outside React - that you then provide.

The former approach involves boilerplate.

The latter approach can cause problems if the provided atom has `ttl: 0` and consuming components unmount, destroying the provided atom. The AtomProvider will continue to provide the destroyed atom indefinitely.

To better handle this, make `AtomProvider` register a static dependency on the provided atom instance. Also introduce new function overloads to `AtomProvider`'s `instance` and `instances` props.

The passed callback receives the ecosystem as its first parameter and should return the atom instance(s) to provide. The passed callback also has access to atom scope.

```ts
function storybookSetup() {
  return (
    <AtomProvider instance={ecosystem => ecosystem.getNode(myAtom)}>
      <MyComponent />
    </AtomProvider>
  )
}
```

A function passed to `instance` should return a single atom instance. A function passed to `instances` should return an array of atom instances to provide. As before, the order of returned instances matters - changing the order or adding/removing items will cause the entire component subtree to unmount/remount.

These new overloads are primarily for use in tests, but they can be useful shorthand anywhere to prevent an extra `useAtomInstance` hook call in providing components.