### PR TITLE
feat(atoms): make EventMap generics easier to pass manually

### DIFF
--- a/packages/atoms/src/classes/Ecosystem.ts
+++ b/packages/atoms/src/classes/Ecosystem.ts
@@ -17,10 +17,8 @@ import {
   ParamlessTemplate,
   Selectable,
   SelectorGenerics,
-  EventMap,
   None,
   InjectSignalConfig,
-  MapEvents,
   SingleEventListener,
   CatchAllListener,
   EventEmitter,
@@ -965,14 +963,14 @@ export class Ecosystem<Context extends Record<string, any> | undefined = any>
     }
   }
 
-  public signal<State, MappedEvents extends EventMap = None>(
+  public signal<State, EventMap extends Record<string, any> = None>(
     state: State,
-    config?: Pick<InjectSignalConfig<MappedEvents>, 'events'>
+    config?: Pick<InjectSignalConfig<EventMap>, 'events'>
   ) {
     const id = this.makeId('signal')
 
     const signal = new Signal<{
-      Events: MapEvents<MappedEvents>
+      Events: EventMap
       State: State
     }>(this, id, state, config?.events)
 

--- a/packages/atoms/src/classes/MappedSignal.ts
+++ b/packages/atoms/src/classes/MappedSignal.ts
@@ -268,6 +268,8 @@ export class MappedSignal<
   public u(map: SignalMap) {
     const entries = Object.entries(map)
 
+    // create a new graph edge buffer so `.get` calls add deps to this
+    // MappedSignal rather than any containing atom
     const prevNode = this.e.cs(this)
 
     // `get` every signal and auto-add each one as a source of the mapped signal

--- a/packages/atoms/src/injectors/injectMappedSignal.ts
+++ b/packages/atoms/src/injectors/injectMappedSignal.ts
@@ -2,10 +2,8 @@ import { MappedSignal, SignalMap } from '../classes/MappedSignal'
 import { Signal } from '../classes/Signal'
 import {
   AnyNonNullishValue,
-  EventMap,
   EventsOf,
   InjectSignalConfig,
-  MapEvents,
   None,
   Prettify,
   StateOf,
@@ -72,16 +70,16 @@ type UnionToTuple<T> = UnionToIntersection<
  */
 export const injectMappedSignal = <
   M extends SignalMap,
-  MappedEvents extends EventMap = None
+  EventMap extends Record<string, any> = None
 >(
   map: M,
-  config?: InjectSignalConfig<MappedEvents>
+  config?: InjectSignalConfig<EventMap>
 ) => {
   const instance = injectSelf()
 
   const signal = injectMemo(() => {
     return new MappedSignal<{
-      Events: Prettify<MapAll<M> & MapEvents<MappedEvents>>
+      Events: Prettify<MapAll<M> & EventMap>
       State: { [K in keyof M]: M[K] extends Signal<any> ? StateOf<M[K]> : M[K] }
     }>(instance.e, instance.e.makeId('signal', instance), map)
   }, [])

--- a/packages/atoms/src/injectors/injectPromise.ts
+++ b/packages/atoms/src/injectors/injectPromise.ts
@@ -6,12 +6,10 @@ import {
 } from '../utils/promiseUtils'
 import {
   AtomApiGenerics,
-  EventMap,
   InjectorDeps,
   InjectPromiseConfig,
   InjectSignalConfig,
   InternalEvaluationReason,
-  MapEvents,
   None,
   PromiseState,
 } from '../types/index'
@@ -28,11 +26,11 @@ import { injectMappedSignal } from './injectMappedSignal'
 
 export interface InjectPromiseAtomApi<
   G extends AtomApiGenerics,
-  MappedEvents extends EventMap,
+  EventMap extends Record<string, any>,
   Data
 > extends AtomApi<G> {
   dataSignal: Signal<{
-    Events: MapEvents<MappedEvents>
+    Events: EventMap
     ResolvedState: Data
     State: Data | undefined
   }>
@@ -102,7 +100,7 @@ const hasInvalidateReason = (node: ReturnType<typeof injectSelf>) => {
  * ```
  */
 export const injectPromise: {
-  <Data, MappedEvents extends EventMap = None>(
+  <Data, EventMap extends Record<string, any> = None>(
     promiseFactory: (params: {
       controller?: AbortController
       prevData?: NoInfer<Data>
@@ -110,43 +108,43 @@ export const injectPromise: {
     deps: InjectorDeps,
     config: Omit<InjectPromiseConfig<Data>, 'initialData'> & {
       initialData: Data
-    } & InjectSignalConfig<MappedEvents>
+    } & InjectSignalConfig<EventMap>
   ): InjectPromiseAtomApi<
     {
       Exports: Record<string, any>
       Promise: Promise<Data>
       Signal: MappedSignal<{
-        Events: MapEvents<MappedEvents>
+        Events: EventMap
         State: Omit<PromiseState<Data>, 'data'> & { data: Data }
       }>
       State: Omit<PromiseState<Data>, 'data'> & { data: Data }
     },
-    MappedEvents,
+    EventMap,
     Data
   >
 
-  <Data, MappedEvents extends EventMap = None>(
+  <Data, EventMap extends Record<string, any> = None>(
     promiseFactory: (params: {
       controller?: AbortController
       prevData?: NoInfer<Data>
     }) => Promise<Data>,
     deps: InjectorDeps,
-    config?: InjectPromiseConfig<Data> & InjectSignalConfig<MappedEvents>
+    config?: InjectPromiseConfig<Data> & InjectSignalConfig<EventMap>
   ): InjectPromiseAtomApi<
     {
       Exports: Record<string, any>
       Promise: Promise<Data>
       Signal: MappedSignal<{
-        Events: MapEvents<MappedEvents>
+        Events: EventMap
         ResolvedState: Omit<PromiseState<Data>, 'data'> & { data: Data }
         State: PromiseState<Data>
       }>
       State: PromiseState<Data>
     },
-    MappedEvents,
+    EventMap,
     Data
   >
-} = <Data, MappedEvents extends EventMap = None>(
+} = <Data, EventMap extends Record<string, any> = None>(
   promiseFactory: (params: {
     controller?: AbortController
     prevData?: NoInfer<Data>
@@ -156,7 +154,7 @@ export const injectPromise: {
     initialData,
     runOnInvalidate,
     ...signalConfig
-  }: InjectPromiseConfig<Data> & InjectSignalConfig<MappedEvents> = {}
+  }: InjectPromiseConfig<Data> & InjectSignalConfig<EventMap> = {}
 ) => {
   const refs = injectRef({ counter: 0 } as {
     controller?: AbortController
@@ -165,7 +163,7 @@ export const injectPromise: {
   })
 
   const dataSignal = injectSignal(initialData, signalConfig) as Signal<{
-    Events: MapEvents<MappedEvents>
+    Events: EventMap
     ResolvedState: Data
     State: Data | undefined
   }>
@@ -174,7 +172,7 @@ export const injectPromise: {
     ...getInitialPromiseState<Data>(),
     data: dataSignal,
   }) as MappedSignal<{
-    Events: MapEvents<MappedEvents>
+    Events: EventMap
     State: PromiseState<Data>
   }>
 
@@ -251,12 +249,12 @@ export const injectPromise: {
       Exports: Record<string, any>
       Promise: Promise<Data>
       Signal: MappedSignal<{
-        Events: MapEvents<MappedEvents>
+        Events: EventMap
         State: PromiseState<Data>
       }>
       State: PromiseState<Data>
     },
-    MappedEvents,
+    EventMap,
     Data
   >
 

--- a/packages/atoms/src/injectors/injectSignal.ts
+++ b/packages/atoms/src/injectors/injectSignal.ts
@@ -1,5 +1,5 @@
 import { Signal } from '../classes/Signal'
-import { EventMap, InjectSignalConfig, MapEvents, None } from '../types/index'
+import { InjectSignalConfig, None } from '../types/index'
 import { untrack } from '../utils/evaluationContext'
 import { Eventless, EventlessStatic } from '../utils/general'
 import { injectMemo } from './injectMemo'
@@ -26,9 +26,12 @@ export const As = <T>() => 0 as unknown as T
  * injected signal. Pass `{ reactive: false }` as the second argument to disable
  * this.
  */
-export const injectSignal = <State, MappedEvents extends EventMap = None>(
+export const injectSignal = <
+  State,
+  EventMap extends Record<string, any> = None
+>(
   state: (() => State) | State,
-  config?: InjectSignalConfig<MappedEvents>
+  config?: InjectSignalConfig<EventMap>
 ) => {
   const instance = injectSelf()
 
@@ -36,7 +39,7 @@ export const injectSignal = <State, MappedEvents extends EventMap = None>(
     const id = instance.e.makeId('signal', instance)
 
     const signal = new Signal<{
-      Events: MapEvents<MappedEvents>
+      Events: EventMap
       State: State
     }>(
       instance.e,

--- a/packages/react/test/__snapshots__/types.test.tsx.snap
+++ b/packages/react/test/__snapshots__/types.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`react types signals 1`] = `
 {
-  "@listener(@signal()-1)-2": {
+  "@listener(@signal()-1)-3": {
     "className": "Listener",
     "observers": {},
     "sources": {
@@ -18,7 +18,7 @@ exports[`react types signals 1`] = `
   "@signal()-1": {
     "className": "Signal",
     "observers": {
-      "@listener(@signal()-1)-2": {
+      "@listener(@signal()-1)-3": {
         "flags": 6,
         "operation": "on",
       },

--- a/packages/react/test/types.test.tsx
+++ b/packages/react/test/types.test.tsx
@@ -41,6 +41,7 @@ import {
   injectEcosystem,
   ResolvedStateOf,
   IonInstanceRecursive,
+  injectMappedSignal,
 } from '@zedux/react'
 import { expectTypeOf } from 'expect-type'
 import { ecosystem, snapshotNodes } from './utils/ecosystem'
@@ -679,6 +680,12 @@ describe('react types', () => {
         initialData: 'bad',
       })
 
+      // @ts-expect-error cannot specify built-in events
+      const signal = injectSignal(1, { events: { change: As<number> } })
+
+      // @ts-expect-error cannot specify built-in events
+      injectMappedSignal({ signal }, { events: { change: As<number> } })
+
       return api(injectSignal(instance.getOnce())).setExports({
         val1,
         val2,
@@ -741,8 +748,8 @@ describe('react types', () => {
   test('AtomApi types helpers', () => {
     const signal = ecosystem.signal('a', {
       events: {
-        eventA: () => 1,
-        eventB: () => 2,
+        eventA: () => 1 as const,
+        eventB: () => 2 as const,
       },
     })
 
@@ -840,6 +847,9 @@ describe('react types', () => {
         b: As<undefined>,
       },
     })
+
+    // @ts-expect-error cannot specify built-in events
+    ecosystem.signal(1, { events: { mutate: As<number> } }).destroy()
 
     type Generics = {
       Events: EventsOf<typeof signal>


### PR DESCRIPTION
## Description

The event map generic on `ecosystem.signal`, `injectSignal`, `injectMappedSignal`, and `injectPromise` expects a map of event names to functions that return the event's payload type. This is because that's how declaring events with runtime objects and Zedux v2's `As` helper works - the `As` helper itself is a function. Passing a generic to it tell Zedux the payload type of the event.

However, when manually typing events via the event map generic on the 4 above APIs, this means you have to map each event name to a function type like so:

```ts
injectSignal<MyStateType, { myEventName: () => MyEventPayload }>(myState)
```

This feels weird. We should make this generic itself a map of event names to payloads, cutting out the middle-man function. The runtime overloads can still infer this generic's type from `As` functions:

```ts
// now manual typing is cleaner:
injectSignal<MyStateType, myEventName: MyEventPayload }>(myState)

// and runtime typing still works:
injectSignal(myState, { events: { myEventName: As<MyEventPayload> } })
```

Note that to actually support manual typing (which isn't currently), this will require a follow-up PR to remove the runtime event map checks which currently prevent Zedux from sending events to signals that don't understand them. This feature is unnecessary overhead and confusing - I would expect manual typing to just work and Zedux to forward events when I emit them rather than trying to be smart and stop them.

It's especially confusing because it's inconsistent - when manually sending an event to a top-level signal, if you ignore the type error, that event will be sent just fine. But when sending an event to a mapped signal, Zedux will drop it since it sees that none of the inner signals accept it. Rather than make this more complex by trying to handle all cases intelligently, we'll just drop this feature. We don't need it.

## Breaking Change

This is technically a breaking TS change. Anywhere that was manually passing event map generics will need to be updated to omit the function part of the value.