### PR TITLE
fix(react): fix import path in `AtomProvider`

### DIFF
--- a/packages/react/src/components/AtomProvider.tsx
+++ b/packages/react/src/components/AtomProvider.tsx
@@ -2,7 +2,7 @@ import { AnyAtomInstance, Ecosystem } from '@zedux/atoms'
 import React, { ReactElement, ReactNode } from 'react'
 import { useEcosystem } from '../hooks/useEcosystem'
 import { getReactContext, reactContextScope } from '../utils'
-import { useAtomInstance } from '../hooks'
+import { useAtomInstance } from '../hooks/useAtomInstance'
 
 /**
  * Provides an atom instance over React context.


### PR DESCRIPTION
## Description

I missed an automatically added import path in #219 that's importing from a directory barrel file. The esm build requires it import from the exact file. Fix that.