### PR TITLE
feat(atoms): consistently batch effect callbacks

### DIFF
--- a/packages/atoms/src/injectors/injectEffect.ts
+++ b/packages/atoms/src/injectors/injectEffect.ts
@@ -66,7 +66,7 @@ export const injectEffect = (
     j: () => {
       prevDescriptor?.c?.()
 
-      const cleanup = untrack(effect) // let this throw
+      const cleanup = untrack(() => e.batch(effect)) // let this throw
 
       if (typeof cleanup === 'function') nextDescriptor.c = cleanup
     },


### PR DESCRIPTION
## Description

`injectEffect` can now upgrade to use the SyncScheduler instead of the AsyncScheduler when its atom evaluates outside React.

When that happens, any state updates that the effect triggers synchronously will be "batched" since the scheduler is flushing when the effect runs. But when using the AsyncScheduler, nothing is batched since those state updates are added to the SyncScheduler which is not flushing in this case.

Fix this by making `injectEffect` wrap its callback in an `ecosystem.batch` call, ensuring the callback is always batched. Effects often trigger async flows, meaning any later updates won't be batched, but that's fine; the important thing is that behavior is consistent regardless which scheduler is used.