### PR TITLE
release: v1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.3.5 (Jul 31, 2025)
+
+### Fixes:
+
+- `react`: bust cached inline selectors in `useAtomSelector` on destroy (#294)
+
 ## v1.3.4 (Feb 15, 2025)
 
 ### Fixes:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zedux",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "A Molecular State Engine for React",
   "type": "module",
   "author": "Joshua Claunch (bowheart <bowheart31@gmail.com>)",

--- a/packages/atoms/package.json
+++ b/packages/atoms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/atoms",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/core": "1.3.4"
+    "@zedux/core": "1.3.5"
   },
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/core",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "A high-level, declarative, composable form of Redux",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/immer",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Official Immer integration for Zedux's store and atomic APIs",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "devDependencies": {
-    "@zedux/atoms": "1.3.4",
+    "@zedux/atoms": "1.3.5",
     "immer": "^10.1.1"
   },
   "exports": {
@@ -36,7 +36,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/atoms": "1.3.4",
+    "@zedux/atoms": "1.3.5",
     "immer": ">=9.0.19"
   },
   "repository": {

--- a/packages/machines/package.json
+++ b/packages/machines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/machines",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Simple native state machine implementation for Zedux atoms",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "devDependencies": {
-    "@zedux/atoms": "1.3.4"
+    "@zedux/atoms": "1.3.5"
   },
   "exports": {
     ".": {
@@ -36,7 +36,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/atoms": "1.3.4"
+    "@zedux/atoms": "1.3.5"
   },
   "repository": {
     "directory": "packages/machines",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/react",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/atoms": "1.3.4"
+    "@zedux/atoms": "1.3.5"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",


### PR DESCRIPTION
## Description

Increment monorepo package versions and update the CHANGELOG for version 1.3.5.

This PR was generated by the release script at https://github.com/Omnistac/zedux/tree/v1.x/scripts/release.js

The packages will be published to npm and a GitHub release will be created after this PR merges.