### PR TITLE
fix(react): make static hooks always rerender on destroy

### DIFF
--- a/packages/react/src/hooks/useAtomInstance.ts
+++ b/packages/react/src/hooks/useAtomInstance.ts
@@ -112,6 +112,7 @@ export const useAtomInstance: {
     ecosystem.S = undefined
   }
 
+  const renderedInstance = instance
   const renderedValue = instance.v
   const isSelector = is(instance, SelectorInstance)
 
@@ -154,7 +155,10 @@ export const useAtomInstance: {
     // an unmounting component's effect cleanup can update or force-destroy the
     // atom instance before this component is mounted. If that happened, trigger
     // a rerender to recreate the atom instance and/or get its new state
-    if ((subscribe && instance.v !== renderedValue) || instance.l === zi.D) {
+    if (
+      (subscribe && instance.v !== renderedValue) ||
+      renderedInstance.l === zi.D
+    ) {
       render({})
     }
 


### PR DESCRIPTION
## Description

When used to create static deps, `useAtomInstance` doesn't currently rerender the component when StrictMode's extra useEffect cleanup destroys a `ttl: 0` atom. Fix that.

There's a check in there that's supposed to catch this (`instance.l === zi.D`estroyed), but another bug fix made it so the `instance` reference here is never destroyed. Just update the check to use the instance that was actually returned by the hook call during render.

Reproduce in a regression test and confirm the fix.