### PR TITLE
feat(atoms): lazily recalculate node weights

### DIFF
--- a/bench/src/index.ts
+++ b/bench/src/index.ts
@@ -26,9 +26,9 @@ async function main() {
     cellxbench(framework)
   }
 
-  // for (const frameworkTest of frameworkInfo) {
-  //   await dynamicBench(frameworkTest)
-  // }
+  for (const frameworkTest of frameworkInfo) {
+    await dynamicBench(frameworkTest)
+  }
 
   // When running chrome profiler, line level profiling numbers disappear when
   // the process exits. Keep it alive

--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -79,7 +79,11 @@ import { AtomInstance } from './instances/AtomInstance'
 import { AsyncScheduler } from './schedulers/AsyncScheduler'
 import { SyncScheduler } from './schedulers/SyncScheduler'
 import { AtomTemplateBase } from './templates/AtomTemplateBase'
-import { handleStateChange, handleStateChangeWithEvent } from '../utils/graph'
+import {
+  handleStateChange,
+  handleStateChangeWithEvent,
+  resolveWeight,
+} from '../utils/graph'
 
 export class Ecosystem<Context extends Record<string, any> | undefined = any>
   implements EventEmitter, Job
@@ -1036,6 +1040,8 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
       > = {}
 
       for (const [id, node] of this.n) {
+        if (node.R) resolveWeight(node)
+
         hash[id] = {
           observers: [...node.o].map(([observer, edge]) => ({
             key: observer.id,

--- a/packages/atoms/src/classes/ZeduxNode.ts
+++ b/packages/atoms/src/classes/ZeduxNode.ts
@@ -59,6 +59,11 @@ export abstract class ZeduxNode<G extends NodeGenerics = AnyNodeGenerics>
   public L: undefined | Listener = undefined
 
   /**
+   * @see Job.R
+   */
+  public R: ((node: ZeduxNode) => void) | undefined = undefined
+
+  /**
    * @see Job.T
    */
   public T = 2 as const
@@ -87,8 +92,6 @@ export abstract class ZeduxNode<G extends NodeGenerics = AnyNodeGenerics>
    * @see Job.W
    */
   public W = 1
-
-  public P = 1
 
   /**
    * Detach this node from the ecosystem and clean up all graph edges and other

--- a/packages/atoms/src/classes/schedulers/SyncScheduler.ts
+++ b/packages/atoms/src/classes/schedulers/SyncScheduler.ts
@@ -1,5 +1,7 @@
 import { Job } from '@zedux/atoms/types/index'
 import { SchedulerBase } from './SchedulerBase'
+import { resolveWeight } from '../../utils/graph'
+import { ZeduxNode } from '../ZeduxNode'
 
 export class SyncScheduler extends SchedulerBase {
   /**
@@ -16,6 +18,9 @@ export class SyncScheduler extends SchedulerBase {
    * queue. Insertion point depends on job's type and weight.
    */
   public schedule(newJob: Job) {
+    // For ZeduxNode jobs, ensure weight is calculated if needed
+    if (newJob.R) resolveWeight(newJob as ZeduxNode)
+
     const weight = newJob.W ?? 0
     const numJobs = this.j.length
 

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -339,6 +339,12 @@ export type IonStateFactory<G extends Omit<AtomGenerics, 'Node' | 'Template'>> =
 
 export interface Job {
   /**
+   * needs`R`ecalculation - for ZeduxNodes, tracks whether this node's weight
+   * needs to be lazily recalculated before this node can be scheduled as a job
+   */
+  R?: (node: ZeduxNode) => void
+
+  /**
    * `W`eight - the weight of the node (for EvaluateZeduxNode jobs).
    */
   W?: number

--- a/packages/react/test/integrations/__snapshots__/graph.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/graph.test.tsx.snap
@@ -242,7 +242,7 @@ exports[`graph getNode(atom) returns the instance 1`] = `
     },
     "state": 3,
     "status": "Active",
-    "weight": 3,
+    "weight": 1,
   },
 }
 `;

--- a/packages/react/test/stores/__snapshots__/graph.test.tsx.snap
+++ b/packages/react/test/stores/__snapshots__/graph.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`graph getInstance(atom) returns the instance 1`] = `
     },
     "state": 3,
     "status": "Active",
-    "weight": 3,
+    "weight": 1,
   },
 }
 `;

--- a/packages/react/test/utils/ecosystem.ts
+++ b/packages/react/test/utils/ecosystem.ts
@@ -13,17 +13,22 @@ export const getEdges = (map: Map<ZeduxNode, GraphEdge>) =>
 
 export const getNodes = () =>
   Object.fromEntries(
-    [...ecosystem.n.entries()].map(([id, node]) => [
-      id,
-      {
-        className: node.constructor.name,
-        observers: getEdges(node.o),
-        sources: getEdges(node.s),
-        state: node.get(),
-        status: node.status,
-        weight: node.W,
-      },
-    ])
+    [...ecosystem.n.entries()].map(([id, node]) => {
+      // resolve node weight if needed
+      if (node.R) node.R(node)
+
+      return [
+        id,
+        {
+          className: node.constructor.name,
+          observers: getEdges(node.o),
+          sources: getEdges(node.s),
+          state: node.get(),
+          status: node.status,
+          weight: node.W,
+        },
+      ]
+    })
   )
 
 export const getSelectorNodes = () =>


### PR DESCRIPTION
## Description

Zedux v2 has made huge strides in perf improvements thanks to the [js-reactivity-benchmark benchmarks](https://github.com/milomg/js-reactivity-benchmark). However, there's one last benchmark category that Zedux still struggles with: The `dynamicBench` category.

Zedux performs well on all but the last, "very dynamic" benchmark. While it's super contrived, probing an area where Zedux purposefully frontloads work due to how all real usages work, Zedux's performance on it is poor enough that it merits revisiting.

The benchmark constantly switches node dependencies around in a moderately-deep graph. Real nodes never do that - you define a node's deps and maybe switch a couple around here or there depending on user actions, feature switches, etc.

Again, super contrived, still, Zedux can take hours to complete this benchmark.

The fix is simple: Lazily recalculate node weights right before a node is scheduled instead of eagerly recalculating when the graph update buffer is flushed after every node evaluation.

This is done with a new `R` property on ZeduxNodes (short for needs`R`ecalculation). That property is set to a `resolveWeight` function that resolves the node's weight when needed. I exposed that function on the property instead of using a boolean flag so that users can easily force-resolve the node's weight if desired e.g. for snapshot testing (like we now do in [packages/react/test/utils/ecosystem.ts](https://github.com/Omnistac/zedux/compare/josh/lazy-weight-recalc?expand=1#diff-3f1ba7e2469a32a278beed55d14806ec44465b9851e8b5ef6d0cbbc1a64b68c1)). If this is often needed, we can easily expose a `weight` getter on ZeduxNodes that auto-resolves the node's weight when retrieved if not resolved.

This has no negative impact on any benchmarks and improves the "very dynamic" dynamicBench benchmark completion time from hours to seconds. With this last (unimportant, really) benchmark fixed, Zedux is now competitive with all other signals libs in every category.