### PR TITLE
feat(atoms): add memos to `ecosystem.n` for cache management

### DIFF
--- a/packages/react/test/integrations/__snapshots__/injectors.test.tsx.snap
+++ b/packages/react/test/integrations/__snapshots__/injectors.test.tsx.snap
@@ -1,0 +1,219 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`injectors when called with no deps, injectMemo() tracks used signals 1`] = `
+{
+  "1": {
+    "className": "AtomInstance",
+    "observers": {},
+    "sources": {
+      "@memo(1)-3": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+      "@signal()-2": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "state": 3,
+    "status": "Active",
+    "weight": 4,
+  },
+  "@memo(1)-3": {
+    "className": "SelectorInstance",
+    "observers": {
+      "1": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "sources": {
+      "@signal()-1": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "state": 1,
+    "status": "Active",
+    "weight": 2,
+  },
+  "@signal()-1": {
+    "className": "Signal",
+    "observers": {
+      "@memo(1)-3": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "sources": {},
+    "state": 1,
+    "status": "Active",
+    "weight": 1,
+  },
+  "@signal()-2": {
+    "className": "Signal",
+    "observers": {
+      "1": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "sources": {},
+    "state": 2,
+    "status": "Active",
+    "weight": 1,
+  },
+}
+`;
+
+exports[`injectors when called with no deps, injectMemo() tracks used signals 2`] = `
+{
+  "1": {
+    "className": "AtomInstance",
+    "observers": {},
+    "sources": {
+      "@memo(1)-3": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+      "@signal()-2": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "state": 13,
+    "status": "Active",
+    "weight": 4,
+  },
+  "@memo(1)-3": {
+    "className": "SelectorInstance",
+    "observers": {
+      "1": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "sources": {
+      "@signal()-1": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "state": 11,
+    "status": "Active",
+    "weight": 2,
+  },
+  "@signal()-1": {
+    "className": "Signal",
+    "observers": {
+      "@memo(1)-3": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "sources": {},
+    "state": 11,
+    "status": "Active",
+    "weight": 1,
+  },
+  "@signal()-2": {
+    "className": "Signal",
+    "observers": {
+      "1": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "sources": {},
+    "state": 2,
+    "status": "Active",
+    "weight": 1,
+  },
+}
+`;
+
+exports[`injectors when called with no deps, injectMemo() tracks used signals 3`] = `
+{
+  "1": {
+    "className": "AtomInstance",
+    "observers": {},
+    "sources": {
+      "@memo(1)-3": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+      "@signal()-2": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "state": 33,
+    "status": "Active",
+    "weight": 4,
+  },
+  "@memo(1)-3": {
+    "className": "SelectorInstance",
+    "observers": {
+      "1": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "sources": {
+      "@signal()-1": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "state": 11,
+    "status": "Active",
+    "weight": 2,
+  },
+  "@signal()-1": {
+    "className": "Signal",
+    "observers": {
+      "@memo(1)-3": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "sources": {},
+    "state": 11,
+    "status": "Active",
+    "weight": 1,
+  },
+  "@signal()-2": {
+    "className": "Signal",
+    "observers": {
+      "1": {
+        "flags": 1,
+        "operation": "get",
+        "p": undefined,
+      },
+    },
+    "sources": {},
+    "state": 22,
+    "status": "Active",
+    "weight": 1,
+  },
+}
+`;
+
+exports[`injectors when called with no deps, injectMemo() tracks used signals 4`] = `{}`;

--- a/packages/react/test/integrations/injectors.test.tsx
+++ b/packages/react/test/integrations/injectors.test.tsx
@@ -17,7 +17,7 @@ import {
   injectSignal,
   injectWhy,
 } from '@zedux/react'
-import { ecosystem } from '../utils/ecosystem'
+import { ecosystem, snapshotNodes } from '../utils/ecosystem'
 
 describe('injectors', () => {
   test('injectors can only be called during atom evaluation', () => {
@@ -339,16 +339,23 @@ describe('injectors', () => {
 
     expect(node1.get()).toBe(3)
     expect(calls).toEqual([1])
+    snapshotNodes()
 
     signal1.set(11)
 
     expect(node1.get()).toBe(13)
     expect(calls).toEqual([1, 11])
+    snapshotNodes()
 
     signal2.set(22)
 
     expect(node1.get()).toBe(33)
     expect(calls).toEqual([1, 11])
+    snapshotNodes()
+
+    node1.destroy()
+
+    snapshotNodes()
   })
 
   test('injectEffect() callback does not track signal usages', () => {


### PR DESCRIPTION
## Description

`@memo` nodes are the only nodes not added to `ecosystem.n`, which is counter-intuitive, ruins Zedux's perfect cache management, and can also hurt dev tools.

Add them to `ecosystem.n` and update existing tests to take ecosystem snapshots, ensuring the `@memo` nodes are present.