### PR TITLE
release: v2.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.0.0-rc.2 (Mar 18, 2025)
+
+### Fixes:
+
+- `react`: fix import path in `AtomProvider` (#224)
+
 ## v2.0.0-rc.1 (Mar 18, 2025)
 
 ### New Features:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zedux",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "A Molecular State Engine for React",
   "type": "module",
   "author": "Joshua Claunch (bowheart <bowheart31@gmail.com>)",

--- a/packages/atoms/package.json
+++ b/packages/atoms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/atoms",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/core",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "A high-level, declarative, composable form of Redux",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/immer",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "Official Immer integration for Zedux's store and atomic APIs",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,11 +10,11 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/stores": "2.0.0-rc.1"
+    "@zedux/stores": "2.0.0-rc.2"
   },
   "devDependencies": {
-    "@zedux/atoms": "2.0.0-rc.1",
-    "@zedux/core": "2.0.0-rc.1",
+    "@zedux/atoms": "2.0.0-rc.2",
+    "@zedux/core": "2.0.0-rc.2",
     "immer": "^10.1.1"
   },
   "exports": {
@@ -39,7 +39,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/atoms": "2.0.0-rc.1",
+    "@zedux/atoms": "2.0.0-rc.2",
     "immer": ">=9.0.19"
   },
   "repository": {

--- a/packages/machines/package.json
+++ b/packages/machines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/machines",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "Simple native state machine implementation for Zedux atoms",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,11 +10,11 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/stores": "2.0.0-rc.1"
+    "@zedux/stores": "2.0.0-rc.2"
   },
   "devDependencies": {
-    "@zedux/atoms": "2.0.0-rc.1",
-    "@zedux/core": "2.0.0-rc.1"
+    "@zedux/atoms": "2.0.0-rc.2",
+    "@zedux/core": "2.0.0-rc.2"
   },
   "exports": {
     ".": {
@@ -39,8 +39,8 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/atoms": "2.0.0-rc.1",
-    "@zedux/core": "2.0.0-rc.1"
+    "@zedux/atoms": "2.0.0-rc.2",
+    "@zedux/core": "2.0.0-rc.2"
   },
   "repository": {
     "directory": "packages/machines",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/react",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/atoms": "2.0.0-rc.1"
+    "@zedux/atoms": "2.0.0-rc.2"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/stores",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "The legacy composable store model of Zedux",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,8 +10,8 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/atoms": "2.0.0-rc.1",
-    "@zedux/core": "2.0.0-rc.1"
+    "@zedux/atoms": "2.0.0-rc.2",
+    "@zedux/core": "2.0.0-rc.2"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
## Description

Increment monorepo package versions and update the CHANGELOG for version 2.0.0-rc.2.

This PR was generated by the release script at https://github.com/Omnistac/zedux/tree/master/scripts/release.js

The packages will be published to npm and a GitHub release will be created after this PR merges.