### PR TITLE
fix(atoms): make external nodes notify on force-destroy

### DIFF
--- a/packages/atoms/src/classes/ZeduxNode.ts
+++ b/packages/atoms/src/classes/ZeduxNode.ts
@@ -473,7 +473,7 @@ export class ExternalNode<
   /**
    * @see ZeduxNode.destroy
    */
-  public destroy(skipUpdate?: boolean) {
+  public destroy(force?: boolean, skipUpdate?: boolean) {
     if (!this.i) return
     if (this.w) this.e.syncScheduler.unschedule(this)
 
@@ -486,7 +486,7 @@ export class ExternalNode<
 
     // notify the external observer of the destruction if needed (does nothing
     // if the external observer initiated the destruction)
-    skipUpdate || this.j()
+    force ? this.n.m && this.n({}) : skipUpdate || this.j()
   }
 
   /**
@@ -540,7 +540,7 @@ export class ExternalNode<
     }
 
     removeEdge(this, source)
-    source === this.i && this.destroy(true)
+    source === this.i && this.destroy(false, true)
   }
 
   /**


### PR DESCRIPTION
## Description

External nodes should trigger a rerender of their React component when they're force-destroyed. This allows ecosystem resets to fully recreate the atom tree from the leaves up (or .. down 'cause it's a tree) since React hooks will create their atoms if they don't exist. But that can't happen if there's no rerender. And currently, `ExternalNode` has a bug where the `destroy` method's first parameter is overloaded as both the `force` and `skipUpdate` param.

Fix that by giving `ExternalNode#destroy` separate params for `force` and `skipUpdate`. Add a test that repros the bug and verifies the fix.

With this fixed, `ecosystem.reset` calls need to be wrapped in `act` in tests involving React. This should have always been the case. Fix that in the one test that needed it.