### PR TITLE
feat(atoms)!: send ecosystem events immediately

### DIFF
--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -29,7 +29,6 @@ import {
   EcosystemEvents,
   InternalEvaluationReason,
   GetNode,
-  Job,
   NodeType,
 } from '../types/index'
 import {
@@ -86,7 +85,7 @@ import {
 } from '../utils/graph'
 
 export class Ecosystem<Context extends Record<string, any> | undefined = any>
-  implements EventEmitter, Job
+  implements EventEmitter
 {
   public asyncScheduler = new AsyncScheduler(this)
   public complexParams = false
@@ -210,18 +209,6 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
    * looked up via these context object references in a scoped context.
    */
   public s: Record<string, Record<string, any>[]> | undefined = undefined
-
-  /**
-   * `w`hy - the list of events this ecosystem is passing to event listeners on
-   * the next job run. This is a singly-linked list. The ecosystem only cares
-   * about the `.f`ullEventMap property.
-   */
-  public w: InternalEvaluationReason | undefined = undefined
-
-  /**
-   * `w`hy `t`ail - the last reason in the `w`hy linked list.
-   */
-  public wt: InternalEvaluationReason | undefined = undefined
 
   /**
    * Only for use by internal addon packages - lets us attach anything we want
@@ -1172,22 +1159,6 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
     } finally {
       this.S = prev
     }
-  }
-
-  /**
-   * @see Job.j
-   */
-  public j() {
-    const isSingleEvent = this.w === this.wt
-    let reason: InternalEvaluationReason | undefined = this.w!
-
-    do {
-      for (const listener of this.L) {
-        listener(isSingleEvent ? reason : reason.r!)
-      }
-    } while ((reason = reason?.l))
-
-    this.w = this.wt = undefined
   }
 
   /**

--- a/packages/atoms/src/utils/ecosystem.ts
+++ b/packages/atoms/src/utils/ecosystem.ts
@@ -68,16 +68,6 @@ const resolveAtom = <A extends AnyAtomTemplate>(
   return maybeOverriddenAtom
 }
 
-export const mapRefToId = (ecosystem: Ecosystem, obj: any, name: string) => {
-  let id = ecosystem.b.get(obj)
-  if (id) return id
-
-  id = ecosystem.makeId('ref', name || 'unknown')
-  ecosystem.b.set(obj, id)
-
-  return id
-}
-
 /**
  * The node gateway. This is the entry point for creating all graph nodes. This
  * only creates nodes if they don't exist yet.
@@ -204,6 +194,16 @@ export const mapOverrides = (overrides: AnyAtomTemplate[]) =>
     map[atom.key] = atom
     return map
   }, {} as Record<string, AnyAtomTemplate>)
+
+export const mapRefToId = (ecosystem: Ecosystem, obj: any, name: string) => {
+  let id = ecosystem.b.get(obj)
+  if (id) return id
+
+  id = ecosystem.makeId('ref', name || 'unknown')
+  ecosystem.b.set(obj, id)
+
+  return id
+}
 
 export const schedulerPre = (ecosystem: Ecosystem) =>
   ecosystem.syncScheduler.f++

--- a/packages/atoms/src/utils/graph.ts
+++ b/packages/atoms/src/utils/graph.ts
@@ -86,7 +86,7 @@ export const addEdge = (
  * first reason added, meaning a job should be scheduled to process this update.
  */
 export const addReason = (
-  node: ZeduxNode | Ecosystem,
+  node: ZeduxNode,
   reason: InternalEvaluationReason
 ) => {
   if (!node.w) {
@@ -376,6 +376,11 @@ export const setNodeStatus = (
     } as const
 
     if (isListeningToCycle) {
+      // ensure this is set before sending the `cycle` ecosystem event for the
+      // new node. It's fine that we set it again to the same ref in other
+      // places.
+      if (oldStatus === INITIALIZING) node.e.n.set(node.id, node)
+
       sendImplicitEcosystemEvent(node.e, reason)
     }
 

--- a/packages/react/test/integrations/plugins.test.tsx
+++ b/packages/react/test/integrations/plugins.test.tsx
@@ -29,11 +29,8 @@ afterEach(() => {
 describe('plugins', () => {
   test('ecosystem events fire only when there are ecosystem event listeners', () => {
     jest.useFakeTimers()
-    const ecosystemJobFn = jest.spyOn(ecosystem, 'j')
     const node1 = ecosystem.getNode(atom1)
     const calls: any[] = []
-
-    expect(ecosystemJobFn).not.toHaveBeenCalled()
 
     const cleanup = ecosystem.on(eventMap => {
       calls.push(Object.keys(eventMap))
@@ -41,21 +38,19 @@ describe('plugins', () => {
 
     node1.set({ a: 11 })
 
-    expect(ecosystemJobFn).toHaveBeenCalledTimes(1)
     expect(calls).toEqual([['change']])
 
     node1.mutate(state => {
       state.a = 111
     })
 
-    expect(ecosystemJobFn).toHaveBeenCalledTimes(2)
     expect(calls).toEqual([['change'], ['mutate', 'change']])
 
     cleanup()
 
     node1.set({ a: 1 })
 
-    expect(ecosystemJobFn).toHaveBeenCalledTimes(2)
+    expect(calls).toEqual([['change'], ['mutate', 'change']])
   })
 
   test('overrides fire cycle events', () => {


### PR DESCRIPTION
## Description

The `runStart` and `runEnd` events need to be sent to ecosystem event listeners immediately. Their primary purpose is timing atom/selector evaluation. Currently, they're batched along with any other ecosystem events and sent all at once at the end of the scheduler flush.

Since some events need to be sent immediately, make all ecosystem events notify ecosystem event listeners immediately. Completely remove all ecosystem event scheduling. I'd rather do this than have the behavior inconsistent.

Unfortunately, this means the original benefit of scheduling ecosystem events is gone. I scheduled them originally to prevent ecosystem event listeners from receiving events during React renders. That would allow them to set React state synchronously after receiving events.

Rather than make plugin authors learn the exceptions, just normalize this rule: Run anything that could result in React state updating in a microtask after receiving events. You can use Zedux's asyncScheduler for this:

```ts
ecosystem.asyncScheduler.schedule({
  j: () => updateMyState(),
  T: 4
})
```

if you don't mind the single-letter properties.

### Breaking Change

This is technically breaking. Any ecosystem event listeners that don't follow the above rule will now cause React "cannot update component while rendering another component" warnings.