### PR TITLE
feat(atoms): add config param to `injectAtomState`

### DIFF
--- a/packages/atoms/src/injectors/injectAtomState.ts
+++ b/packages/atoms/src/injectors/injectAtomState.ts
@@ -4,6 +4,7 @@ import {
   AnyAtomGenerics,
   AnyAtomTemplate,
   ExportsOf,
+  InjectAtomInstanceConfig,
   ParamlessTemplate,
   ParamsOf,
   StateHookTuple,
@@ -17,7 +18,8 @@ import { injectAtomInstance } from './injectAtomInstance'
 export const injectAtomState: {
   <A extends AnyAtomTemplate<{ Node: AtomInstance }>>(
     template: A,
-    params: ParamsOf<A>
+    params: ParamsOf<A>,
+    config?: Omit<InjectAtomInstanceConfig, 'subscribe'>
   ): StateHookTuple<StateOf<A>, ExportsOf<A>>
 
   <A extends AnyAtomTemplate<{ Node: AtomInstance; Params: [] }>>(
@@ -28,16 +30,19 @@ export const injectAtomState: {
     template: ParamlessTemplate<A>
   ): StateHookTuple<StateOf<A>, ExportsOf<A>>
 
-  <I extends AtomInstance>(instance: I): StateHookTuple<
-    StateOf<I>,
-    ExportsOf<I>
-  >
+  <I extends AtomInstance>(
+    instance: I,
+    params?: [],
+    config?: Omit<InjectAtomInstanceConfig, 'subscribe'>
+  ): StateHookTuple<StateOf<I>, ExportsOf<I>>
 } = <G extends AnyAtomGenerics<{ Node: AtomInstance }>>(
   atom: AtomTemplateBase<G>,
-  params?: G['Params']
+  params?: G['Params'],
+  config?: Omit<InjectAtomInstanceConfig, 'subscribe'>
 ): StateHookTuple<G['State'], G['Exports']> => {
   const instance = injectAtomInstance(atom, params, {
     operation: 'injectAtomState',
+    ...config,
     subscribe: true,
   })
 

--- a/packages/react/test/integrations/injectors.test.tsx
+++ b/packages/react/test/integrations/injectors.test.tsx
@@ -394,4 +394,28 @@ describe('injectors', () => {
 
     expect(callback?.name).toBe('fn')
   })
+
+  test("injectAtomState's default operation name can be overridden", () => {
+    const atom1 = atom('1', () => 1)
+
+    const atom2 = atom('2', () => {
+      const [state] = injectAtomState(atom1, [], { operation: 'test' })
+
+      return state
+    })
+
+    const node2 = ecosystem.getNode(atom2)
+
+    expect(node2.get()).toBe(1)
+
+    expect([...node2.s.values()]).toMatchInlineSnapshot(`
+      [
+        {
+          "flags": 1,
+          "operation": "test",
+          "p": undefined,
+        },
+      ]
+    `)
+  })
 })


### PR DESCRIPTION
## Description

To better mirror `useAtomState`, give `injectAtomState` a third param: A config object with one optional property: `operation`. This property has the exact same effect as other hooks and injectors.

This isn't a big deal as the `operation` is just for debugging, but I'd expect this field to be there just for completeness given all the other APIs.

Add a test that confirms the type additions work and the new feature works.