### PR TITLE
fix: improve types for ions and promises in atoms and atom apis

### DIFF
--- a/packages/atoms/src/factories/api.ts
+++ b/packages/atoms/src/factories/api.ts
@@ -1,5 +1,5 @@
 import { AtomApi } from '../classes/AtomApi'
-import { AtomApiPromise, StateOf } from '../types/index'
+import { AtomApiPromise, None, ResolvedStateOf, StateOf } from '../types/index'
 import { Signal } from '../classes/Signal'
 
 /**
@@ -21,7 +21,7 @@ export const api: {
   // Signals (AtomApi cloning)
   <
     SignalType extends Signal<any> = Signal<any>,
-    Exports extends Record<string, any> = Record<string, never>,
+    Exports extends Record<string, any> = None,
     PromiseType extends AtomApiPromise = undefined
   >(
     value: AtomApi<{
@@ -39,15 +39,16 @@ export const api: {
 
   // Signals (normal)
   <SignalType extends Signal<any> = Signal<any>>(value: SignalType): AtomApi<{
-    Exports: Record<string, never>
+    Exports: None
     Promise: undefined
+    ResolvedState: ResolvedStateOf<SignalType>
     Signal: SignalType
     State: StateOf<SignalType>
   }>
 
   // No Value
   (): AtomApi<{
-    Exports: Record<string, never>
+    Exports: None
     Promise: undefined
     Signal: undefined
     State: undefined
@@ -56,7 +57,7 @@ export const api: {
   // No Value (passing generics manually)
   <
     State = undefined,
-    Exports extends Record<string, any> = Record<string, never>,
+    Exports extends Record<string, any> = None,
     PromiseType extends AtomApiPromise = undefined
   >(): AtomApi<{
     Exports: Exports
@@ -68,7 +69,7 @@ export const api: {
   // No Signal (AtomApi cloning)
   <
     State = undefined,
-    Exports extends Record<string, any> = Record<string, never>,
+    Exports extends Record<string, any> = None,
     PromiseType extends AtomApiPromise = undefined
   >(
     value: AtomApi<{
@@ -87,7 +88,7 @@ export const api: {
   // Normal Value
   <
     State = undefined,
-    Exports extends Record<string, any> = Record<string, never>,
+    Exports extends Record<string, any> = None,
     SignalType extends
       | Signal<{ Events: any; State: State }>
       | undefined = undefined
@@ -101,7 +102,7 @@ export const api: {
   }>
 } = <
   State = undefined,
-  Exports extends Record<string, any> = Record<string, never>,
+  Exports extends Record<string, any> = None,
   SignalType extends
     | Signal<{ Events: any; State: State }>
     | undefined = undefined,
@@ -121,6 +122,7 @@ export const api: {
       | AtomApi<{
           Exports: Exports
           Promise: PromiseType
+          ResolvedState: State
           Signal: SignalType
           State: State
         }>

--- a/packages/atoms/src/factories/atom.ts
+++ b/packages/atoms/src/factories/atom.ts
@@ -17,7 +17,7 @@ export const atom: {
   <
     State = any,
     Params extends any[] = [],
-    Exports extends Record<string, any> = Record<string, never>
+    Exports extends Record<string, any> = None
   >(
     key: string,
     value: (...params: Params) => AtomApi<{
@@ -40,21 +40,46 @@ export const atom: {
     StateType,
     EventsType extends Record<string, any> = None,
     Params extends any[] = [],
-    Exports extends Record<string, any> = Record<string, never>,
-    PromiseType extends AtomApiPromise = undefined
+    Exports extends Record<string, any> = None,
+    PromiseType extends AtomApiPromise = undefined,
+    ResolvedState = StateType
   >(
     key: string,
     value: (...params: Params) =>
       | Signal<{
-          State: StateType
           Events: EventsType
           Params: any
+          State: StateType
           Template: any
         }>
       | AtomApi<{
           Exports: Exports
           Promise: PromiseType
-          Signal: Signal<{ State: StateType; Events: EventsType }>
+          Signal: Signal<{
+            Events: EventsType
+            Params: any
+            State: StateType
+            Template: any
+          }>
+          State: StateType
+        }>
+      | Signal<{
+          Events: EventsType
+          Params: any
+          ResolvedState: ResolvedState
+          State: StateType
+          Template: any
+        }>
+      | AtomApi<{
+          Exports: Exports
+          Promise: PromiseType
+          Signal: Signal<{
+            Events: EventsType
+            Params: any
+            ResolvedState: ResolvedState
+            State: StateType
+            Template: any
+          }>
           State: StateType
         }>,
     config?: AtomConfig<StateType>
@@ -64,16 +89,17 @@ export const atom: {
     Events: EventsType
     Exports: Exports
     Promise: PromiseType
+    ResolvedState: ResolvedState
   }>
 
   // Catch-all
   <
     State = any,
     Params extends any[] = [],
-    Exports extends Record<string, any> = Record<string, never>,
+    Exports extends Record<string, any> = None,
     Events extends Record<string, any> = None,
     SignalType extends
-      | Signal<{ State: State; Events: Events }>
+      | Signal<{ Events: Events; Params: any; State: State; Template: any }>
       | undefined = undefined,
     PromiseType extends AtomApiPromise = undefined
   >(
@@ -96,10 +122,10 @@ export const atom: {
 } = <
   State = any,
   Params extends any[] = [],
-  Exports extends Record<string, any> = Record<string, never>,
+  Exports extends Record<string, any> = None,
   Events extends Record<string, any> = None,
   SignalType extends
-    | Signal<{ State: State; Events: Events }>
+    | Signal<{ Events: Events; Params: any; State: State; Template: any }>
     | undefined = undefined,
   PromiseType extends AtomApiPromise = undefined
 >(

--- a/packages/atoms/src/factories/ion.ts
+++ b/packages/atoms/src/factories/ion.ts
@@ -10,8 +10,6 @@ import {
   AtomApiPromise,
   IonStateFactory,
   PromiseState,
-  StateOf,
-  EventsOf,
   None,
 } from '../types/index'
 
@@ -51,30 +49,62 @@ export const ion: {
 
   // Signals
   <
-    SignalType extends Signal<any> = Signal<any>,
+    StateType,
+    EventsType extends Record<string, any> = None,
     Params extends any[] = [],
     Exports extends Record<string, any> = None,
-    PromiseType extends AtomApiPromise = undefined
+    PromiseType extends AtomApiPromise = undefined,
+    ResolvedState = StateType
   >(
     key: string,
     value: (
       ecosystem: Ecosystem,
       ...params: Params
     ) =>
-      | SignalType
+      | Signal<{
+          Events: EventsType
+          Params: any
+          State: StateType
+          Template: any
+        }>
       | AtomApi<{
           Exports: Exports
           Promise: PromiseType
-          Signal: SignalType
-          State: StateOf<SignalType>
+          Signal: Signal<{
+            Events: EventsType
+            Params: any
+            State: StateType
+            Template: any
+          }>
+          State: StateType
+        }>
+      | Signal<{
+          Events: EventsType
+          Params: any
+          ResolvedState: ResolvedState
+          State: StateType
+          Template: any
+        }>
+      | AtomApi<{
+          Exports: Exports
+          Promise: PromiseType
+          Signal: Signal<{
+            Events: EventsType
+            Params: any
+            ResolvedState: ResolvedState
+            State: StateType
+            Template: any
+          }>
+          State: StateType
         }>,
-    config?: AtomConfig<StateOf<SignalType>>
+    config?: AtomConfig<StateType>
   ): IonTemplateRecursive<{
-    State: StateOf<SignalType>
+    State: StateType
     Params: Params
-    Events: EventsOf<SignalType>
+    Events: EventsType
     Exports: Exports
     Promise: PromiseType
+    ResolvedState: ResolvedState
   }>
 
   // No Signal (TODO: Is this overload unnecessary? `atom` doesn't have it)

--- a/packages/atoms/src/types/atoms.ts
+++ b/packages/atoms/src/types/atoms.ts
@@ -7,7 +7,6 @@ import {
   SelectorTemplate,
   Prettify,
   Selectable,
-  ZeduxPromise,
 } from './index'
 import { SelectorInstance } from '../classes/SelectorInstance'
 import type { Signal } from '../classes/Signal'
@@ -151,7 +150,19 @@ export type PromiseOf<A extends AnyAtomApi | AnyAtomTemplate | ZeduxNode> =
     : never
 
 export type ResolvedStateOf<A extends AnyAtomTemplate | ZeduxNode> =
-  PromiseOf<A> extends ZeduxPromise<any> ? Awaited<PromiseOf<A>> : StateOf<A>
+  A extends AtomTemplateBase<infer G>
+    ? G extends { ResolvedState: infer R }
+      ? R
+      : StateOf<A>
+    : A extends ZeduxNode<{
+        Events: any
+        Params: any
+        ResolvedState: infer R
+        State: any
+        Template: any
+      }>
+    ? R
+    : StateOf<A>
 
 export type SelectorGenerics = Pick<AtomGenerics, 'State'> & {
   Params: any[]

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -480,9 +480,3 @@ export type StateHookTuple<State, Exports> = [
   State,
   ExportsInfusedSetter<State, Exports>
 ]
-
-export interface ZeduxPromise<T> extends Promise<T> {
-  // this type needs a junk field to prevent TS from collapsing it down to match
-  // normal `Promise` types
-  _: never
-}

--- a/packages/react/test/integrations/suspense.test.tsx
+++ b/packages/react/test/integrations/suspense.test.tsx
@@ -7,7 +7,6 @@ import {
   useAtomInstance,
   useAtomState,
   useAtomValue,
-  ZeduxPromise,
 } from '@zedux/react'
 import React, { Suspense } from 'react'
 import { ErrorBoundary } from '../utils/ErrorBoundary'
@@ -265,9 +264,9 @@ describe('suspense', () => {
       expectTypeOf(state1).toEqualTypeOf<number>()
       expectTypeOf(value1NoSuspense).toEqualTypeOf<number | undefined>()
       expectTypeOf(state1NoSuspense).toEqualTypeOf<number | undefined>()
-      expectTypeOf(value2).toEqualTypeOf<number | undefined>()
+      expectTypeOf(value2).toEqualTypeOf<number>()
 
-      expectTypeOf(instance1.promise).toEqualTypeOf<ZeduxPromise<number>>()
+      expectTypeOf(instance1.promise).toEqualTypeOf<Promise<number>>()
       expectTypeOf<StateOf<typeof instance1>>().toEqualTypeOf<
         number | undefined
       >()
@@ -278,7 +277,7 @@ describe('suspense', () => {
       expectTypeOf<StateOf<typeof instance2>>().toEqualTypeOf<
         number | undefined
       >()
-      expectTypeOf(instanceValue2).toEqualTypeOf<number | undefined>()
+      expectTypeOf(instanceValue2).toEqualTypeOf<number>()
       expectTypeOf(instanceValue2NoSuspense).toEqualTypeOf<number | undefined>()
 
       return <div data-testid="value">{value1 + (value2 || 0) + value}</div>

--- a/packages/react/test/legacy-types.test.tsx
+++ b/packages/react/test/legacy-types.test.tsx
@@ -11,6 +11,7 @@ import {
   injectCallback,
   injectMemo,
   injectSelf,
+  None,
   ParamlessTemplate,
   PromiseState,
 } from '@zedux/react'
@@ -149,11 +150,9 @@ describe('react types', () => {
     expectTypeOf<StoreAtomInstanceParams>().toEqualTypeOf<[p: string]>()
     expectTypeOf<StoreAtomInstanceParams>().toEqualTypeOf<ValueAtomInstanceParams>()
 
-    expectTypeOf<StoreAtomExports>().toEqualTypeOf<Record<string, never>>()
+    expectTypeOf<StoreAtomExports>().toEqualTypeOf<None>()
     expectTypeOf<StoreAtomExports>().toEqualTypeOf<ValueAtomExports>()
-    expectTypeOf<StoreAtomInstanceExports>().toEqualTypeOf<
-      Record<string, never>
-    >()
+    expectTypeOf<StoreAtomInstanceExports>().toEqualTypeOf<None>()
     expectTypeOf<StoreAtomInstanceExports>().toEqualTypeOf<ValueAtomInstanceExports>()
 
     expectTypeOf<StoreAtomPromise>().toBeUndefined()
@@ -168,12 +167,40 @@ describe('react types', () => {
 
     expectTypeOf<TStoreAtomInstance>().toEqualTypeOf<typeof storeInstance>()
     expectTypeOf<TStoreAtomTemplate>().toEqualTypeOf<typeof storeInstance.t>()
-    expectTypeOf<TValueAtomInstance>().toEqualTypeOf<typeof storeInstance>()
+    expectTypeOf<TValueAtomInstance>().toEqualTypeOf<
+      StoreAtomInstance<
+        {
+          Events: None
+          Exports: None
+          Params: [p: string]
+          Promise: undefined
+          State: string
+          Store: Store<string>
+        } & {
+          Node: StoreAtomInstanceRecursive<{
+            Events: None
+            Exports: None
+            Params: [p: string]
+            Promise: undefined
+            State: string
+            Store: Store<string>
+          }>
+          Template: StoreAtomTemplateRecursive<{
+            Events: None
+            Exports: None
+            Params: [p: string]
+            Promise: undefined
+            State: string
+            Store: Store<string>
+          }>
+        }
+      >
+    >()
     expectTypeOf<TValueAtomTemplate>().toEqualTypeOf<
       StoreAtomTemplateRecursive<{
         State: ValueAtomState
         Params: ValueAtomParams
-        Events: Record<string, never>
+        Events: None
         Exports: ValueAtomExports
         Store: ValueAtomStore
         Promise: ValueAtomPromise
@@ -251,7 +278,7 @@ describe('react types', () => {
       AtomExportsType<typeof queryWithPromiseAtom>
     >().toEqualTypeOf<ExpectedExports>()
     expectTypeOf<AtomExportsType<typeof noExportsAtom>>().toEqualTypeOf<
-      Record<string, never>
+      Record<never, never>
     >()
 
     expectTypeOf<AtomStoreType<typeof storeBasedAtom>>().toEqualTypeOf<
@@ -331,11 +358,9 @@ describe('react types', () => {
     expectTypeOf<StoreIonInstanceParams>().toEqualTypeOf<[p: string]>()
     expectTypeOf<StoreIonInstanceParams>().toEqualTypeOf<ValueIonInstanceParams>()
 
-    expectTypeOf<StoreIonExports>().toEqualTypeOf<Record<string, never>>()
+    expectTypeOf<StoreIonExports>().toEqualTypeOf<None>()
     expectTypeOf<StoreIonExports>().toEqualTypeOf<ValueIonExports>()
-    expectTypeOf<StoreIonInstanceExports>().toEqualTypeOf<
-      Record<string, never>
-    >()
+    expectTypeOf<StoreIonInstanceExports>().toEqualTypeOf<None>()
     expectTypeOf<StoreIonInstanceExports>().toEqualTypeOf<ValueIonInstanceExports>()
 
     expectTypeOf<StoreIonPromise>().toBeUndefined()
@@ -353,7 +378,7 @@ describe('react types', () => {
       StoreIonTemplateRecursive<{
         State: StoreIonState
         Params: StoreIonParams
-        Events: Record<string, never>
+        Events: None
         Exports: StoreIonExports
         Store: StoreIonStore
         Promise: StoreIonPromise
@@ -364,7 +389,7 @@ describe('react types', () => {
       StoreIonTemplateRecursive<{
         State: StoreIonState
         Params: StoreIonParams
-        Events: Record<string, never>
+        Events: None
         Exports: StoreIonExports
         Store: StoreIonStore
         Promise: StoreIonPromise
@@ -482,8 +507,8 @@ describe('react types', () => {
     expect(val).toBe('A')
     expectTypeOf<typeof innerInstance>().toMatchTypeOf<
       StoreAtomInstanceRecursive<{
-        Events: Record<string, never>
-        Exports: Record<string, never>
+        Events: None
+        Exports: None
         Params: []
         State: string
         Store: Store<string>
@@ -493,8 +518,8 @@ describe('react types', () => {
 
     expectTypeOf<typeof outerInstance>().toMatchTypeOf<
       StoreAtomInstanceRecursive<{
-        Events: Record<string, never>
-        Exports: Record<string, never>
+        Events: None
+        Exports: None
         Params: [
           instance: StoreAtomInstance<
             AnyStoreAtomGenerics<{
@@ -561,7 +586,7 @@ describe('react types', () => {
       StoreAtomInstanceRecursive<{
         State: string
         Params: [p: string]
-        Events: Record<string, never>
+        Events: None
         Exports: {
           getBool: () => boolean
           getNum: () => number
@@ -574,8 +599,9 @@ describe('react types', () => {
       StoreAtomInstanceRecursive<{
         State: number | string[] | undefined
         Params: [a?: boolean | undefined, b?: string[] | undefined]
-        Events: Record<string, never>
-        Exports: Record<string, never>
+        Events: None
+        Exports: None
+        ResolvedState: number | string[] | undefined
         Store: Store<number | string[] | undefined>
         Promise: undefined
       }>

--- a/packages/stores/src/injectStorePromise.ts
+++ b/packages/stores/src/injectStorePromise.ts
@@ -6,7 +6,6 @@ import {
   InjectStoreConfig,
   injectWhy,
   PromiseState,
-  ZeduxPromise,
 } from '@zedux/atoms'
 import { detailedTypeof, RecursivePartial, Store } from '@zedux/core'
 import {
@@ -74,7 +73,8 @@ export const injectStorePromise: {
     } & InjectStoreConfig
   ): StoreAtomApi<{
     Exports: Record<string, any>
-    Promise: ZeduxPromise<T>
+    Promise: Promise<T>
+    ResolvedState: T
     State: T
     Store: Store<T>
   }>
@@ -87,7 +87,8 @@ export const injectStorePromise: {
     } & InjectStoreConfig
   ): StoreAtomApi<{
     Exports: Record<string, any>
-    Promise: ZeduxPromise<T>
+    Promise: Promise<T>
+    ResolvedState: T
     State: Omit<PromiseState<T>, 'data'> & { data: T }
     Store: Store<Omit<PromiseState<T>, 'data'> & { data: T }>
   }>
@@ -100,7 +101,8 @@ export const injectStorePromise: {
     } & InjectStoreConfig
   ): StoreAtomApi<{
     Exports: Record<string, any>
-    Promise: ZeduxPromise<T>
+    Promise: Promise<T>
+    ResolvedState: T
     State: T | undefined
     Store: Store<T | undefined>
   }>
@@ -111,7 +113,8 @@ export const injectStorePromise: {
     config?: InjectStorePromiseConfig<T> & InjectStoreConfig
   ): StoreAtomApi<{
     Exports: Record<string, any>
-    Promise: ZeduxPromise<T>
+    Promise: Promise<T>
+    ResolvedState: T
     State: PromiseState<T>
     Store: Store<PromiseState<T>>
   }>
@@ -128,7 +131,7 @@ export const injectStorePromise: {
   const refs = injectRef({ counter: 0 } as {
     controller?: AbortController
     counter: number
-    promise: ZeduxPromise<T>
+    promise: Promise<T>
   })
 
   const store = injectStore(
@@ -188,7 +191,7 @@ export const injectStorePromise: {
         store.setStateDeep(getErrorPromiseState(error))
       })
 
-    return promise as ZeduxPromise<T>
+    return promise
   }, deps && [...deps, refs.current.counter])
 
   injectEffect(
@@ -199,5 +202,5 @@ export const injectStorePromise: {
     []
   )
 
-  return storeApi(store).setPromise(refs.current.promise)
+  return storeApi(store).setPromise(refs.current.promise) as any
 }

--- a/packages/stores/src/storeApi.ts
+++ b/packages/stores/src/storeApi.ts
@@ -1,4 +1,4 @@
-import { AtomApiPromise } from '@zedux/atoms'
+import { AtomApiPromise, None } from '@zedux/atoms'
 import { Store, StoreStateType } from '@zedux/core'
 import { StoreAtomApi } from './StoreAtomApi'
 
@@ -21,7 +21,7 @@ export const storeApi: {
   // Custom Stores (AtomApi cloning)
   <
     StoreType extends Store<any> = Store<any>,
-    Exports extends Record<string, any> = Record<string, never>,
+    Exports extends Record<string, any> = None,
     PromiseType extends AtomApiPromise = undefined
   >(
     value: StoreAtomApi<{
@@ -39,7 +39,7 @@ export const storeApi: {
 
   // Custom Stores (normal)
   <StoreType extends Store<any> = Store<any>>(value: StoreType): StoreAtomApi<{
-    Exports: Record<string, never>
+    Exports: None
     Promise: undefined
     State: StoreStateType<StoreType>
     Store: StoreType
@@ -47,7 +47,7 @@ export const storeApi: {
 
   // No Value
   (): StoreAtomApi<{
-    Exports: Record<string, never>
+    Exports: None
     Promise: undefined
     State: undefined
     Store: undefined
@@ -55,7 +55,7 @@ export const storeApi: {
 
   <
     State = undefined,
-    Exports extends Record<string, any> = Record<string, never>,
+    Exports extends Record<string, any> = None,
     PromiseType extends AtomApiPromise = undefined
   >(): StoreAtomApi<{
     Exports: Exports
@@ -67,7 +67,7 @@ export const storeApi: {
   // No Store (AtomApi cloning)
   <
     State = undefined,
-    Exports extends Record<string, any> = Record<string, never>,
+    Exports extends Record<string, any> = None,
     PromiseType extends AtomApiPromise = undefined
   >(
     value: StoreAtomApi<{
@@ -85,7 +85,7 @@ export const storeApi: {
 
   // No Store (normal)
   <State = undefined>(value: State): StoreAtomApi<{
-    Exports: Record<string, never>
+    Exports: None
     Promise: undefined
     State: State
     Store: undefined
@@ -94,7 +94,7 @@ export const storeApi: {
   // Catch-all
   <
     State = undefined,
-    Exports extends Record<string, any> = Record<string, never>,
+    Exports extends Record<string, any> = None,
     StoreType extends Store<State> = Store<State>,
     PromiseType extends AtomApiPromise = undefined
   >(
@@ -115,7 +115,7 @@ export const storeApi: {
   }>
 } = <
   State = undefined,
-  Exports extends Record<string, any> = Record<string, never>,
+  Exports extends Record<string, any> = None,
   StoreType extends Store<State> | undefined = undefined,
   PromiseType extends AtomApiPromise = undefined
 >(

--- a/packages/stores/src/storeAtom.ts
+++ b/packages/stores/src/storeAtom.ts
@@ -1,4 +1,4 @@
-import { AtomConfig, AtomApiPromise, PromiseState } from '@zedux/atoms'
+import { AtomConfig, AtomApiPromise, PromiseState, None } from '@zedux/atoms'
 import { Store, StoreStateType } from '@zedux/core'
 import { StoreAtomApi } from './StoreAtomApi'
 import {
@@ -12,7 +12,7 @@ export const storeAtom: {
   <
     State = any,
     Params extends any[] = [],
-    Exports extends Record<string, any> = Record<string, never>
+    Exports extends Record<string, any> = None
   >(
     key: string,
     value: (...params: Params) => StoreAtomApi<{
@@ -25,7 +25,7 @@ export const storeAtom: {
   ): StoreAtomTemplateRecursive<{
     State: PromiseState<State>
     Params: Params
-    Events: Record<string, never>
+    Events: None
     Exports: Exports
     Store: Store<PromiseState<State>>
     Promise: Promise<State>
@@ -35,8 +35,9 @@ export const storeAtom: {
   <
     StoreType extends Store<any> = Store<any>,
     Params extends any[] = [],
-    Exports extends Record<string, any> = Record<string, never>,
-    PromiseType extends AtomApiPromise = undefined
+    Exports extends Record<string, any> = None,
+    PromiseType extends AtomApiPromise = undefined,
+    ResolvedState = StoreStateType<StoreType>
   >(
     key: string,
     value: (...params: Params) =>
@@ -44,6 +45,7 @@ export const storeAtom: {
       | StoreAtomApi<{
           Exports: Exports
           Promise: PromiseType
+          ResolvedState: ResolvedState
           State: StoreStateType<Store>
           Store: StoreType
         }>,
@@ -51,8 +53,9 @@ export const storeAtom: {
   ): StoreAtomTemplateRecursive<{
     State: StoreStateType<StoreType>
     Params: Params
-    Events: Record<string, never>
+    Events: None
     Exports: Exports
+    ResolvedState: ResolvedState
     Store: StoreType
     Promise: PromiseType
   }>
@@ -61,13 +64,13 @@ export const storeAtom: {
   <
     State = any,
     Params extends any[] = [],
-    Exports extends Record<string, any> = Record<string, never>,
+    Exports extends Record<string, any> = None,
     StoreType extends Store<State> = Store<State>,
     PromiseType extends AtomApiPromise = undefined
   >(
     key: string,
     value: StoreAtomValueOrFactory<{
-      Events: Record<string, never>
+      Events: None
       Exports: Exports
       Params: Params
       Promise: PromiseType
@@ -76,7 +79,7 @@ export const storeAtom: {
     }>,
     config?: AtomConfig<State>
   ): StoreAtomTemplateRecursive<{
-    Events: Record<string, never>
+    Events: None
     Exports: Exports
     Params: Params
     Promise: PromiseType
@@ -86,13 +89,13 @@ export const storeAtom: {
 } = <
   State = any,
   Params extends any[] = [],
-  Exports extends Record<string, any> = Record<string, never>,
+  Exports extends Record<string, any> = None,
   StoreType extends Store<State> = Store<State>,
   PromiseType extends AtomApiPromise = undefined
 >(
   key: string,
   value: StoreAtomValueOrFactory<{
-    Events: Record<string, never>
+    Events: None
     Exports: Exports
     Params: Params
     Promise: PromiseType

--- a/packages/stores/src/storeIon.ts
+++ b/packages/stores/src/storeIon.ts
@@ -1,4 +1,4 @@
-import { AtomConfig, AtomGetters, PromiseState } from '@zedux/atoms'
+import { AtomConfig, AtomGetters, None, PromiseState } from '@zedux/atoms'
 import { Store, StoreStateType } from '@zedux/core'
 import { StoreAtomApi } from './StoreAtomApi'
 import { StoreIonTemplate, StoreIonTemplateRecursive } from './StoreIonTemplate'
@@ -9,7 +9,7 @@ export const storeIon: {
   <
     State = any,
     Params extends any[] = [],
-    Exports extends Record<string, any> = Record<string, never>
+    Exports extends Record<string, any> = None
   >(
     key: string,
     value: (
@@ -25,7 +25,7 @@ export const storeIon: {
   ): StoreIonTemplateRecursive<{
     State: PromiseState<State>
     Params: Params
-    Events: Record<string, never>
+    Events: None
     Exports: Exports
     Store: Store<PromiseState<State>>
     Promise: Promise<State>
@@ -35,7 +35,7 @@ export const storeIon: {
   <
     StoreType extends Store<any> = Store<any>,
     Params extends any[] = [],
-    Exports extends Record<string, any> = Record<string, never>,
+    Exports extends Record<string, any> = None,
     PromiseType extends StoreAtomApiPromise = undefined
   >(
     key: string,
@@ -54,7 +54,7 @@ export const storeIon: {
   ): StoreIonTemplateRecursive<{
     State: StoreStateType<StoreType>
     Params: Params
-    Events: Record<string, never>
+    Events: None
     Exports: Exports
     Store: StoreType
     Promise: PromiseType
@@ -64,7 +64,7 @@ export const storeIon: {
   <
     State = any,
     Params extends any[] = [],
-    Exports extends Record<string, any> = Record<string, never>,
+    Exports extends Record<string, any> = None,
     PromiseType extends StoreAtomApiPromise = undefined
   >(
     key: string,
@@ -83,7 +83,7 @@ export const storeIon: {
   ): StoreIonTemplateRecursive<{
     State: State
     Params: Params
-    Events: Record<string, never>
+    Events: None
     Exports: Exports
     Store: Store<State>
     Promise: PromiseType
@@ -93,7 +93,7 @@ export const storeIon: {
   <
     State = any,
     Params extends any[] = [],
-    Exports extends Record<string, any> = Record<string, never>,
+    Exports extends Record<string, any> = None,
     StoreType extends Store<any> = Store<any>,
     PromiseType extends StoreAtomApiPromise = undefined
   >(
@@ -101,7 +101,7 @@ export const storeIon: {
     get: StoreIonStateFactory<{
       State: State
       Params: Params
-      Events: Record<string, never>
+      Events: None
       Exports: Exports
       Store: StoreType
       Promise: PromiseType
@@ -110,7 +110,7 @@ export const storeIon: {
   ): StoreIonTemplateRecursive<{
     State: State
     Params: Params
-    Events: Record<string, never>
+    Events: None
     Exports: Exports
     Store: StoreType
     Promise: PromiseType
@@ -118,7 +118,7 @@ export const storeIon: {
 } = <
   State = any,
   Params extends any[] = [],
-  Exports extends Record<string, any> = Record<string, never>,
+  Exports extends Record<string, any> = None,
   StoreType extends Store<State> = Store<State>,
   PromiseType extends StoreAtomApiPromise = undefined
 >(
@@ -126,7 +126,7 @@ export const storeIon: {
   get: StoreIonStateFactory<{
     State: State
     Params: Params
-    Events: Record<string, never>
+    Events: None
     Exports: Exports
     Store: StoreType
     Promise: PromiseType


### PR DESCRIPTION
@affects atoms, stores

## Description

Ion instances aren't currently accepted as valid signals for the `api` factory. Also the ZeduxPromise should not be used to infer the state type of nodes, since the node's promise and state can be unrelated.

Fix both of those and improve some other overloads, type helpers, and tests.