### PR TITLE
fix(atoms): skip template-less nodes in node filter

### DIFF
--- a/packages/atoms/src/classes/ZeduxNode.ts
+++ b/packages/atoms/src/classes/ZeduxNode.ts
@@ -286,7 +286,7 @@ export abstract class ZeduxNode<G extends NodeGenerics = AnyNodeGenerics>
             : lowerCaseId.includes(templateOrKey.toLowerCase())
           : (t?.key && (templateOrKey as AtomTemplateBase)?.key === t?.key) ||
             templateOrKey === t
-      ) || excludeTags.some(tag => t.tags?.includes(tag))
+      ) || excludeTags.some(tag => t?.tags?.includes(tag))
 
     return (
       !isExcluded &&
@@ -299,7 +299,7 @@ export abstract class ZeduxNode<G extends NodeGenerics = AnyNodeGenerics>
             : (t?.key && (templateOrKey as AtomTemplateBase)?.key === t?.key) ||
               templateOrKey === t
         ) ||
-        includeTags.some(tag => t.tags?.includes(tag)))
+        includeTags.some(tag => t?.tags?.includes(tag)))
     )
   }
 

--- a/packages/react/test/units/Ecosystem.test.tsx
+++ b/packages/react/test/units/Ecosystem.test.tsx
@@ -290,4 +290,11 @@ describe('Ecosystem', () => {
   test('why() returns undefined if called outside atom or selector evaluation', () => {
     expect(ecosystem.why()).toBeUndefined()
   })
+
+  test('when the ecosystem contains signals, `.findAll` with `includeTags` or `excludeTags` skips them', () => {
+    const signal = ecosystem.signal(1)
+
+    expect(ecosystem.findAll({ includeTags: ['example'] })).toEqual([])
+    expect(ecosystem.findAll({ excludeTags: ['example'] })).toEqual([signal])
+  })
 })


### PR DESCRIPTION
## Description

Signals now don't have templates. This means the `includeTags` and `excludeTags` filters in `ZeduxNode#f`ilter need to skip them.

Do that. We apparently didn't have any tests testing `includeTags`/`excludeTags` when signals are present. Add one.