### PR TITLE
fix(atoms): correct the return type of `Ecosystem#getNode`

### DIFF
--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -30,6 +30,7 @@ import {
   InternalEvaluationReason,
   GetNode,
   NodeType,
+  Get,
 } from '../types/index'
 import {
   CATCH_ALL,
@@ -467,17 +468,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
    * this is functionally equivalent to calling `.get()` directly on the passed
    * instance.
    */
-  public get: {
-    <A extends AnyAtomTemplate>(template: A, params: ParamsOf<A>): StateOf<A>
-    <A extends AnyAtomTemplate<{ Params: [] }>>(template: A): StateOf<A>
-    <A extends AnyAtomTemplate>(template: ParamlessTemplate<A>): StateOf<A>
-
-    <N extends ZeduxNode>(node: N): StateOf<N>
-
-    <S extends Selectable>(template: S, params: ParamsOf<S>): StateOf<S>
-    <S extends Selectable<any, []>>(template: S): StateOf<S>
-    <S extends Selectable>(template: ParamlessTemplate<S>): StateOf<S>
-  } = <A extends AnyAtomTemplate>(
+  public get: Get = <A extends AnyAtomTemplate>(
     atom: A | AnyAtomInstance,
     params?: ParamsOf<A>
   ) => getNode(this, atom, params as ParamsOf<A>).get()
@@ -570,7 +561,7 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
    * Unlike `.getNode`, this is static - it doesn't register graph dependencies
    * even when called in reactive contexts.
    */
-  public getOnce: GetNode = <G extends AtomGenerics>(
+  public getOnce: Get = <G extends AtomGenerics>(
     template: AtomTemplateBase<G> | ZeduxNode<G> | SelectorTemplate<G>,
     params?: G['Params']
   ) => getNode(this, template, params).getOnce()

--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -157,6 +157,18 @@ export type ExportsInfusedSetter<State, Exports> = Exports & {
   (settable: Settable<State>, meta?: any): State
 }
 
+export interface Get {
+  <A extends AnyAtomTemplate>(template: A, params: ParamsOf<A>): StateOf<A>
+  <A extends AnyAtomTemplate<{ Params: [] }>>(template: A): StateOf<A>
+  <A extends AnyAtomTemplate>(template: ParamlessTemplate<A>): StateOf<A>
+
+  <N extends ZeduxNode>(node: N): StateOf<N>
+
+  <S extends Selectable>(template: S, params: ParamsOf<S>): StateOf<S>
+  <S extends Selectable<any, []>>(template: S): StateOf<S>
+  <S extends Selectable>(template: ParamlessTemplate<S>): StateOf<S>
+}
+
 export interface GetNode {
   // TODO: Dedupe these overloads
   // atoms

--- a/packages/react/test/units/Ecosystem.test.tsx
+++ b/packages/react/test/units/Ecosystem.test.tsx
@@ -1,6 +1,7 @@
-import { atom, createEcosystem, ion } from '@zedux/react'
+import { atom, createEcosystem, injectEcosystem, ion } from '@zedux/react'
 import { ecosystem } from '../utils/ecosystem'
 import { mockConsole } from '../utils/console'
+import { expectTypeOf } from 'expect-type'
 
 describe('Ecosystem', () => {
   test('passing a SelectorInstance to .select() and .get() returns the result of the passed instance', () => {
@@ -191,6 +192,24 @@ describe('Ecosystem', () => {
 
     expect(reactiveNode2.get()).toBe(1) // re-ran on source node force-destroy
     expect(staticNode2.get()).toBe(11)
+  })
+
+  test("getOnce() returns the resolved node's value", () => {
+    const atomA = atom('a', 1)
+    const atomB = atom('b', () => injectEcosystem().getOnce(atomA))
+    const valueA = ecosystem.getOnce(atomA)
+    const valueB = ecosystem.getOnce(atomB)
+
+    expectTypeOf(valueA).toEqualTypeOf<number>()
+    expect(valueA).toBe(1)
+    expectTypeOf(valueB).toEqualTypeOf<number>()
+    expect(valueB).toBe(1)
+
+    ecosystem.getNode(atomA).set(2)
+    expect(ecosystem.getOnce(atomA)).toBe(2)
+    expect(ecosystem.getOnce(atomB)).toBe(1) // getOnce registers no deps
+
+    expect(ecosystem.getNode(atomB).s.size).toBe(0)
   })
 
   test('getOnce() does not register graph edges in reactive contexts', () => {


### PR DESCRIPTION
## Description

The return type of `Ecosystem#getOnce` was copied from `Ecosystem#getNodeOnce` and never changed. This means `getOnce` thinks it returns a node instead of a node's value. Fix this and make sure the tests verify the type.

Resolves #246.