### PR TITLE
fix(react): make config passed to `useAtomState` override defaults

### DIFF
--- a/packages/react/src/hooks/useAtomState.ts
+++ b/packages/react/src/hooks/useAtomState.ts
@@ -83,10 +83,12 @@ export const useAtomState: {
   ): StateHookTuple<ResolvedStateOf<I>, ExportsOf<I>>
 } = <G extends AnyAtomGenerics<{ Node: AtomInstance }>>(
   atom: AtomTemplateBase<G>,
-  params?: G['Params']
+  params?: G['Params'],
+  config?: Omit<ZeduxHookConfig, 'subscribe'>
 ): StateHookTuple<G['State'], G['Exports']> => {
   const instance = useAtomInstance(atom, params, {
     operation: 'useAtomState',
+    ...config,
     subscribe: true,
   })
 

--- a/packages/react/test/integrations/suspense.test.tsx
+++ b/packages/react/test/integrations/suspense.test.tsx
@@ -299,4 +299,35 @@ describe('suspense', () => {
 
     expect(div).toHaveTextContent('4')
   })
+
+  test('useAtomState() can be configured to not suspend', async () => {
+    const atom1 = atom('1', () => {
+      return api(Promise.resolve(1))
+    })
+
+    const calls: any[] = []
+
+    function Child() {
+      const [state] = useAtomState(atom1, [], { suspend: false })
+      calls.push(state.data)
+
+      return <div data-testid="value">{state.data}</div>
+    }
+
+    function Parent() {
+      return (
+        <Suspense fallback={<div>loading...</div>}>
+          <Child />
+        </Suspense>
+      )
+    }
+
+    const { findByTestId } = renderInEcosystem(<Parent />, {
+      useStrictMode: true,
+    })
+
+    await findByTestId('value')
+
+    expect(calls).toEqual([undefined, undefined, 1, 1])
+  })
 })


### PR DESCRIPTION
## Description

The types for `useAtomState` say that a config object can be passed to control whether the hook suspends and to set the `operation` string for debugging. But currently, the config object is completely ignored in `useAtomState`.

Actually use the config object. Make it override the default `operation` string and pass its `suspend` value along to its internal `useAtomInstance` call.

Add a test that reproduces the issue and confirms the fix.