### PR TITLE
fix: make stores scheduler kick off the atoms scheduler first

### DIFF
--- a/packages/react/test/stores/graph.test.tsx
+++ b/packages/react/test/stores/graph.test.tsx
@@ -241,10 +241,10 @@ describe('graph', () => {
 
     let why: EvaluationReason[] | undefined
 
-    const selector1 = ({ get }: AtomGetters) => {
+    const selector1 = jest.fn(({ get }: AtomGetters) => {
       why = ecosystem.why()
       return get(atom1) + get(atom2)
-    }
+    })
 
     const selectorInstance = ecosystem.getNode(selector1)
     const atomInstance = ecosystem.getInstance(atom1)
@@ -254,6 +254,7 @@ describe('graph', () => {
 
     atomInstance.setState('aa')
 
+    expect(selector1).toHaveBeenCalledTimes(2)
     expect(selectorInstance.v).toBe('aaaab')
     expect(why).toHaveLength(2)
     expect(why).toEqual([

--- a/packages/stores/src/StoreAtomInstance.ts
+++ b/packages/stores/src/StoreAtomInstance.ts
@@ -204,6 +204,11 @@ export class StoreAtomInstance<
   public j() {
     this.N = []
     this._isEvaluating = true
+
+    // all stores created during evaluation automatically belong to the
+    // ecosystem.
+    Store.s = this.e.syncScheduler
+
     const prevNode = this.e.cs(this)
 
     try {
@@ -264,6 +269,8 @@ export class StoreAtomInstance<
       throw err
     } finally {
       this._isEvaluating = false
+
+      Store.s = undefined
 
       // even if evaluation errored, we need to update observers if the store's
       // state changed


### PR DESCRIPTION
@affects core, stores

## Description

When store and atom state updates get interwoven in recursive atom/store trees, the store scheduler needs to fully flush before any atom updates run to prevent atom updates from happening out of order.

Kick off the atom scheduler before any store updates.