### PR TITLE
fix: add `asyncScheduler.queue`; fix strict mode atom destroy loop

### DIFF
--- a/packages/atoms/src/classes/ZeduxNode.ts
+++ b/packages/atoms/src/classes/ZeduxNode.ts
@@ -533,7 +533,12 @@ export class ExternalNode<
    * wants esp. in strict mode (usage in React hooks is currently the primary
    * purpose of external nodes).
    */
-  public k(source: ZeduxNode) {
+  public k(source: ZeduxNode, queue?: boolean) {
+    if (queue) {
+      this.c = this.e.asyncScheduler.queue(() => this.k(source))
+      return
+    }
+
     removeEdge(this, source)
     source === this.i && this.destroy(true)
   }

--- a/packages/atoms/src/classes/schedulers/AsyncScheduler.ts
+++ b/packages/atoms/src/classes/schedulers/AsyncScheduler.ts
@@ -9,6 +9,18 @@ const queueMicrotask =
 
 export class AsyncScheduler extends SchedulerBase {
   /**
+   * A convenience method for using the above `queueMicrotask` shim efficiently
+   * via scheduling. Plugin authors may want to use this to update atom state
+   * safely upon receiving an ecosystem event.
+   */
+  public queue(callback: () => void) {
+    const job = { j: callback, T: 3 as const }
+    this.schedule(job)
+
+    return () => this.unschedule(job)
+  }
+
+  /**
    * Insert a job at the end of the queue. Schedule a flush if this scheduler is
    * not currently running and not scheduled yet.
    *

--- a/packages/react/test/integrations/events.test.tsx
+++ b/packages/react/test/integrations/events.test.tsx
@@ -40,6 +40,7 @@ describe('events', () => {
     unmount()
 
     jest.advanceTimersByTime(1)
+    ecosystem.asyncScheduler.flush()
 
     const expectedStaleEvent: CycleEvent = {
       oldStatus: 'Active',

--- a/packages/react/test/units/__snapshots__/useAtomSelector.test.tsx.snap
+++ b/packages/react/test/units/__snapshots__/useAtomSelector.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "state": {
       "val": 1,
     },
-    "status": "Stale",
+    "status": "Active",
     "weight": 1,
   },
   "@component(Test)-:rb:": {
@@ -180,7 +180,7 @@ exports[`useAtomSelector inline selector that returns a different object referen
     "state": {
       "val": 2,
     },
-    "status": "Stale",
+    "status": "Active",
     "weight": 1,
   },
   "@component(Test)-:rb:": {

--- a/packages/react/test/units/useAtomSelector.test.tsx
+++ b/packages/react/test/units/useAtomSelector.test.tsx
@@ -514,7 +514,7 @@ describe('useAtomSelector', () => {
     const div = await findByTestId('text')
 
     expect(div.innerHTML).toBe('1')
-    expect(renders).toBe(4) // 2 rerenders + 2 for strict mode
+    expect(renders).toBe(2) // 1 render + 1 for strict mode
     snapshotNodes()
 
     act(() => {
@@ -523,7 +523,7 @@ describe('useAtomSelector', () => {
     })
 
     expect(div.innerHTML).toBe('2')
-    expect(renders).toBe(6) // 3 rerenders + 3 for strict mode
+    expect(renders).toBe(4) // 2 renders + 2 for strict mode
     snapshotNodes()
   })
 


### PR DESCRIPTION
@affects atoms, react

## Description

#232 introduced a bug in React StrictMode that tests were actually catching but I missed it in the snapshot output. On rerender, `useAtomInstance`'s `useEffect` can trigger an infinite destruction-recreation loop thanks to StrictMode's extra effect cleanup/rerun. Fix that by running cleanup in a microtask.

Expose a convenient way to use AsyncScheduler's existing `queueMicrotask` shim via a new `ecosystem.asyncScheduler.queue` method. Use that for the `useAtomInstance` fix.