### PR TITLE
feat(atoms): dynamically update atom exports; improve export wrapping

### DIFF
--- a/packages/react/test/units/AtomApi.test.tsx
+++ b/packages/react/test/units/AtomApi.test.tsx
@@ -17,4 +17,51 @@ describe('AtomApi', () => {
     expect(node1.exports.fn).not.toBe(fn)
     expect(node1.exports.fn.name).toBe('fn')
   })
+
+  test('passing an api to api() clones it', () => {
+    const promise = Promise.resolve(1)
+    const api1 = api(1).setExports({ b: 2 }).setPromise(promise).setTtl(1000)
+    const api2 = api(api1)
+
+    expect(api1).not.toBe(api2)
+    expect(api1.exports).toEqual({ b: 2 })
+    expect(api1.promise).toBe(promise)
+    expect(api1.signal).toBe(undefined)
+    expect(api1.value).toBe(1)
+    expect(api1.ttl).toBe(1000)
+    expect(api2.exports).toEqual({ b: 2 })
+    expect(api2.promise).toBe(promise)
+    expect(api2.signal).toBe(undefined)
+    expect(api2.value).toBe(1)
+    expect(api2.ttl).toBe(1000)
+  })
+
+  test('functions with static properties are not wrapped', () => {
+    const atom1 = atom('1', () => {
+      const fn = () => {}
+      fn.staticProp = 1
+
+      return api().setExports({ fn })
+    })
+
+    const node1 = ecosystem.getNode(atom1)
+    const { fn } = node1.exports
+
+    expect(fn.staticProp).toBe(1)
+  })
+
+  test('classes themselves are not wrapped', () => {
+    const atom1 = atom('1', () => {
+      class Test {
+        prop = 1
+      }
+
+      return api().setExports({ Test })
+    })
+
+    const node1 = ecosystem.getNode(atom1)
+    const { Test } = node1.exports
+
+    expect(new Test().prop).toBe(1)
+  })
 })


### PR DESCRIPTION
## Description

Since the inception of atom exports, they've always had the requirement of being "stable". When creating an exported function, you have to ensure the function doesn't close over any values that can become stable. This is because Zedux only sets the atom's exports after initial atom evaluation and never updates them.

Zedux does that because working with stable exports is much easier than trying to figure out when those exported function references change out from under you. Exports are not state, so there's no easy way to tell _when_ the reference is updated. Basically, that would mean you should never destructure the exports off an atom:

```ts
const { someExport } = useAtomInstance(myAtom)

useEffect(() => {
  // if exports weren't stable, `someExport` may be outdated here
}, [])
```

Turning all exports into a JS Proxy wouldn't improve this DX either. But there is something we can do. Since atom apis already wrap functions by default, we can swap out the underlying function that Zedux's function wrapper wraps. This fixes the by-far most common scenario of an exported function closing over a stale value by allowing those exported function references to change while keeping the exposed function references stable for consumers.

Implement this dynamic wrapping. Also improve the wrapping logic's function detection to exclude classes themselves or any functions with static properties attached. All non-normal function values are still never updated after initial evaluation. And that's fine - any non-function values that are expected to update should be put in state (or the atom's promise).

TL;DR You can now do this:

```ts
const exampleAtom = atom('example', () => {
  const signal = injectSignal('some state')
  const state = signal.get()

  const someExport = () => state // totally fine now!

  return api(signal).setExports({ someExport })
})
```