### PR TITLE
feat: improve `injectPromise` and `injectStorePromise` type overloads

### DIFF
--- a/packages/atoms/src/injectors/injectPromise.ts
+++ b/packages/atoms/src/injectors/injectPromise.ts
@@ -102,7 +102,51 @@ const hasInvalidateReason = (node: ReturnType<typeof injectSelf>) => {
  * })
  * ```
  */
-export const injectPromise = <Data, MappedEvents extends EventMap = None>(
+export const injectPromise: {
+  <Data, MappedEvents extends EventMap = None>(
+    promiseFactory: (params: {
+      controller?: AbortController
+      prevData?: NoInfer<Data>
+    }) => Promise<Data>,
+    deps: InjectorDeps,
+    config: Omit<InjectPromiseConfig<Data>, 'initialData'> & {
+      initialData: Data
+    } & InjectSignalConfig<MappedEvents>
+  ): InjectPromiseAtomApi<
+    {
+      Exports: Record<string, any>
+      Promise: ZeduxPromise<Data>
+      Signal: MappedSignal<{
+        Events: MapEvents<MappedEvents>
+        State: Omit<PromiseState<Data>, 'data'> & { data: Data }
+      }>
+      State: Omit<PromiseState<Data>, 'data'> & { data: Data }
+    },
+    MappedEvents,
+    Data
+  >
+
+  <Data, MappedEvents extends EventMap = None>(
+    promiseFactory: (params: {
+      controller?: AbortController
+      prevData?: NoInfer<Data>
+    }) => Promise<Data>,
+    deps: InjectorDeps,
+    config?: InjectPromiseConfig<Data> & InjectSignalConfig<MappedEvents>
+  ): InjectPromiseAtomApi<
+    {
+      Exports: Record<string, any>
+      Promise: ZeduxPromise<Data>
+      Signal: MappedSignal<{
+        Events: MapEvents<MappedEvents>
+        State: PromiseState<Data>
+      }>
+      State: PromiseState<Data>
+    },
+    MappedEvents,
+    Data
+  >
+} = <Data, MappedEvents extends EventMap = None>(
   promiseFactory: (params: {
     controller?: AbortController
     prevData?: NoInfer<Data>
@@ -217,5 +261,5 @@ export const injectPromise = <Data, MappedEvents extends EventMap = None>(
 
   atomApi.dataSignal = dataSignal
 
-  return atomApi
+  return atomApi as any // required to satisfy both overloads
 }

--- a/packages/react/test/types.test.tsx
+++ b/packages/react/test/types.test.tsx
@@ -37,6 +37,7 @@ import {
   InvalidateEvent,
   PromiseChangeEvent,
   Ecosystem,
+  InjectPromiseAtomApi,
 } from '@zedux/react'
 import { expectTypeOf } from 'expect-type'
 import { ecosystem, snapshotNodes } from './utils/ecosystem'
@@ -619,6 +620,14 @@ describe('react types', () => {
       const val5 = injectMemo(() => true, [])
       const val6 = injectCallback(() => true, [])
       const val7 = injectPromise(() => Promise.resolve(1), [])
+      const val8 = injectPromise(() => Promise.resolve('a'), [], {
+        initialData: 'b',
+      })
+
+      injectPromise(() => Promise.resolve(true), [1, 'a'], {
+        // @ts-expect-error initialData must match promiseFactory return type
+        initialData: 'bad',
+      })
 
       return api(injectSignal(instance.getOnce())).setExports({
         val1,
@@ -628,6 +637,7 @@ describe('react types', () => {
         val5,
         val6,
         val7,
+        val8,
       })
     })
 
@@ -647,6 +657,19 @@ describe('react types', () => {
         State: PromiseState<number>
         Signal: Signal<{ Events: None; State: PromiseState<number> }>
       }>
+      val8: InjectPromiseAtomApi<
+        {
+          Exports: Record<string, any>
+          Promise: Promise<string>
+          State: Omit<PromiseState<string>, 'data'> & { data: string }
+          Signal: Signal<{
+            Events: None
+            State: Omit<PromiseState<string>, 'data'> & { data: string }
+          }>
+        },
+        None,
+        string
+      >
     }>()
   })
 

--- a/packages/stores/src/injectStorePromise.ts
+++ b/packages/stores/src/injectStorePromise.ts
@@ -68,6 +68,33 @@ export const injectStorePromise: {
   <T>(
     promiseFactory: (controller?: AbortController) => Promise<T>,
     deps: InjectorDeps,
+    config: Omit<InjectStorePromiseConfig, 'dataOnly' | 'initialData'> & {
+      dataOnly: true
+      initialData: T
+    } & InjectStoreConfig
+  ): StoreAtomApi<{
+    Exports: Record<string, any>
+    Promise: ZeduxPromise<T>
+    State: T
+    Store: Store<T>
+  }>
+
+  <T>(
+    promiseFactory: (controller?: AbortController) => Promise<T>,
+    deps: InjectorDeps,
+    config: Omit<InjectStorePromiseConfig, 'initialData'> & {
+      initialData: T
+    } & InjectStoreConfig
+  ): StoreAtomApi<{
+    Exports: Record<string, any>
+    Promise: ZeduxPromise<T>
+    State: Omit<PromiseState<T>, 'data'> & { data: T }
+    Store: Store<Omit<PromiseState<T>, 'data'> & { data: T }>
+  }>
+
+  <T>(
+    promiseFactory: (controller?: AbortController) => Promise<T>,
+    deps: InjectorDeps,
     config: Omit<InjectStorePromiseConfig, 'dataOnly'> & {
       dataOnly: true
     } & InjectStoreConfig


### PR DESCRIPTION
## Description

The new `injectPromise` improvements could also do with some better type overloads that recognize the `initialData` config option specifically. When specified, the resulting `data` is never `undefined`.

Add overloads that reflect this, reducing the need for nullish checks when using the returned `dataSignal`'s value or the `signal`'s (for `injectPromise`) or `store`'s (for `injectStorePromise`) `data` value.