### PR TITLE
fix(atoms): prevent inferring params/result from selector config options

### DIFF
--- a/packages/atoms/src/types/index.ts
+++ b/packages/atoms/src/types/index.ts
@@ -67,9 +67,15 @@ export type AtomSelector<State = any, Params extends any[] = any> = (
 ) => State
 
 export interface AtomSelectorConfig<State = any, Params extends any[] = any> {
-  argsComparator?: (newArgs: Params, oldArgs: Params) => boolean
+  argsComparator?: (
+    newArgs: NoInfer<Params>,
+    oldArgs: NoInfer<Params>
+  ) => boolean
   name?: string
-  resultsComparator?: (newResult: State, oldResult: State) => boolean
+  resultsComparator?: (
+    newResult: NoInfer<State>,
+    oldResult: NoInfer<State>
+  ) => boolean
   selector: AtomSelector<State, Params>
 }
 


### PR DESCRIPTION
## Description

Currently when an `AtomSelectorConfig` object specifies an `argsComparator`, Zedux infers the params type of the selector itself from the `argsComparator` function's parameter types.

This is a problem, especially since using Lodash's `isEqual` function is one of the primary use cases of `argsComparator`, which makes the selector's params `any`. And `any` is especially bad since it ruins all typing for the `params` argument of all Zedux APIs, making it easy to pass a non-array value with that selector by mistake.

Fix this by adding TypeScript's `NoInfer` type to the `argsComparator` and `resultsComparator` parameter types on `AtomSelectorConfig`. I'm not sure why `resultsComparator` doesn't have the same problem, but add `NoInfer` to that too anyway.

Add tests that reproduce the type errors and confirm the fix.