### PR TITLE
fix(stores): prevent state tearing in nested storeAtom store subscribers

### DIFF
--- a/packages/react/test/stores/atom-stores.test.tsx
+++ b/packages/react/test/stores/atom-stores.test.tsx
@@ -1,6 +1,6 @@
 import { createStore } from '@zedux/core'
 import { injectAtomInstance, injectEffect } from '@zedux/react'
-import { storeAtom, injectStore } from '@zedux/stores'
+import { storeAtom, injectStore, storeIon } from '@zedux/stores'
 import { ecosystem } from '../utils/ecosystem'
 
 describe('stores in atoms', () => {
@@ -84,5 +84,94 @@ describe('stores in atoms', () => {
 
     expect(instance1.getState()).toBe(3)
     expect(instance2.getState()).toBe(1)
+  })
+
+  test("nested store subscribers don't see state tearing", () => {
+    const calls: {
+      atomValue: number
+      passedStoreValue: number
+      storeValue: number
+    }[] = []
+
+    // this exact setup - atom1 -> atom2 -> atom3 - reproduces an actual state
+    // tearing bug we had.
+    const atom1 = storeAtom('1', () => injectStore(1))
+
+    const atom2 = storeIon('2', ({ get }) => get(atom1))
+
+    const atom3 = storeAtom('3', () => {
+      const store = injectStore(1)
+      const instance2 = injectAtomInstance(atom2)
+
+      injectEffect(
+        () => {
+          const subscription = instance2.store.subscribe(newState => {
+            calls.push({
+              // for store atom's, `.get` is an alias for `.getState` which is
+              // an alias for `.store.getState`. But `.getOnce` returns
+              // `instance.v` directly, so check that for state tearing:
+              atomValue: instance2.getOnce(),
+              passedStoreValue: newState,
+              storeValue: instance2.store.getState(),
+            })
+          })
+
+          return () => subscription.unsubscribe()
+        },
+        [],
+        { synchronous: true }
+      )
+
+      return store
+    })
+
+    ecosystem.getInstance(atom3)
+    ecosystem.getInstance(atom1).store.setState(2)
+
+    // Verify no state tearing occurred - subscribers should see consistent state
+    expect(calls).toEqual([
+      { atomValue: 2, passedStoreValue: 2, storeValue: 2 },
+    ])
+  })
+
+  test("normal store subscribers don't see state tearing", () => {
+    let evaluationCount = 0
+    const storeValues: number[] = []
+    const instanceValues: number[] = []
+
+    const atom1 = storeAtom('reevaluation-tearing-test', () => {
+      evaluationCount++
+      const initialValue = evaluationCount * 10
+
+      // Return raw value that will be wrapped in a store
+      return initialValue
+    })
+
+    const instance = ecosystem.getInstance(atom1)
+
+    // Subscribe to both the store and track instance values
+    const storeSubscription = instance.store.subscribe(newState => {
+      storeValues.push(newState)
+      instanceValues.push(instance.get())
+    })
+
+    // Initial state
+    expect(instance.get()).toBe(10)
+    expect(instance.store.getState()).toBe(10)
+
+    // Trigger reevaluation
+    instance.invalidate()
+
+    // After reevaluation, both should be consistent
+    expect(instance.get()).toBe(20)
+    expect(instance.store.getState()).toBe(20)
+
+    // Clean up
+    storeSubscription.unsubscribe()
+
+    // Verify no state tearing - instance value should always match store value
+    storeValues.forEach((storeValue, index) => {
+      expect(instanceValues[index]).toBe(storeValue)
+    })
   })
 })


### PR DESCRIPTION
## Description

There's an edge case with `StoreAtomInstance`s in v2 where subscribers to a store in a store atom can run before the store atom's `.v`alue property is synchronized with the store's own state. Since `storeAtomInstance.get` and `storeAtomInstance.getState` are just aliases for `store.getState`, those don't cause problems. However, `storeAtomInstance.getOnce` reads the `.v`alue directly, leading to a state tearing bug in that (probably rare) case.

See the new regression test, "nested store subscribers don't see state tearing", in `atom-stores.test.tsx` for more details on the exact setup where this state tearing was happening.

Fix the state tearing by keeping `storeAtomInstance.v`alue more immediately in sync with `storeAtomInstance.store._state` every time it changes. Add a regression test and another test that verifies the fix and ensures similar patterns are working as expected.