### PR TITLE
feat!: improve `injectPromise` - add `dataSignal`, `initialData`, `ZeduxPromise`

### DIFF
--- a/docs/docs/migrations/v2.mdx
+++ b/docs/docs/migrations/v2.mdx
@@ -337,6 +337,7 @@ function App() {
   - The types have been improved to make editors autocomplete those `@`-prefixed strings, leading to some slick DX.
   - Pass an array of filters (`.findAll([...myFilters])`) as a shorthand for `.findAll({ include: [...myFilters] })`
 - `untrack` - A new top-level export for bumping out of a reactive context.
+- `AtomProvider` now accepts function overloads for its `instance` and `instances` props. The function will receive the ecosystem as its first parameter and should return an atom instance (or an array of instances for the `instances` prop).
 - When called with no deps, `injectMemo` now automatically tracks any signal usages in the callback and reactively updates when they change, causing the injecting atom to reevaluate.
 - `ecosystem.withScope` - Runs a callback in a scoped context with the passed scope.
 - `injectCallback` now wraps the callback in `ecosystem.withScope` (in addition to `ecosystem.batch`) if the injecting atom is scoped.
@@ -672,6 +673,8 @@ This section is a work in progress
 - `atomTemplate.getInstanceId` -> `atomTemplate.getNodeId`
 - `ecosystem._idGenerator.generateId` -> `ecosystem.makeId`. Use the new `makeId` ecosystem config option in tests instead of mocking Zedux APIs.
 - `AtomSelectorOrConfig` -> `SelectorTemplate`
+- The `initialState` option of `injectPromise` -> `initialData`.
+- The `dataOnly` option of `injectPromise` -> use the returned `dataSignal` instead.
 
 For mods (previously added to `ZeduxPlugin`s, now "ecosystem events" registered with `ecosystem.on`), replace:
 
@@ -722,7 +725,7 @@ To do this, replace any store-atom-related imports from `@zedux/atoms` or `@zedu
 
 ```ts
 import {
-  // APIs that need aliasing for migrating from Zedux v1:
+  // APIs you may want to alias when migrating from Zedux v1:
   injectStorePromise as injectPromise,
   storeApi as api,
   storeAtom as atom,
@@ -751,7 +754,7 @@ import {
 } from '@zedux/stores'
 
 import type {
-  // Types that need aliasing for migrating from Zedux v1:
+  // Types you may want to alias when migrating from Zedux v1:
   AnyStoreAtomApi as AnyAtomApi,
   AnyStoreAtomApiGenerics as AnyAtomApiGenerics,
   AnyStoreAtomGenerics as AnyAtomGenerics,

--- a/packages/atoms/src/factories/atom.ts
+++ b/packages/atoms/src/factories/atom.ts
@@ -3,8 +3,6 @@ import {
   AtomApiPromise,
   AtomValueOrFactory,
   PromiseState,
-  StateOf,
-  EventsOf,
   None,
 } from '../types/index'
 import {
@@ -39,25 +37,31 @@ export const atom: {
 
   // Signals
   <
-    SignalType extends Signal<any> = Signal<any>,
+    StateType,
+    EventsType extends Record<string, any> = None,
     Params extends any[] = [],
     Exports extends Record<string, any> = Record<string, never>,
     PromiseType extends AtomApiPromise = undefined
   >(
     key: string,
     value: (...params: Params) =>
-      | SignalType
+      | Signal<{
+          State: StateType
+          Events: EventsType
+          Params: any
+          Template: any
+        }>
       | AtomApi<{
           Exports: Exports
           Promise: PromiseType
-          Signal: SignalType
-          State: StateOf<SignalType>
+          Signal: Signal<{ State: StateType; Events: EventsType }>
+          State: StateType
         }>,
-    config?: AtomConfig<StateOf<SignalType>>
+    config?: AtomConfig<StateType>
   ): AtomTemplateRecursive<{
-    State: StateOf<SignalType>
+    State: StateType
     Params: Params
-    Events: EventsOf<SignalType>
+    Events: EventsType
     Exports: Exports
     Promise: PromiseType
   }>

--- a/packages/atoms/src/injectors/injectPromise.ts
+++ b/packages/atoms/src/injectors/injectPromise.ts
@@ -102,37 +102,10 @@ const hasInvalidateReason = (node: ReturnType<typeof injectSelf>) => {
  * })
  * ```
  */
-export const injectPromise: {
-  <Data, MappedEvents extends EventMap = None>(
-    promiseFactory: (params: {
-      controller?: AbortController
-      dataSignal: Signal<{
-        State: Data | undefined
-        Events: MapEvents<MappedEvents>
-      }>
-    }) => Promise<Data>,
-    deps?: InjectorDeps,
-    config?: InjectPromiseConfig<Data> & InjectSignalConfig<MappedEvents>
-  ): InjectPromiseAtomApi<
-    {
-      Exports: Record<string, any>
-      Promise: ZeduxPromise<Data>
-      Signal: MappedSignal<{
-        Events: MapEvents<MappedEvents>
-        State: PromiseState<Data>
-      }>
-      State: PromiseState<Data>
-    },
-    MappedEvents,
-    Data
-  >
-} = <Data, MappedEvents extends EventMap = None>(
+export const injectPromise = <Data, MappedEvents extends EventMap = None>(
   promiseFactory: (params: {
     controller?: AbortController
-    dataSignal: Signal<{
-      State: Data | undefined
-      Events: MapEvents<MappedEvents>
-    }>
+    prevData?: NoInfer<Data>
   }) => Promise<Data>,
   deps?: InjectorDeps,
   {
@@ -180,7 +153,7 @@ export const injectPromise: {
     try {
       promise = promiseFactory({
         controller: refs.current.controller,
-        dataSignal,
+        prevData: dataSignal.v,
       })
     } catch (err) {
       signal.mutate(getErrorPromiseState(err))

--- a/packages/atoms/src/injectors/injectPromise.ts
+++ b/packages/atoms/src/injectors/injectPromise.ts
@@ -21,10 +21,11 @@ import { injectMemo } from './injectMemo'
 import { injectSignal } from './injectSignal'
 import { injectRef } from './injectRef'
 import { AtomApi } from '../classes/AtomApi'
+import type { MappedSignal } from '../classes/MappedSignal'
+import type { Signal } from '../classes/Signal'
 import { Invalidate } from '../utils/general'
 import { injectSelf } from './injectSelf'
 import { injectMappedSignal } from './injectMappedSignal'
-import { MappedSignal, Signal } from '../classes'
 
 export class InjectPromiseAtomApi<
   G extends AtomApiGenerics,

--- a/packages/atoms/src/types/atoms.ts
+++ b/packages/atoms/src/types/atoms.ts
@@ -7,6 +7,7 @@ import {
   SelectorTemplate,
   Prettify,
   Selectable,
+  ZeduxPromise,
 } from './index'
 import { SelectorInstance } from '../classes/SelectorInstance'
 import type { Signal } from '../classes/Signal'
@@ -148,6 +149,9 @@ export type PromiseOf<A extends AnyAtomApi | AnyAtomTemplate | ZeduxNode> =
     : A extends AtomApi<infer G>
     ? G['Promise']
     : never
+
+export type ResolvedStateOf<A extends AnyAtomTemplate | ZeduxNode> =
+  PromiseOf<A> extends ZeduxPromise<any> ? Awaited<PromiseOf<A>> : StateOf<A>
 
 export type SelectorGenerics = Pick<AtomGenerics, 'State'> & {
   Params: any[]

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -257,8 +257,7 @@ export type InjectOrUseSelector<State, Params extends any[]> = Params extends []
   : <D = any>(params: Params, selector: (state: State) => D) => D
 
 export interface InjectPromiseConfig<T = any> {
-  dataOnly?: boolean
-  initialState?: T
+  initialData?: T
   runOnInvalidate?: boolean
 }
 
@@ -475,3 +474,9 @@ export type StateHookTuple<State, Exports> = [
   State,
   ExportsInfusedSetter<State, Exports>
 ]
+
+export interface ZeduxPromise<T> extends Promise<T> {
+  // this type needs a junk field to prevent TS from collapsing it down to match
+  // normal `Promise` types
+  _: never
+}

--- a/packages/atoms/src/utils/promiseUtils.ts
+++ b/packages/atoms/src/utils/promiseUtils.ts
@@ -1,7 +1,9 @@
 import { PromiseState } from '../types/index'
 
-export const getErrorPromiseState = <T>(error: Error): PromiseState<T> => ({
-  error,
+export const getErrorPromiseState = <T>(error: unknown): PromiseState<T> => ({
+  error: (error as Error | undefined)?.stack
+    ? (error as Error)
+    : new Error(error?.toString()),
   isError: true,
   isLoading: false,
   isSuccess: false,
@@ -16,10 +18,11 @@ export const getInitialPromiseState = <T>(data?: T): PromiseState<T> => ({
   status: 'loading' as const,
 })
 
-export const getSuccessPromiseState = <T>(data: T): PromiseState<T> => ({
-  data,
-  isError: false,
-  isLoading: false,
-  isSuccess: true,
-  status: 'success',
-})
+export const getSuccessPromiseState = <T>(data: T) =>
+  ({
+    data,
+    isError: false,
+    isLoading: false,
+    isSuccess: true,
+    status: 'success',
+  } satisfies PromiseState<T>)

--- a/packages/react/src/hooks/useAtomState.ts
+++ b/packages/react/src/hooks/useAtomState.ts
@@ -6,10 +6,12 @@ import {
   ExportsOf,
   ParamlessTemplate,
   ParamsOf,
+  ResolvedStateOf,
   StateHookTuple,
   StateOf,
 } from '@zedux/atoms'
 import { useAtomInstance } from './useAtomInstance'
+import { ZeduxHookConfig } from '../types'
 
 /**
  * Creates an atom instance for the passed atom template based on the passed
@@ -50,21 +52,35 @@ import { useAtomInstance } from './useAtomInstance'
 export const useAtomState: {
   <A extends AnyAtomTemplate<{ Node: AtomInstance }>>(
     template: A,
-    params: ParamsOf<A>
-  ): StateHookTuple<StateOf<A>, ExportsOf<A>>
-
-  <A extends AnyAtomTemplate<{ Node: AtomInstance; Params: [] }>>(
-    template: A
+    params: ParamsOf<A>,
+    config: Omit<ZeduxHookConfig, 'subscribe' | 'suspend'> & { suspend: false }
   ): StateHookTuple<StateOf<A>, ExportsOf<A>>
 
   <A extends AnyAtomTemplate<{ Node: AtomInstance }>>(
-    template: ParamlessTemplate<A>
-  ): StateHookTuple<StateOf<A>, ExportsOf<A>>
+    template: A,
+    params: ParamsOf<A>,
+    config?: Omit<ZeduxHookConfig, 'subscribe'>
+  ): StateHookTuple<ResolvedStateOf<A>, ExportsOf<A>>
 
-  <I extends AtomInstance>(instance: I): StateHookTuple<
-    StateOf<I>,
-    ExportsOf<I>
-  >
+  <A extends AnyAtomTemplate<{ Node: AtomInstance; Params: [] }>>(
+    template: A
+  ): StateHookTuple<ResolvedStateOf<A>, ExportsOf<A>>
+
+  <A extends AnyAtomTemplate<{ Node: AtomInstance }>>(
+    template: ParamlessTemplate<A>
+  ): StateHookTuple<ResolvedStateOf<A>, ExportsOf<A>>
+
+  <I extends AtomInstance>(
+    instance: I,
+    params: [],
+    config: Omit<ZeduxHookConfig, 'subscribe' | 'suspend'> & { suspend: false }
+  ): StateHookTuple<StateOf<I>, ExportsOf<I>>
+
+  <I extends AtomInstance>(
+    instance: I,
+    params?: [],
+    config?: Omit<ZeduxHookConfig, 'subscribe'>
+  ): StateHookTuple<ResolvedStateOf<I>, ExportsOf<I>>
 } = <G extends AnyAtomGenerics<{ Node: AtomInstance }>>(
   atom: AtomTemplateBase<G>,
   params?: G['Params']

--- a/packages/react/src/hooks/useAtomValue.ts
+++ b/packages/react/src/hooks/useAtomValue.ts
@@ -5,6 +5,7 @@ import {
   AtomTemplateBase,
   ParamlessTemplate,
   ParamsOf,
+  ResolvedStateOf,
   Selectable,
   StateOf,
 } from '@zedux/atoms'
@@ -39,21 +40,37 @@ import { useAtomInstance } from './useAtomInstance'
  * ```
  */
 export const useAtomValue: {
+  // no suspense
+  <A extends AnyAtomTemplate>(
+    template: A,
+    params: ParamsOf<A>,
+    config: Omit<ZeduxHookConfig, 'subscribe' | 'suspend'> & { suspend: false }
+  ): StateOf<A>
+
+  // suspense
   <A extends AnyAtomTemplate>(
     template: A,
     params: ParamsOf<A>,
     config?: Omit<ZeduxHookConfig, 'subscribe'>
-  ): StateOf<A>
+  ): ResolvedStateOf<A>
 
-  <A extends AnyAtomTemplate<{ Params: [] }>>(template: A): StateOf<A>
+  <A extends AnyAtomTemplate<{ Params: [] }>>(template: A): ResolvedStateOf<A>
 
-  <A extends AnyAtomTemplate>(template: ParamlessTemplate<A>): StateOf<A>
+  <A extends AnyAtomTemplate>(
+    template: ParamlessTemplate<A>
+  ): ResolvedStateOf<A>
+
+  <I extends AnyAtomInstance>(
+    instance: I,
+    params: [],
+    config: Omit<ZeduxHookConfig, 'subscribe' | 'suspend'> & { suspend: false }
+  ): StateOf<I>
 
   <I extends AnyAtomInstance>(
     instance: I,
     params?: [],
     config?: Omit<ZeduxHookConfig, 'subscribe'>
-  ): StateOf<I>
+  ): ResolvedStateOf<I>
 
   <S extends Selectable>(
     template: S,

--- a/packages/react/test/integrations/promises.test.tsx
+++ b/packages/react/test/integrations/promises.test.tsx
@@ -259,22 +259,33 @@ describe('injectPromise', () => {
 
   test('the dataSignal is passed to the promise factory', async () => {
     const atom1 = atom('1', () => {
-      return injectPromise(async ({ dataSignal }) => {
-        dataSignal.set('a')
+      return injectPromise(
+        async ({
+          prevData,
+        }: {
+          controller?: AbortController
+          prevData?: string
+        }) => {
+          await Promise.resolve(1)
 
-        await Promise.resolve(1)
-
-        return 'b'
-      })
+          return prevData ? prevData + 'b' : 'a'
+        },
+        [],
+        { runOnInvalidate: true }
+      )
     })
 
     const node1 = ecosystem.getNode(atom1)
+    expect(node1.get().data).toBeUndefined()
 
+    await node1.promise
+    expect(node1.get().data).toBe('a')
+
+    node1.invalidate()
     expect(node1.get().data).toBe('a')
 
     await node1.promise
-
-    expect(node1.get().data).toBe('b')
+    expect(node1.get().data).toBe('ab')
   })
 
   test('The AbortController aborts on rerun', async () => {

--- a/packages/react/test/integrations/promises.test.tsx
+++ b/packages/react/test/integrations/promises.test.tsx
@@ -1,11 +1,13 @@
 import {
   api,
+  As,
   atom,
   injectAtomValue,
   injectPromise,
   injectRef,
 } from '@zedux/react'
 import { ecosystem } from '../utils/ecosystem'
+import { expectTypeOf } from 'expect-type'
 
 const reloadAtom = atom('reload', 0)
 
@@ -36,53 +38,6 @@ const queryAtom = atom('query', () => {
 })
 
 describe('promises', () => {
-  test('injectPromise retains data during reload', async () => {
-    jest.useFakeTimers()
-
-    const promiseInstance = ecosystem.getInstance(promiseAtom)
-    const reloadInstance = ecosystem.getInstance(reloadAtom)
-
-    expect(promiseInstance.get()).toEqual({
-      data: undefined,
-      isError: false,
-      isLoading: true,
-      isSuccess: false,
-      status: 'loading',
-    })
-
-    jest.runAllTimers()
-    await Promise.resolve() // wait for injectPromise's `.then` to run
-
-    expect(promiseInstance.get()).toEqual({
-      data: 0,
-      isError: false,
-      isLoading: false,
-      isSuccess: true,
-      status: 'success',
-    })
-
-    reloadInstance.set(1)
-
-    expect(promiseInstance.get()).toEqual({
-      data: 0,
-      isError: false,
-      isLoading: true,
-      isSuccess: false,
-      status: 'loading',
-    })
-
-    jest.runAllTimers()
-    await Promise.resolve() // wait for injectPromise's `.then` to run
-
-    expect(promiseInstance.get()).toEqual({
-      data: 2,
-      isError: false,
-      isLoading: false,
-      isSuccess: true,
-      status: 'success',
-    })
-  })
-
   test('query atoms retain data during reload', async () => {
     jest.useFakeTimers()
 
@@ -129,8 +84,57 @@ describe('promises', () => {
       status: 'success',
     })
   })
+})
 
-  test('injectPromise runOnInvalidate reruns promise factory on atom invalidation', async () => {
+describe('injectPromise', () => {
+  test('retains data during reload', async () => {
+    jest.useFakeTimers()
+
+    const promiseInstance = ecosystem.getInstance(promiseAtom)
+    const reloadInstance = ecosystem.getInstance(reloadAtom)
+
+    expect(promiseInstance.get()).toEqual({
+      data: undefined,
+      isError: false,
+      isLoading: true,
+      isSuccess: false,
+      status: 'loading',
+    })
+
+    jest.runAllTimers()
+    await Promise.resolve() // wait for injectPromise's `.then` to run
+
+    expect(promiseInstance.get()).toEqual({
+      data: 0,
+      isError: false,
+      isLoading: false,
+      isSuccess: true,
+      status: 'success',
+    })
+
+    reloadInstance.set(1)
+
+    expect(promiseInstance.get()).toEqual({
+      data: 0,
+      isError: false,
+      isLoading: true,
+      isSuccess: false,
+      status: 'loading',
+    })
+
+    jest.runAllTimers()
+    await Promise.resolve() // wait for injectPromise's `.then` to run
+
+    expect(promiseInstance.get()).toEqual({
+      data: 2,
+      isError: false,
+      isLoading: false,
+      isSuccess: true,
+      status: 'success',
+    })
+  })
+
+  test('runOnInvalidate reruns promise factory on atom invalidation', async () => {
     jest.useFakeTimers()
 
     const promiseInstance = ecosystem.getNode(promiseAtom, [true])
@@ -176,7 +180,7 @@ describe('promises', () => {
     })
   })
 
-  test('injectPromise does not rerun promise function on atom invalidation when !runOnInvalidate', async () => {
+  test('does not rerun promise function on atom invalidation when !runOnInvalidate', async () => {
     jest.useFakeTimers()
 
     const promiseInstance = ecosystem.getInstance(promiseAtom, [false])
@@ -220,5 +224,124 @@ describe('promises', () => {
       isSuccess: true,
       status: 'success',
     })
+  })
+
+  test('custom events reach the dataSignal and outer observers', () => {
+    const calls: any[] = []
+
+    const atom1 = atom('1', () => {
+      const atomApi = injectPromise(() => Promise.resolve(1), [], {
+        events: { test: As<string> },
+      })
+
+      return atomApi.setExports({ dataSignal: atomApi.dataSignal })
+    })
+
+    const node1 = ecosystem.getNode(atom1)
+
+    node1.on('test', event => {
+      expectTypeOf(event).toEqualTypeOf<string>()
+      calls.push(['atom', event])
+    })
+
+    node1.x.dataSignal.on('test', event => {
+      expectTypeOf(event).toEqualTypeOf<string>()
+      calls.push(['dataSignal', event])
+    })
+
+    node1.send({ test: 'a' })
+
+    expect(calls).toEqual([
+      ['dataSignal', 'a'],
+      ['atom', 'a'],
+    ])
+  })
+
+  test('the dataSignal is passed to the promise factory', async () => {
+    const atom1 = atom('1', () => {
+      return injectPromise(async ({ dataSignal }) => {
+        dataSignal.set('a')
+
+        await Promise.resolve(1)
+
+        return 'b'
+      })
+    })
+
+    const node1 = ecosystem.getNode(atom1)
+
+    expect(node1.get().data).toBe('a')
+
+    await node1.promise
+
+    expect(node1.get().data).toBe('b')
+  })
+
+  test('The AbortController aborts on rerun', async () => {
+    const calls: any[] = []
+
+    const atom1 = atom('1', () => {
+      return injectPromise(
+        async ({ controller }) => {
+          if (controller) {
+            controller.signal.onabort = () => {
+              calls.push('aborted')
+            }
+          }
+
+          calls.push('awaiting')
+          await Promise.resolve(1)
+          calls.push('resolved')
+
+          return 'a'
+        },
+        [],
+        { runOnInvalidate: true }
+      )
+    })
+
+    const node1 = ecosystem.getNode(atom1)
+
+    expect(calls).toEqual(['awaiting'])
+
+    await node1.promise
+
+    expect(calls).toEqual(['awaiting', 'resolved'])
+
+    node1.invalidate()
+
+    expect(calls).toEqual(['awaiting', 'resolved', 'awaiting', 'aborted'])
+  })
+
+  test('abort is aborted if the promise factory returns the same promise reference', async () => {
+    const calls: any[] = []
+    const promise = Promise.resolve('a')
+
+    const atom1 = atom('1', () => {
+      return injectPromise(
+        ({ controller }) => {
+          if (controller) {
+            controller.signal.onabort = () => {
+              calls.push('aborted')
+            }
+          }
+
+          calls.push('awaiting')
+
+          return promise
+        },
+        [],
+        { runOnInvalidate: true }
+      )
+    })
+
+    const node1 = ecosystem.getNode(atom1)
+    await node1.promise
+
+    expect(calls).toEqual(['awaiting'])
+
+    node1.invalidate()
+
+    expect(calls).toEqual(['awaiting', 'awaiting'])
   })
 })

--- a/packages/react/test/snippets/suspense.tsx
+++ b/packages/react/test/snippets/suspense.tsx
@@ -13,16 +13,12 @@ const wait = (time: number) =>
   new Promise<string>(resolve => setTimeout(() => resolve('whatever'), time))
 
 const suspendingAtom = atom('suspending', (param?: string) => {
-  const promiseApi = injectPromise(
-    async () => {
-      const val = await wait(2500)
-      return val
-    },
-    [],
-    { dataOnly: true }
-  )
+  const { dataSignal, promise } = injectPromise(async () => {
+    const val = await wait(2500)
+    return val
+  }, [])
 
-  return api("I am the value you're looking for").setPromise(promiseApi.promise)
+  return api("I am the value you're looking for").setPromise(promise)
 })
 
 const forwardingAtom = atom('forwarding', (param?: string) => {

--- a/packages/react/test/stores/injectStorePromise.test.tsx
+++ b/packages/react/test/stores/injectStorePromise.test.tsx
@@ -1,0 +1,50 @@
+import { useAtomState, useAtomValue } from '@zedux/react'
+import { injectStorePromise, storeAtom } from '@zedux/stores'
+import React, { Suspense } from 'react'
+import { renderInEcosystem } from '../utils/renderInEcosystem'
+import { expectTypeOf } from 'expect-type'
+
+describe('injectStorePromise', () => {
+  test('dataOnly types are correct', async () => {
+    const suspendingAtom = storeAtom('suspending', () => {
+      return injectStorePromise(() => Promise.resolve(1), [], {
+        dataOnly: true,
+      })
+    })
+
+    function Child() {
+      const value = useAtomValue(suspendingAtom)
+      const valueNoSuspense = useAtomValue(suspendingAtom, [], {
+        suspend: false,
+      })
+      const [state] = useAtomState(suspendingAtom)
+      const [stateNoSuspense] = useAtomState(suspendingAtom, [], {
+        suspend: false,
+      })
+
+      expectTypeOf(value).toEqualTypeOf<number>()
+      expectTypeOf(valueNoSuspense).toEqualTypeOf<number | undefined>()
+      expectTypeOf(state).toEqualTypeOf<number>()
+      expectTypeOf(stateNoSuspense).toEqualTypeOf<number | undefined>()
+
+      return (
+        <div data-testid="value">
+          {value} {valueNoSuspense} {state} {stateNoSuspense}
+        </div>
+      )
+    }
+
+    function Parent() {
+      return (
+        <Suspense fallback={<div>Loading...</div>}>
+          <Child />
+        </Suspense>
+      )
+    }
+
+    const { findByTestId } = renderInEcosystem(<Parent />)
+    const div = await findByTestId('value')
+
+    expect(div).toHaveTextContent('1 1 1 1')
+  })
+})

--- a/packages/stores/src/injectStorePromise.ts
+++ b/packages/stores/src/injectStorePromise.ts
@@ -2,7 +2,6 @@ import {
   injectEffect,
   injectMemo,
   InjectorDeps,
-  InjectPromiseConfig,
   injectRef,
   InjectStoreConfig,
   injectWhy,
@@ -17,6 +16,7 @@ import {
 import { StoreAtomApi } from './StoreAtomApi'
 import { storeApi } from './storeApi'
 import { injectStore } from './injectStore'
+import { InjectStorePromiseConfig } from './types'
 
 /**
  * Create a memoized promise reference. Kicks off the promise immediately
@@ -44,12 +44,13 @@ import { injectStore } from './injectStore'
  * - `dataOnly`: Set this to true to prevent the store from tracking promise
  *   status and make your promise's `data` the entire state.
  *
- * - `initialState`: Set the initial state of the store (e.g. a placeholder
- *   value before the promise resolves)
+ * - `initialData`: Set the initial state of the store's `data` property (or the
+ *   entire state if `dataOnly` is true). For example, use this to set a default
+ *   `data` value before the promise resolves.
  *
  * - store config: Any other config options will be passed directly to
- *   `injectStore`'s config. For example, pass `subscribe: false` to
- *   prevent the store from reevaluating the current atom on update.
+ *   `injectStore`'s config. For example, pass `subscribe: false` to prevent the
+ *   store from reevaluating the current atom on update.
  *
  * ```ts
  * const promiseApi = injectPromise(async () => {
@@ -57,7 +58,7 @@ import { injectStore } from './injectStore'
  *   return await response.json()
  * }, [url], {
  *   dataOnly: true,
- *   initialState: '',
+ *   initialData: '',
  *   subscribe: false
  * })
  * ```
@@ -66,7 +67,7 @@ export const injectStorePromise: {
   <T>(
     promiseFactory: (controller?: AbortController) => Promise<T>,
     deps: InjectorDeps,
-    config: Omit<InjectPromiseConfig, 'dataOnly'> & {
+    config: Omit<InjectStorePromiseConfig, 'dataOnly'> & {
       dataOnly: true
     } & InjectStoreConfig
   ): StoreAtomApi<{
@@ -79,7 +80,7 @@ export const injectStorePromise: {
   <T>(
     promiseFactory: (controller?: AbortController) => Promise<T>,
     deps?: InjectorDeps,
-    config?: InjectPromiseConfig<T> & InjectStoreConfig
+    config?: InjectStorePromiseConfig<T> & InjectStoreConfig
   ): StoreAtomApi<{
     Exports: Record<string, any>
     Promise: Promise<T>
@@ -91,10 +92,10 @@ export const injectStorePromise: {
   deps?: InjectorDeps,
   {
     dataOnly,
-    initialState,
+    initialData,
     runOnInvalidate,
     ...storeConfig
-  }: InjectPromiseConfig<T> & InjectStoreConfig = {}
+  }: InjectStorePromiseConfig<T> & InjectStoreConfig = {}
 ) => {
   const refs = injectRef({ counter: 0 } as {
     controller?: AbortController
@@ -103,7 +104,7 @@ export const injectStorePromise: {
   })
 
   const store = injectStore(
-    dataOnly ? initialState : getInitialPromiseState<T>(initialState),
+    dataOnly ? initialData : getInitialPromiseState<T>(initialData),
     storeConfig
   )
 

--- a/packages/stores/src/injectStorePromise.ts
+++ b/packages/stores/src/injectStorePromise.ts
@@ -6,6 +6,7 @@ import {
   InjectStoreConfig,
   injectWhy,
   PromiseState,
+  ZeduxPromise,
 } from '@zedux/atoms'
 import { detailedTypeof, RecursivePartial, Store } from '@zedux/core'
 import {
@@ -72,9 +73,9 @@ export const injectStorePromise: {
     } & InjectStoreConfig
   ): StoreAtomApi<{
     Exports: Record<string, any>
-    Promise: Promise<T>
-    State: T
-    Store: Store<T>
+    Promise: ZeduxPromise<T>
+    State: T | undefined
+    Store: Store<T | undefined>
   }>
 
   <T>(
@@ -83,7 +84,7 @@ export const injectStorePromise: {
     config?: InjectStorePromiseConfig<T> & InjectStoreConfig
   ): StoreAtomApi<{
     Exports: Record<string, any>
-    Promise: Promise<T>
+    Promise: ZeduxPromise<T>
     State: PromiseState<T>
     Store: Store<PromiseState<T>>
   }>
@@ -100,7 +101,7 @@ export const injectStorePromise: {
   const refs = injectRef({ counter: 0 } as {
     controller?: AbortController
     counter: number
-    promise: Promise<T>
+    promise: ZeduxPromise<T>
   })
 
   const store = injectStore(
@@ -160,7 +161,7 @@ export const injectStorePromise: {
         store.setStateDeep(getErrorPromiseState(error))
       })
 
-    return promise
+    return promise as ZeduxPromise<T>
   }, deps && [...deps, refs.current.counter])
 
   injectEffect(

--- a/packages/stores/src/types.ts
+++ b/packages/stores/src/types.ts
@@ -130,6 +130,12 @@ export type AtomPromiseType<
   ? G['Promise']
   : never
 
+export interface InjectStorePromiseConfig<T = any> {
+  dataOnly?: boolean
+  initialData?: T
+  runOnInvalidate?: boolean
+}
+
 export type StoreAtomStateFactory<
   G extends Pick<
     StoreAtomGenerics,


### PR DESCRIPTION
@affects atoms, react, stores

## Description

Implement all `injectPromise` improvements discussed in #220 for Zedux v2, with one change: Instead of passing the full `dataSignal` to the callback function, pass the dataSignal's current value as `prevData`.

After digging in, I saw this change was necessary for two reasons:

- TS infers the callback's return value as `unknown`, even when using `NoInfer` on the dataSignal's type. With `prevData` and `NoInfer`, TS also infers `unknown`, but it's much easier to manually type `prevData` than `dataSignal` to fix it. If you don't actually use `prevData`, inference works as normal. Since it should be rare that you need `prevData`, I'm fine requiring manual typing when you do.
- It becomes confusing that the value returned from the promise factory overwrites the `dataSignal`'s value, even if you set it manually right before the promise factory returned.

Full change list:

- Rename `initialState` to `initialData`
- Replace the `dataOnly` with a new `dataSignal` that's returned from `injectPromise`. This signal's value is also passed to the `injectPromise` promise factory:
- Rework the promise factory's arguments. Instead of receiving a single AbortController, it now receives an object with `{ controller, prevData }` properties.
- Create a new `ZeduxPromise` type that is a drop-in replacement for any atom's `Promise` generic and holds the type of `injectPromise`'s resolved `data` value.
  - Improve overloads of `useAtomState` and `useAtomValue` to know that the value is resolved when using suspense. Use the new `ZeduxPromise` type to infer that value.
  - Create a new `ResolvedStateOf` type helper

Also improve `injectStorePromise`:

- Rename `initialState` to `initialData`
- Add `ZeduxPromise` types for better hook suspense inference.

I didn't update `injectStorePromise` to pass `prevData` to the promise factory. I figure that's an advanced usage and if people want it, we can just say they need to use the signals-based `injectPromise` instead.