### PR TITLE
release: v2.0.0-rc.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.0.0-rc.19 (Mar 25, 2026)
+
+### New Features:
+
+- `atoms`: support AtomSelectors in MappedSignal (#369)
+
 ## v2.0.0-rc.18 (Mar 20, 2026)
 
 ### Fixes:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zedux",
-  "version": "2.0.0-rc.18",
+  "version": "2.0.0-rc.19",
   "description": "A Molecular State Engine for React",
   "type": "module",
   "author": "Joshua Claunch (bowheart <bowheart31@gmail.com>)",

--- a/packages/atoms/package.json
+++ b/packages/atoms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/atoms",
-  "version": "2.0.0-rc.18",
+  "version": "2.0.0-rc.19",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/core",
-  "version": "2.0.0-rc.18",
+  "version": "2.0.0-rc.19",
   "description": "A high-level, declarative, composable form of Redux",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/immer/package.json
+++ b/packages/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/immer",
-  "version": "2.0.0-rc.18",
+  "version": "2.0.0-rc.19",
   "description": "Official Immer integration for Zedux's store and atomic APIs",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,11 +10,11 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/stores": "2.0.0-rc.18"
+    "@zedux/stores": "2.0.0-rc.19"
   },
   "devDependencies": {
-    "@zedux/atoms": "2.0.0-rc.18",
-    "@zedux/core": "2.0.0-rc.18",
+    "@zedux/atoms": "2.0.0-rc.19",
+    "@zedux/core": "2.0.0-rc.19",
     "immer": "catalog:"
   },
   "exports": {
@@ -39,7 +39,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/atoms": "2.0.0-rc.18",
+    "@zedux/atoms": "2.0.0-rc.19",
     "immer": ">=9.0.19"
   },
   "repository": {

--- a/packages/machines/package.json
+++ b/packages/machines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/machines",
-  "version": "2.0.0-rc.18",
+  "version": "2.0.0-rc.19",
   "description": "Simple native state machine implementation for Zedux atoms",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,15 +10,15 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/stores": "2.0.0-rc.18"
+    "@zedux/stores": "2.0.0-rc.19"
   },
   "devDependencies": {
     "react": "catalog:",
     "react-dom": "catalog:",
     "@types/react-dom": "catalog:",
     "@types/react": "catalog:",
-    "@zedux/atoms": "2.0.0-rc.18",
-    "@zedux/core": "2.0.0-rc.18"
+    "@zedux/atoms": "2.0.0-rc.19",
+    "@zedux/core": "2.0.0-rc.19"
   },
   "exports": {
     ".": {
@@ -43,8 +43,8 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@zedux/atoms": "2.0.0-rc.18",
-    "@zedux/core": "2.0.0-rc.18"
+    "@zedux/atoms": "2.0.0-rc.19",
+    "@zedux/core": "2.0.0-rc.19"
   },
   "repository": {
     "directory": "packages/machines",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/react",
-  "version": "2.0.0-rc.18",
+  "version": "2.0.0-rc.19",
   "description": "A Molecular State Engine for React",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,7 +10,7 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/atoms": "2.0.0-rc.18"
+    "@zedux/atoms": "2.0.0-rc.19"
   },
   "devDependencies": {
     "@testing-library/dom": "catalog:",

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zedux/stores",
-  "version": "2.0.0-rc.18",
+  "version": "2.0.0-rc.19",
   "description": "The legacy composable store model of Zedux",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -10,8 +10,8 @@
     "url": "https://github.com/Omnistac/zedux/issues"
   },
   "dependencies": {
-    "@zedux/atoms": "2.0.0-rc.18",
-    "@zedux/core": "2.0.0-rc.18"
+    "@zedux/atoms": "2.0.0-rc.19",
+    "@zedux/core": "2.0.0-rc.19"
   },
   "exports": {
     ".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,14 +224,14 @@ importers:
   packages/immer:
     dependencies:
       '@zedux/stores':
-        specifier: 2.0.0-rc.18
+        specifier: 2.0.0-rc.19
         version: link:../stores
     devDependencies:
       '@zedux/atoms':
-        specifier: 2.0.0-rc.18
+        specifier: 2.0.0-rc.19
         version: link:../atoms
       '@zedux/core':
-        specifier: 2.0.0-rc.18
+        specifier: 2.0.0-rc.19
         version: link:../core
       immer:
         specifier: 'catalog:'
@@ -240,7 +240,7 @@ importers:
   packages/machines:
     dependencies:
       '@zedux/stores':
-        specifier: 2.0.0-rc.18
+        specifier: 2.0.0-rc.19
         version: link:../stores
     devDependencies:
       '@types/react':
@@ -250,10 +250,10 @@ importers:
         specifier: 'catalog:'
         version: 19.0.2(@types/react@19.0.1)
       '@zedux/atoms':
-        specifier: 2.0.0-rc.18
+        specifier: 2.0.0-rc.19
         version: link:../atoms
       '@zedux/core':
-        specifier: 2.0.0-rc.18
+        specifier: 2.0.0-rc.19
         version: link:../core
       react:
         specifier: 'catalog:'
@@ -265,7 +265,7 @@ importers:
   packages/react:
     dependencies:
       '@zedux/atoms':
-        specifier: 2.0.0-rc.18
+        specifier: 2.0.0-rc.19
         version: link:../atoms
     devDependencies:
       '@testing-library/dom':
@@ -293,10 +293,10 @@ importers:
   packages/stores:
     dependencies:
       '@zedux/atoms':
-        specifier: 2.0.0-rc.18
+        specifier: 2.0.0-rc.19
         version: link:../atoms
       '@zedux/core':
-        specifier: 2.0.0-rc.18
+        specifier: 2.0.0-rc.19
         version: link:../core
 
 packages:


### PR DESCRIPTION
## Description

Increment monorepo package versions and update the CHANGELOG for version 2.0.0-rc.19.

This PR was generated by the release script at https://github.com/Omnistac/zedux/tree/master/scripts/release.ts

The packages will be published to npm and a GitHub release will be created after this PR merges.