### PR TITLE
feat(atoms): dedupe mapped signal events that reach multiple children

### DIFF
--- a/packages/atoms/src/injectors/injectMappedSignal.ts
+++ b/packages/atoms/src/injectors/injectMappedSignal.ts
@@ -2,8 +2,10 @@ import { MappedSignal, SignalMap } from '../classes/MappedSignal'
 import { Signal } from '../classes/Signal'
 import {
   AnyNonNullishValue,
+  EventMap,
   EventsOf,
   InjectSignalConfig,
+  MapEvents,
   None,
   Prettify,
   StateOf,
@@ -68,15 +70,18 @@ type UnionToTuple<T> = UnionToIntersection<
  * })
  * ```
  */
-export const injectMappedSignal = <M extends SignalMap>(
+export const injectMappedSignal = <
+  M extends SignalMap,
+  MappedEvents extends EventMap = None
+>(
   map: M,
-  config?: Pick<InjectSignalConfig<MapAll<M>>, 'reactive'>
+  config?: InjectSignalConfig<MappedEvents>
 ) => {
   const instance = injectSelf()
 
   const signal = injectMemo(() => {
     return new MappedSignal<{
-      Events: Prettify<MapAll<M>>
+      Events: Prettify<MapAll<M> & MapEvents<MappedEvents>>
       State: { [K in keyof M]: M[K] extends Signal<any> ? StateOf<M[K]> : M[K] }
     }>(instance.e, instance.e.makeId('signal', instance), map)
   }, [])


### PR DESCRIPTION
## Description

`MappedSignal#set` currently handles the case where a single call causes updates in multiple inner signals. It also filters down which events to pass to each inner signal.

`MappedSignal#send` is missing these features - when an event is sent directly to the wrapping signal that reaches multiple inner signals, each inner signal will propagate the event again, back up to the mapped signal and its observers. `MappedSignal#send` also does not support the object overload of `Signal#send` even though the types suggest it does.

Fix those cases. Make `MappedSignal#send` handle the object overload. Make it only propagate each event to its own observers once. Also give mapped signals the ability to specify their own events. Add tests for all of that.